### PR TITLE
Clean up Font code and add Reverse adaptor

### DIFF
--- a/Game/Game.m.cpp
+++ b/Game/Game.m.cpp
@@ -7,8 +7,8 @@
 int main()
 {
     using namespace Sprocket;
-
     Log::Init();
+
     Window window("Game!");
     SceneManager sceneManager;
     ModelManager modelManager;

--- a/Sprocket/Graphics/Primitives/Texture.cpp
+++ b/Sprocket/Graphics/Primitives/Texture.cpp
@@ -139,7 +139,7 @@ bool Texture::operator==(const Texture& other) const
 
 void Texture::SetSubTexture(
     const Maths::ivec4& region,
-    const std::vector<unsigned char>& data)
+    const unsigned char* data)
 {
     Bind();
 
@@ -150,7 +150,7 @@ void Texture::SetSubTexture(
     auto c = d_channels == Channels::RGBA ? GL_RGBA : GL_RED;
     glTexSubImage2D(GL_TEXTURE_2D,
                     0, region.x, region.y, region.z, region.w, 
-                    c, GL_UNSIGNED_BYTE, (void*)data.data());
+                    c, GL_UNSIGNED_BYTE, (void*)data);
 
     Unbind();
 }

--- a/Sprocket/Graphics/Primitives/Texture.h
+++ b/Sprocket/Graphics/Primitives/Texture.h
@@ -40,7 +40,7 @@ public:
     static const Texture& White();
 
     void SetSubTexture(const Maths::ivec4& region,
-                       const std::vector<unsigned char>& data);
+                       const unsigned char* data);
 
     unsigned int Id() const;
 

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -24,6 +24,7 @@
 #include "Events/WindowEvent.h"
 
 // UTILITY
+#include "Utility/Adaptors.h"
 #include "Utility/Log.h"
 #include "Utility/Colour.h"
 #include "Utility/HashPair.h"

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -177,7 +177,7 @@ bool Font::LoadGlyph(char c, float size)
     std::size_t tgt_w = src_w + 2 * padding;
     std::size_t tgt_h = src_h + 2 * padding;
 
-    Maths::ivec4 region = d_atlas.GetRegion(tgt_w, tgt_h);
+    Maths::ivec4 region = d_atlas.GetRegion(tgt_w, tgt_h, padding);
 
     if (region.x < 0) {
         SPKT_LOG_ERROR("Texture atlas is full!");

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -177,7 +177,7 @@ bool Font::LoadGlyph(char c, float size)
     std::size_t tgt_w = src_w + 2 * padding;
     std::size_t tgt_h = src_h + 2 * padding;
 
-    Maths::ivec4 region = d_atlas.GetRegion(tgt_w, tgt_h, padding);
+    Maths::ivec4 region = d_atlas.GetRegion(src_w, src_h, padding);
 
     if (region.x < 0) {
         SPKT_LOG_ERROR("Texture atlas is full!");
@@ -187,26 +187,27 @@ bool Font::LoadGlyph(char c, float size)
     }
 
     std::vector<unsigned char> buffer;
-    buffer.resize(tgt_w * tgt_h);
+    buffer.resize(src_w * src_h);
+    std::memcpy(buffer.data(), ft_bitmap.buffer, src_w * src_h);
     
-    unsigned char *dst_ptr = buffer.data() + (padding * tgt_w + padding);
-    unsigned char *src_ptr = ft_bitmap.buffer;
-    for (std::size_t i = 0; i < src_h; i++ )
-    {
-        std::memcpy(dst_ptr, src_ptr, ft_bitmap.width);
-        dst_ptr += tgt_w;
-        src_ptr += ft_bitmap.pitch;
-    }
+    //unsigned char *dst_ptr = buffer.data() + (padding * tgt_w + padding);
+    //unsigned char *src_ptr = ft_bitmap.buffer;
+    //for (std::size_t i = 0; i < src_h; i++ )
+    //{
+    //    std::memcpy(dst_ptr, src_ptr, ft_bitmap.width);
+    //    dst_ptr += tgt_w;
+    //    src_ptr += ft_bitmap.pitch;
+    //}
 
-    d_atlas.SetRegion({region.x, region.y, tgt_w, tgt_h}, buffer);
+    d_atlas.SetRegion(region, buffer);
 
     uint32_t codepoint = ToUTF32(&c);
 
     auto& font = d_fontData[size];
     Glyph& glyph = font.glyphs[codepoint];
     glyph.codepoint = ToUTF32(&c);
-    glyph.width     = tgt_w;
-    glyph.height    = tgt_h;
+    glyph.width     = src_w;
+    glyph.height    = src_h;
     glyph.offset    = {ft_glyph_left, ft_glyph_top};
     glyph.texture.x = region.x / (float)d_atlas.Width();
     glyph.texture.y = region.y / (float)d_atlas.Height();

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -171,13 +171,9 @@ bool Font::LoadGlyph(char c, float size)
     int ft_glyph_top    = slot->bitmap_top;
     int ft_glyph_left   = slot->bitmap_left;
 
-    std::size_t src_w = ft_bitmap.width;
-    std::size_t src_h = ft_bitmap.rows;
-
-    std::size_t tgt_w = src_w + 2 * padding;
-    std::size_t tgt_h = src_h + 2 * padding;
-
-    Maths::ivec4 region = d_atlas.GetRegion(src_w, src_h, padding);
+    Maths::ivec4 region = d_atlas.GetRegion(
+        ft_bitmap.width, ft_bitmap.rows, padding
+    );
 
     if (region.x < 0) {
         SPKT_LOG_ERROR("Texture atlas is full!");
@@ -187,17 +183,9 @@ bool Font::LoadGlyph(char c, float size)
     }
 
     std::vector<unsigned char> buffer;
-    buffer.resize(src_w * src_h);
-    std::memcpy(buffer.data(), ft_bitmap.buffer, src_w * src_h);
-    
-    //unsigned char *dst_ptr = buffer.data() + (padding * tgt_w + padding);
-    //unsigned char *src_ptr = ft_bitmap.buffer;
-    //for (std::size_t i = 0; i < src_h; i++ )
-    //{
-    //    std::memcpy(dst_ptr, src_ptr, ft_bitmap.width);
-    //    dst_ptr += tgt_w;
-    //    src_ptr += ft_bitmap.pitch;
-    //}
+    unsigned int length = ft_bitmap.width * ft_bitmap.rows;
+    buffer.resize(length);
+    std::memcpy(buffer.data(), ft_bitmap.buffer, length);
 
     d_atlas.SetRegion(region, buffer);
 
@@ -206,8 +194,8 @@ bool Font::LoadGlyph(char c, float size)
     auto& font = d_fontData[size];
     Glyph& glyph = font.glyphs[codepoint];
     glyph.codepoint = ToUTF32(&c);
-    glyph.width     = src_w;
-    glyph.height    = src_h;
+    glyph.width     = ft_bitmap.width;
+    glyph.height    = ft_bitmap.rows;
     glyph.offset    = {ft_glyph_left, ft_glyph_top};
     glyph.texture.x = region.x / (float)d_atlas.Width();
     glyph.texture.y = region.y / (float)d_atlas.Height();

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -151,8 +151,6 @@ bool Font::LoadGlyph(char c, float size)
     FT_Library library;
     FT_Face face;
 
-    int padding = 1; // Potentially make this modifiable.
-
     if (!LoadFace(d_filename, size, &library, &face)) {
         return false;
     }
@@ -166,14 +164,12 @@ bool Font::LoadGlyph(char c, float size)
         return false;
     }
 
-    FT_GlyphSlot slot   = face->glyph;
-    FT_Bitmap ft_bitmap = slot->bitmap;
-    int ft_glyph_top    = slot->bitmap_top;
-    int ft_glyph_left   = slot->bitmap_left;
+    FT_GlyphSlot slot = face->glyph;
+    FT_Bitmap bitmap  = slot->bitmap;
+    int ft_glyph_top  = slot->bitmap_top;
+    int ft_glyph_left = slot->bitmap_left;
 
-    Maths::ivec4 region = d_atlas.GetRegion(
-        ft_bitmap.width, ft_bitmap.rows, padding
-    );
+    Maths::ivec4 region = d_atlas.GetRegion(bitmap.width, bitmap.rows);
 
     if (region.x < 0) {
         SPKT_LOG_ERROR("Texture atlas is full!");
@@ -183,9 +179,9 @@ bool Font::LoadGlyph(char c, float size)
     }
 
     std::vector<unsigned char> buffer;
-    unsigned int length = ft_bitmap.width * ft_bitmap.rows;
+    unsigned int length = bitmap.width * bitmap.rows;
     buffer.resize(length);
-    std::memcpy(buffer.data(), ft_bitmap.buffer, length);
+    std::memcpy(buffer.data(), bitmap.buffer, length);
 
     d_atlas.SetRegion(region, buffer);
 
@@ -194,8 +190,8 @@ bool Font::LoadGlyph(char c, float size)
     auto& font = d_fontData[size];
     Glyph& glyph = font.glyphs[codepoint];
     glyph.codepoint = ToUTF32(&c);
-    glyph.width     = ft_bitmap.width;
-    glyph.height    = ft_bitmap.rows;
+    glyph.width     = bitmap.width;
+    glyph.height    = bitmap.rows;
     glyph.offset    = {ft_glyph_left, ft_glyph_top};
     glyph.texture.x = region.x / (float)d_atlas.Width();
     glyph.texture.y = region.y / (float)d_atlas.Height();

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -66,6 +66,7 @@ Maths::ivec4 FontAtlas::GetRegion(
     // Add padding
     width += 2 * padding;
     height += 2 * padding;
+    
     Maths::ivec4 region{0, 0, width, height};
 
     std::size_t best_height = std::numeric_limits<std::size_t>::max();
@@ -133,8 +134,8 @@ Maths::ivec4 FontAtlas::GetRegion(
     }
 
     // Remove padding
-    //region.x += padding;
-    //region.y += padding;
+    region.x += padding;
+    region.y += padding;
     region.z -= 2 * padding;
     region.w -= 2 * padding;
     return region;

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -23,8 +23,8 @@ void FontAtlas::SetRegion(
 {
     assert(region.x > 0);
     assert(region.y > 0);
-    assert(region.z > 0);
-    assert(region.w > 0);
+    //assert(region.z > 0);
+    //assert(region.w > 0);
     assert(region.x + region.z < d_texture.Width());
     assert(region.y + region.w < d_texture.Height());
     assert(data.size() == region.z * region.w); // width * height
@@ -64,7 +64,9 @@ Maths::ivec4 FontAtlas::GetRegion(
     int padding)
 {
     // Add padding
-    Maths::ivec4 region{0, 0, width + 2 * padding, height + 2 * padding};
+    width += 2 * padding;
+    height += 2 * padding;
+    Maths::ivec4 region{0, 0, width, height};
 
     std::size_t best_height = std::numeric_limits<std::size_t>::max();
     std::size_t best_width = std::numeric_limits<std::size_t>::max();
@@ -131,8 +133,8 @@ Maths::ivec4 FontAtlas::GetRegion(
     }
 
     // Remove padding
-    region.x += padding;
-    region.y += padding;
+    //region.x += padding;
+    //region.y += padding;
     region.z -= 2 * padding;
     region.w -= 2 * padding;
     return region;

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -58,9 +58,13 @@ int FontAtlas::Fit(int index, int width, int height)
     return y;
 }
 
-Maths::ivec4 FontAtlas::GetRegion(std::size_t width, std::size_t height)
+Maths::ivec4 FontAtlas::GetRegion(
+    std::size_t width,
+    std::size_t height,
+    int padding)
 {
-    Maths::ivec4 region{0, 0, width, height};
+    // Add padding
+    Maths::ivec4 region{0, 0, width + 2 * padding, height + 2 * padding};
 
     std::size_t best_height = std::numeric_limits<std::size_t>::max();
     std::size_t best_width = std::numeric_limits<std::size_t>::max();
@@ -126,6 +130,11 @@ Maths::ivec4 FontAtlas::GetRegion(std::size_t width, std::size_t height)
         }
     }
 
+    // Remove padding
+    region.x += padding;
+    region.y += padding;
+    region.z -= 2 * padding;
+    region.w -= 2 * padding;
     return region;
 }
 

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -58,15 +58,13 @@ int FontAtlas::Fit(int index, int width, int height)
     return y;
 }
 
-Maths::ivec4 FontAtlas::GetRegion(
-    std::size_t width,
-    std::size_t height,
-    int padding)
+Maths::ivec4 FontAtlas::GetRegion(std::size_t width, std::size_t height)
 {
     // Add padding
+    int padding = 1;
     width += 2 * padding;
     height += 2 * padding;
-    
+
     Maths::ivec4 region{0, 0, width, height};
 
     std::size_t best_height = std::numeric_limits<std::size_t>::max();

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -19,16 +19,12 @@ FontAtlas::FontAtlas(int width, int height)
 
 void FontAtlas::SetRegion(
     const Maths::ivec4& region,
-    const std::vector<unsigned char>& data)
+    const unsigned char* data)
 {
     assert(region.x > 0);
     assert(region.y > 0);
-    //assert(region.z > 0);
-    //assert(region.w > 0);
     assert(region.x + region.z < d_texture.Width());
     assert(region.y + region.w < d_texture.Height());
-    assert(data.size() == region.z * region.w); // width * height
-
     d_texture.SetSubTexture(region, data);
 }
 

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -17,11 +17,7 @@ class FontAtlas
 public:
     FontAtlas(int width, int height);
 
-    Maths::ivec4 GetRegion(
-        std::size_t width,
-        std::size_t height,
-        int padding
-    );
+    Maths::ivec4 GetRegion(std::size_t width, std::size_t height);
 
     void SetRegion(
         const Maths::ivec4& region,

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -19,7 +19,8 @@ public:
 
     Maths::ivec4 GetRegion(
         std::size_t width,
-        std::size_t height
+        std::size_t height,
+        int padding
     );
 
     void SetRegion(

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -21,7 +21,7 @@ public:
 
     void SetRegion(
         const Maths::ivec4& region,
-        const std::vector<unsigned char>& data
+        const unsigned char* data
     );
 
     std::size_t Width() const { return d_texture.Width(); }

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -7,6 +7,7 @@
 #include "Maths.h"
 #include "RenderContext.h"
 #include "BufferLayout.h"
+#include "Adaptors.h"
 
 #include <functional>
 #include <sstream>
@@ -142,19 +143,17 @@ void SimpleUI::EndFrame()
 
     std::size_t moveToFront = 0;
 
-    for (auto it = d_panelOrder.rbegin(); it != d_panelOrder.rend(); ++it) {
-        const auto& panel = d_panels[*it];
-        const auto& quads = panel.widgetRegions;
-        for (std::size_t i = quads.size(); i != 0;) {
-            --i;
-            const auto& quad = quads[i];
+    for (const auto& panelHash : Reversed(d_panelOrder)) {
+        const auto& panel = d_panels[panelHash];
+
+        for (const auto& quad : Reversed(panel.widgetRegions)) {
             std::size_t hash = quad.hash;
             auto hovered = d_mouse.InRegion(quad.region.x, quad.region.y, quad.region.z, quad.region.w);
             auto clicked = hovered && d_mouse.IsButtonClicked(Mouse::LEFT);
 
             if (!foundClicked && ((d_clicked == hash) || clicked)) {
                 foundClicked = true;
-                moveToFront = *it;
+                moveToFront = panelHash;
                 if (d_clicked != hash) {
                     d_widgetTimes[d_clicked].unclickedTime = d_time;
                     d_widgetTimes[hash].clickedTime = d_time;
@@ -197,8 +196,8 @@ void SimpleUI::EndFrame()
     d_shader.LoadUniform("u_proj_matrix", proj);
 
     d_buffer.Bind();
-    for (auto it = d_panelOrder.begin(); it != d_panelOrder.end(); ++it) {
-        const auto& panel = d_panels[*it];
+    for (const auto& panelHash : d_panelOrder) {
+        const auto& panel = d_panels[panelHash];
         d_shader.LoadUniformInt("texture_channels", 1);
         Texture::White().Bind();
         d_buffer.Draw(panel.quadVertices, panel.quadIndices);

--- a/Sprocket/Utility/Adaptors.h
+++ b/Sprocket/Utility/Adaptors.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <vector>
+
+namespace Sprocket {
+
+template <typename Iterable>
+class Reversed
+{
+    Iterable& d_container;
+
+public:
+    Reversed(Iterable& container) : d_container(container) {}
+
+    auto begin() { return d_container.rbegin(); }
+    auto end() { return d_container.rend(); }
+
+    auto cbegin() { return d_container.crbegin(); }
+    auto cend() { return d_container.crend(); }
+};
+
+}


### PR DESCRIPTION
* Simplified the Font loading code and remove all `std::memcpy`s.
* Add `Reversed` class to allow looping backwards in a range-based for loop.