### PR TITLE
Split core functionality out of simpleui

### DIFF
--- a/Game/EscapeMenu.cpp
+++ b/Game/EscapeMenu.cpp
@@ -127,25 +127,9 @@ void EscapeMenu::OnUpdate(double dt)
         d_ui.Checkbox("B", buttonQuad, &valB);
         buttonQuad.x += buttonQuad.z + 10.0f;
 
-        //d_ui.Image(
-        //    "Font Atlas",
-        //    d_ui.GetFont().GetAtlas(),
-        //    {buttonQuad.x, buttonQuad.y + 10}
-        //);
-
         d_ui.EndPanel();
     }
-
-    //static vec4 imageRegion{3*w/4, 100, 50, 50};
-    //bool dragImage = true;
-    //if (d_ui.StartPanel("Image", &imageRegion, &dragImage, &dragImage)) {
-
-    //    static Sprocket::Texture space("Resources/Textures/Space.png");
-    //    d_ui.Image("Space", space, {50, 50});
-
-    //    d_ui.EndPanel();
-    //}
-
+    
     d_ui.EndFrame();
 
     d_core.window->SetCursorVisibility(true);

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -37,8 +37,9 @@ add_library(Sprocket STATIC
             UI/Font/FontAtlas.cpp
             UI/Font/Font.cpp
             
-            UI/DevUI.cpp
+            UI/UIEngine.cpp
             UI/SimpleUI.cpp
+            UI/DevUI.cpp
 
             Graphics/RenderContext.cpp
             Graphics/Shader.cpp

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(Sprocket STATIC
             
             UI/UIEngine.cpp
             UI/SimpleUI.cpp
+            UI/SinglePanelUI.cpp
             UI/DevUI.cpp
 
             Graphics/RenderContext.cpp

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -16,6 +16,7 @@
 
 #include "UI/UIEngine.h"
 #include "UI/SimpleUI.h"
+#include "UI/SinglePanelUI.h"
 #include "UI/DevUI.h"
 
 // EVENTS

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -14,8 +14,9 @@
 #include "UI/Font/Font.h"
 #include "UI/Font/Glyph.h"
 
-#include "UI/DevUI.h"
+#include "UI/UIEngine.h"
 #include "UI/SimpleUI.h"
+#include "UI/DevUI.h"
 
 // EVENTS
 #include "Events/Event.h"

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -211,4 +211,23 @@ float Font::GetKerning(char left, char right, float size)
     return 0.0f;
 }
 
+float Font::TextWidth(const std::string& text, float size)
+{
+    float width = 0;
+    for (char c : text) { // TODO: Take kerning into account.
+        auto glyph = GetGlyph(c, size);
+        width += glyph.advance.x;
+    }
+
+    Glyph first = GetGlyph(text.front(), size);
+    width -= first.offset.x;
+
+    Glyph last = GetGlyph(text.back(), size);
+    width += last.width;
+    width += last.offset.x;
+    width -= last.advance.x;
+
+    return width;
+}
+
 }

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -214,8 +214,13 @@ float Font::GetKerning(char left, char right, float size)
 float Font::TextWidth(const std::string& text, float size)
 {
     float width = 0;
-    for (char c : text) { // TODO: Take kerning into account.
-        auto glyph = GetGlyph(c, size);
+    for (int i = 0; i != text.size(); ++i) {
+        auto glyph = GetGlyph(text[i], size);
+
+        if (i > 0) {
+            width += GetKerning(text[i-1], text[i], size);
+        }
+
         width += glyph.advance.x;
     }
 

--- a/Sprocket/UI/Font/Font.h
+++ b/Sprocket/UI/Font/Font.h
@@ -48,6 +48,8 @@ public:
     void Bind() const { d_atlas.Bind(); }
     void Unbind() const { d_atlas.Unbind(); }
 
+    float TextWidth(const std::string& text, float size);
+
     Texture GetAtlas() const { return d_atlas.GetAtlas(); }
 };
 

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -136,7 +136,7 @@ bool SimpleUI::Button(const std::string& name, const Maths::vec4& region)
     Maths::vec4 shape = Interpolate(info, info.quad, hoveredRegion, clickedRegion);
     
     d_engine.DrawQuad(colour, shape);
-    d_engine.DrawText(name, 36.0f, info.quad);
+    d_engine.DrawText(name, 36.0f, info.quad, Alignment::RIGHT);
 
     return info.onClick;
 }

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -152,7 +152,7 @@ bool SimpleUI::Button(const std::string& name,
                       const Maths::vec4& region)
 {
     Maths::vec4 copy = d_engine.ApplyOffset(region);
-    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
+    auto info = d_engine.RegisterWidget(name, copy);
 
     Maths::vec4 hoveredRegion = copy;
     hoveredRegion.x -= 10.0f;
@@ -176,7 +176,7 @@ bool SimpleUI::Checkbox(const std::string& name,
                         bool* value)
 {
     Maths::vec4 copy = d_engine.ApplyOffset(region);
-    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
+    auto info = d_engine.RegisterWidget(name, copy);
 
     auto unselected = Interpolate(info, d_theme.backgroundColour, d_theme.backgroundColour*1.1f, d_theme.clickedColour);
     auto selected = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);;
@@ -205,7 +205,7 @@ void SimpleUI::Slider(const std::string& name,
                       float* value, float min, float max)
 {
     Maths::vec4 copy = d_engine.ApplyOffset(region);
-    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
+    auto info = d_engine.RegisterWidget(name, copy);
 
     float x = copy.x;
     float y = copy.y;
@@ -233,7 +233,7 @@ void SimpleUI::Dragger(const std::string& name,
                        float* value, float speed)
 {
     Maths::vec4 copy = d_engine.ApplyOffset(region);
-    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
+    auto info = d_engine.RegisterWidget(name, copy);
 
     Maths::vec4 colour = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);
     

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -77,145 +77,32 @@ template <typename T> T Interpolate(
 
 SimpleUI::SimpleUI(Window* window)
     : d_window(window)
-    , d_shader("Resources/Shaders/SimpleUI.vert",
-               "Resources/Shaders/SimpleUI.frag")
-    , d_font("Resources/Fonts/Coolvetica.ttf")
+    , d_engine(window)
 {
     d_keyboard.ConsumeAll(false);
-
-    BufferLayout layout(sizeof(BufferVertex));
-    layout.AddAttribute(DataType::FLOAT, 2);
-    layout.AddAttribute(DataType::FLOAT, 4);
-    layout.AddAttribute(DataType::FLOAT, 2);
-    d_buffer.SetBufferLayout(layout);
-}
-
-Maths::vec4 SimpleUI::ApplyOffset(const Maths::vec4& region)
-{
-    if (d_currentPanel) {
-        Maths::vec4 quad = region;
-        quad.x += d_currentPanel->region.x;
-        quad.y += d_currentPanel->region.y;
-        return quad;
-    }
-    return region;
-}
-
-std::string SimpleUI::MangleName(const std::string& name)
-{
-    return d_currentPanel->name + "##" + name;
 }
 
 void SimpleUI::OnEvent(Event& event)
 {
     d_keyboard.OnEvent(event);
     d_mouse.OnEvent(event);
+    d_engine.OnEvent(event);
 }
 
 void SimpleUI::OnUpdate(double dt)
 {
     d_mouse.OnUpdate();
-    d_time += dt;
-    d_clickedTime += dt;
-    d_hoveredTime += dt;
-
-    if (d_mouse.IsButtonReleased(Mouse::LEFT)) {
-        d_clickedTime = 0.0;
-        if (d_clicked > 0) {
-            d_widgetTimes[d_clicked].unclickedTime = d_time;
-            d_clicked = 0;
-        }
-    }
+    d_engine.OnUpdate(dt);
 }
 
 void SimpleUI::StartFrame()
 {
-    d_panels.clear();
-    d_currentPanel = nullptr;
+    d_engine.StartFrame();
 }
 
 void SimpleUI::EndFrame()
 {
-    assert(!d_currentPanel);
-
-    bool foundHovered = false;
-    bool foundClicked = false;
-
-    std::size_t moveToFront = 0;
-
-    for (const auto& panelHash : Reversed(d_panelOrder)) {
-        const auto& panel = d_panels[panelHash];
-
-        for (const auto& quad : Reversed(panel.widgetRegions)) {
-            std::size_t hash = quad.hash;
-            auto hovered = d_mouse.InRegion(quad.region.x, quad.region.y, quad.region.z, quad.region.w);
-            auto clicked = hovered && d_mouse.IsButtonClicked(Mouse::LEFT);
-
-            if (!foundClicked && ((d_clicked == hash) || clicked)) {
-                foundClicked = true;
-                moveToFront = panelHash;
-                if (d_clicked != hash) {
-                    d_widgetTimes[d_clicked].unclickedTime = d_time;
-                    d_widgetTimes[hash].clickedTime = d_time;
-                    d_clicked = hash;
-                    d_onClick = hash;
-                    d_clickedTime = 0.0;
-                }
-            }
-            
-            if (!foundHovered && hovered) {
-                foundHovered = true;
-                if (d_hovered != hash) {
-                    d_widgetTimes[d_hovered].unhoveredTime = d_time;
-                    d_widgetTimes[hash].hoveredTime = d_time;
-                    d_hovered = hash;
-                    d_onHover = hash;
-                    d_hoveredTime = 0.0;
-                }
-            }
-        }
-    }
-
-    if (foundHovered == false) {
-        d_hoveredTime = 0.0;
-        if (d_hovered > 0) {
-            d_widgetTimes[d_hovered].unhoveredTime = d_time;
-            d_hovered = 0;
-        }
-    }
-
-    Sprocket::RenderContext rc;
-    rc.AlphaBlending(true);
-    rc.FaceCulling(false);
-    rc.DepthTesting(false);
-
-    float w = (float)d_window->Width();
-    float h = (float)d_window->Height();
-    auto proj = Maths::Ortho(0, w, h, 0);
-    d_shader.Bind();
-    d_shader.LoadUniform("u_proj_matrix", proj);
-
-    d_buffer.Bind();
-    for (const auto& panelHash : d_panelOrder) {
-        const auto& panel = d_panels[panelHash];
-        d_shader.LoadUniformInt("texture_channels", 1);
-        Texture::White().Bind();
-        d_buffer.Draw(panel.quadVertices, panel.quadIndices);
-        d_font.Bind();
-        d_buffer.Draw(panel.textVertices, panel.textIndices);
-        for (const auto& cmd : panel.extraCommands) {
-            d_shader.LoadUniformInt("texture_channels", cmd.texture->GetChannels());
-            cmd.texture->Bind();
-            d_buffer.Draw(cmd.vertices, cmd.indices);
-        }
-    }
-    d_buffer.Unbind();
-
-    if (moveToFront > 0) {
-        auto toMove = std::find(d_panelOrder.begin(), d_panelOrder.end(), moveToFront);
-        d_panelOrder.erase(toMove);
-        d_panelOrder.push_back(moveToFront);
-    }
+    d_engine.EndFrame();
 }
 
 bool SimpleUI::StartPanel(
@@ -224,32 +111,9 @@ bool SimpleUI::StartPanel(
     bool* active,
     bool* draggable)
 {
-    assert(!d_currentPanel);
-    assert(region != nullptr);
-    assert(active != nullptr);
+    d_engine.StartPanel(name, region, active, draggable);
 
-    if (*active) {
-        std::size_t hash = std::hash<std::string>{}(name);
-
-        auto it = std::find(d_panelOrder.begin(), d_panelOrder.end(), hash);
-        if (it == d_panelOrder.end()) {
-            d_panelOrder.push_back(hash);
-        }
-        
-        auto& panel = d_panels[hash];
-        panel.name = name;
-        panel.hash = hash;
-        panel.region = *region;
-
-        d_currentPanel = &panel;
-        
-        auto info = RegisterWidget(name, *region);
-
-        if (info.mouseDown && *draggable) {
-            region->x += d_mouse.GetMouseOffset().x;
-            region->y += d_mouse.GetMouseOffset().y;
-        }
-
+    if(*active) {
         float thickness = 5.0f;
         auto border = *region;
         border.x -= thickness;
@@ -257,8 +121,8 @@ bool SimpleUI::StartPanel(
         border.z += 2.0f * thickness;
         border.w += 2.0f * thickness;
 
-        DrawQuad(d_theme.backgroundColour * 0.35f, border);
-        DrawQuad(d_theme.backgroundColour * 0.7f, *region);
+        d_engine.DrawQuad(d_theme.backgroundColour * 0.35f, border);
+        d_engine.DrawQuad(d_theme.backgroundColour * 0.7f, *region);
     }
 
     return *active;
@@ -266,102 +130,13 @@ bool SimpleUI::StartPanel(
 
 void SimpleUI::EndPanel()
 {
-    assert(d_currentPanel);
-    d_currentPanel = nullptr;
-}
-
-void SimpleUI::DrawQuad(const Maths::vec4& colour,
-                        const Maths::vec4& region)
-{
-    assert(d_currentPanel);
-    auto copy = region;
-    float x = copy.x;
-    float y = copy.y;
-    float width = copy.z;
-    float height = copy.w;
-
-    auto& cmd = d_panels[d_currentPanel->hash];
-
-    auto col = colour;
-    col.a = 1;
-
-    std::size_t index = cmd.quadVertices.size();
-    cmd.quadVertices.push_back({{x,         y},          col});
-    cmd.quadVertices.push_back({{x + width, y},          col});
-    cmd.quadVertices.push_back({{x,         y + height}, col});
-    cmd.quadVertices.push_back({{x + width, y + height}, col});
-
-    cmd.quadIndices.push_back(index + 0);
-    cmd.quadIndices.push_back(index + 1);
-    cmd.quadIndices.push_back(index + 2);
-    cmd.quadIndices.push_back(index + 2);
-    cmd.quadIndices.push_back(index + 1);
-    cmd.quadIndices.push_back(index + 3);
-}
-
-void SimpleUI::DrawText(
-    const std::string& text,
-    float size,
-    const Maths::vec4& region)
-{
-    assert(d_currentPanel);
-
-    auto copy = region;
-    Maths::vec4 colour = {1.0, 1.0, 1.0, 1.0};
-
-    Glyph first = d_font.GetGlyph(text.front(), size);
-    auto textInfo = GetTextInfo(d_font, size, text);
-
-    Maths::vec2 pen = {
-        region.x + (copy.z - textInfo.width) / 2.0f,
-        region.y + (copy.w - first.height) / 2.0f
-    };
-
-    pen.x -= first.offset.x;
-    pen.y += first.offset.y;
-    
-    for (std::size_t i = 0; i != text.size(); ++i) {
-        auto glyph = d_font.GetGlyph(text[i], size);
-
-        if (i > 0) {
-            pen.x += d_font.GetKerning(text[i-1], text[i], size);
-        }
-
-        float xPos = pen.x + glyph.offset.x;
-        float yPos = pen.y - glyph.offset.y;
-
-        float width = glyph.width;
-        float height = glyph.height;
-
-        float x = glyph.texture.x;
-        float y = glyph.texture.y;
-        float w = glyph.texture.z;
-        float h = glyph.texture.w;
-
-        pen += glyph.advance;
-
-        auto& cmd = d_panels[d_currentPanel->hash];
-
-        unsigned int index = cmd.textVertices.size();
-        cmd.textVertices.push_back({{xPos,         yPos},          colour, {x,     y    }});
-        cmd.textVertices.push_back({{xPos + width, yPos},          colour, {x + w, y    }});
-        cmd.textVertices.push_back({{xPos,         yPos + height}, colour, {x,     y + h}});
-        cmd.textVertices.push_back({{xPos + width, yPos + height}, colour, {x + w, y + h}});
-
-        cmd.textIndices.push_back(index + 0);
-        cmd.textIndices.push_back(index + 1);
-        cmd.textIndices.push_back(index + 2);
-        cmd.textIndices.push_back(index + 2);
-        cmd.textIndices.push_back(index + 1);
-        cmd.textIndices.push_back(index + 3);
-    }
+    d_engine.EndPanel();
 }
 
 void SimpleUI::Quad(const Maths::vec4& colour, const Maths::vec4& quad)
 {
-    assert(d_currentPanel);
-    auto copy = ApplyOffset(quad);
-    DrawQuad(colour, copy);
+    auto copy = d_engine.ApplyOffset(quad);
+    d_engine.DrawQuad(colour, copy);
 }
 
 void SimpleUI::Text(
@@ -369,17 +144,15 @@ void SimpleUI::Text(
     float size,
     const Maths::vec4& quad)
 {
-    assert(d_currentPanel);
-    auto copy = ApplyOffset(quad);
-    DrawText(text, size, copy);
+    auto copy = d_engine.ApplyOffset(quad);
+    d_engine.DrawText(text, size, copy);
 }
 
 bool SimpleUI::Button(const std::string& name,
                       const Maths::vec4& region)
 {
-    assert(d_currentPanel);
-    Maths::vec4 copy = ApplyOffset(region);
-    auto info = RegisterWidget(MangleName(name), copy);
+    Maths::vec4 copy = d_engine.ApplyOffset(region);
+    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
 
     Maths::vec4 hoveredRegion = copy;
     hoveredRegion.x -= 10.0f;
@@ -392,8 +165,8 @@ bool SimpleUI::Button(const std::string& name,
     Maths::vec4 colour = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);
     Maths::vec4 shape = Interpolate(info, copy, hoveredRegion, clickedRegion);
     
-    DrawQuad(colour, shape);
-    DrawText(name, 36.0f, copy);
+    d_engine.DrawQuad(colour, shape);
+    d_engine.DrawText(name, 36.0f, copy);
 
     return info.onClick;
 }
@@ -402,9 +175,8 @@ bool SimpleUI::Checkbox(const std::string& name,
                         const Maths::vec4& region,
                         bool* value)
 {
-    assert(d_currentPanel);
-    Maths::vec4 copy = ApplyOffset(region);
-    auto info = RegisterWidget(MangleName(name), copy);
+    Maths::vec4 copy = d_engine.ApplyOffset(region);
+    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
 
     auto unselected = Interpolate(info, d_theme.backgroundColour, d_theme.backgroundColour*1.1f, d_theme.clickedColour);
     auto selected = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);;
@@ -422,8 +194,8 @@ bool SimpleUI::Checkbox(const std::string& name,
         *value = !(*value);
     }
 
-    DrawQuad(colour, copy);
-    DrawText(name, 36.0f, copy);
+    d_engine.DrawQuad(colour, copy);
+    d_engine.DrawText(name, 36.0f, copy);
 
     return *value; 
 }
@@ -432,9 +204,8 @@ void SimpleUI::Slider(const std::string& name,
                       const Maths::vec4& region,
                       float* value, float min, float max)
 {
-    assert(d_currentPanel);
-    Maths::vec4 copy = ApplyOffset(region);
-    auto info = RegisterWidget(MangleName(name), copy);
+    Maths::vec4 copy = d_engine.ApplyOffset(region);
+    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
 
     float x = copy.x;
     float y = copy.y;
@@ -445,9 +216,9 @@ void SimpleUI::Slider(const std::string& name,
     Maths::vec4 rightColour = d_theme.backgroundColour;
     
     float ratio = (*value - min) / (max - min);
-    DrawQuad(leftColour, {x, y, ratio * width, height});
-    DrawQuad(rightColour, {x + ratio * width, y, (1 - ratio) * width, height});
-    DrawText(name + ": " + Maths::ToString(*value, 0), 36.0f, copy);
+    d_engine.DrawQuad(leftColour, {x, y, ratio * width, height});
+    d_engine.DrawQuad(rightColour, {x + ratio * width, y, (1 - ratio) * width, height});
+    d_engine.DrawText(name + ": " + Maths::ToString(*value, 0), 36.0f, copy);
 
     if (info.mouseDown) {
         auto mouse = d_mouse.GetMousePos();
@@ -461,14 +232,13 @@ void SimpleUI::Dragger(const std::string& name,
                        const Maths::vec4& region,
                        float* value, float speed)
 {
-    assert(d_currentPanel);
-    Maths::vec4 copy = ApplyOffset(region);
-    auto info = RegisterWidget(MangleName(name), copy);
+    Maths::vec4 copy = d_engine.ApplyOffset(region);
+    auto info = d_engine.RegisterWidget(d_engine.MangleName(name), copy);
 
     Maths::vec4 colour = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);
     
-    DrawQuad(colour, copy);
-    DrawText(name + ": " + Maths::ToString(*value, 0), 36.0f, copy);
+    d_engine.DrawQuad(colour, copy);
+    d_engine.DrawText(name + ": " + Maths::ToString(*value, 0), 36.0f, copy);
 
     if (info.mouseDown) {
         *value += d_mouse.GetMouseOffset().x * speed;
@@ -479,11 +249,10 @@ void SimpleUI::Image(const std::string& name,
                      const Texture& image,
                      const Maths::vec2& position)
 {
-    assert(d_currentPanel);
     Maths::vec4 region{position.x, position.y, image.Width(), image.Height()};
-    Maths::vec4 copy = ApplyOffset(region);
+    Maths::vec4 copy = d_engine.ApplyOffset(region);
 
-    auto& cmd = d_currentPanel->extraCommands.emplace_back(DrawCommand());
+    DrawCommand cmd;
     cmd.vertices = {
         {{copy.x,          copy.y         }, {1.0, 1.0, 1.0, 1.0}, {0.0, 0.0}},
         {{copy.x + copy.z, copy.y         }, {1.0, 1.0, 1.0, 1.0}, {1.0, 0.0}},
@@ -492,42 +261,7 @@ void SimpleUI::Image(const std::string& name,
     };
     cmd.indices = {0, 1, 2, 2, 1, 3};
     cmd.texture = &image;
+    d_engine.SubmitDrawCommand(cmd);
 }
-
-WidgetInfo SimpleUI::RegisterWidget(const std::string& name,
-                                    const Maths::vec4& region)
-{
-    assert(d_currentPanel);
-    WidgetInfo info;
-    std::size_t hash = std::hash<std::string>{}(name);
-    d_panels[d_currentPanel->hash].widgetRegions.push_back({hash, region});
-
-    if (hash == d_clicked) {
-        info.mouseDown = d_clickedTime;
-    }
-
-    info.sinceUnlicked = d_time - d_widgetTimes[hash].unclickedTime;
-    info.sinceClicked = d_time - d_widgetTimes[hash].clickedTime;
-
-    if (hash == d_hovered) {
-        info.mouseOver = d_hoveredTime;
-    }
-    
-    info.sinceUnhovered = d_time - d_widgetTimes[hash].unhoveredTime;
-    info.sinceHovered = d_time - d_widgetTimes[hash].hoveredTime;
-
-    if (d_onClick == hash) { // Consume the onCLick
-        d_onClick = 0;
-        info.onClick = true;
-    }
-
-    if (d_onHover == hash) { // Consume the onHover
-        d_onHover = 0;
-        info.onHover = true;
-    }
-
-    return info;
-}
-
 
 }

--- a/Sprocket/UI/SimpleUI.h
+++ b/Sprocket/UI/SimpleUI.h
@@ -6,6 +6,7 @@
 #include "MouseProxy.h"
 #include "StreamBuffer.h"
 #include "Font.h"
+#include "UIEngine.h"
 
 #include <vector>
 #include <unordered_map>
@@ -15,77 +16,12 @@
 
 namespace Sprocket {
 
-struct BufferVertex
-{
-    Maths::vec2 position;
-    Maths::vec4 colour;
-    Maths::vec2 textureCoords = {0.0, 0.0};
-};
-
 struct SimpleUITheme
 {
     Maths::vec4 backgroundColour;
     Maths::vec4 baseColour;
     Maths::vec4 hoveredColour;
     Maths::vec4 clickedColour;
-};
-
-struct QuadData
-{
-    std::size_t hash;
-    Maths::vec4 region;
-};
-
-struct DrawCommand
-{
-    std::vector<BufferVertex> vertices;
-    std::vector<unsigned int> indices;
-    const Texture* texture;
-};
-
-struct Panel
-{
-    std::string name;
-    std::size_t hash;
-    Maths::vec4 region;
-
-    std::vector<QuadData> widgetRegions;
-
-    // Render data
-    std::vector<BufferVertex> quadVertices;
-    std::vector<unsigned int> quadIndices;
-
-    std::vector<BufferVertex> textVertices;
-    std::vector<unsigned int> textIndices;
-
-    std::vector<DrawCommand> extraCommands;
-};
-
-struct WidgetTimes
-{
-    double hoveredTime = 0.0;
-    double unhoveredTime = 0.0;
-    double clickedTime = 0.0;
-    double unclickedTime = 0.0;
-};
-
-struct WidgetInfo
-// When registering a new widget with the UIEngine, the callers gets
-// this struct back. It contains, in seconds, the amount of time that
-// the current widget has been (un)hovered and (un)clicked, among
-// other pieces of info. The caller can then use this information to
-// decide how the widget should be rendered.
-{
-    double mouseOver = 0.0;
-    double sinceHovered = 0.0f;
-    double sinceUnhovered = 0.0;
-
-    double mouseDown = 0.0;
-    double sinceClicked = 0.0;
-    double sinceUnlicked = 0.0;
-    
-    bool onClick = false;
-    bool onHover = false;
 };
 
 class SimpleUI
@@ -97,51 +33,7 @@ class SimpleUI
     KeyboardProxy d_keyboard;
     MouseProxy d_mouse;
 
-    Font d_font;
-
-    // Rendering code    
-    Shader d_shader;
-    StreamBuffer d_buffer;
-
-    void DrawQuad(const Maths::vec4& colour, const Maths::vec4& quad);
-    void DrawText(const std::string& text, float size, const Maths::vec4& quad);
-        // Basic draw functions, does not take panelling into account.
-    
-    // Panel info 
-    std::unordered_map<std::size_t, Panel> d_panels;
-    Panel* d_currentPanel = nullptr;
-    std::deque<std::size_t> d_panelOrder;
-
-    Maths::vec4 ApplyOffset(const Maths::vec4& region);
-        // Returns the region offsetted by the position of the current
-        // panel if there is one, or region otherwise.
-
-    std::string MangleName(const std::string& name);
-        // Returns <panel name>##<name> if there is a current panel,
-        // or name otherwise.
-
-    std::size_t d_hovered = 0;
-    std::size_t d_clicked = 0;
-        // Hashes of the currently hovered/clicked widgets.
-
-    double d_hoveredTime = 0.0;
-    double d_clickedTime = 0.0;
-        // Times (in seconds) that the current widgets have been
-        // hovered/selected.
-
-    std::unordered_map<std::size_t, WidgetTimes> d_widgetTimes;
-        // Hash -> time map keeping track of the last time each
-        // widget was unselected. Used to calculate the unhovered
-        // and unclicked times.
-
-    double d_time = 0.0;
-        // A steadily increasing timer used to set the unselected
-        // times in the maps above.
-
-    std::size_t d_onClick = 0;
-    std::size_t d_onHover = 0;
-        // Stores which widget has been clicked/hovered so that it can
-        // be acted on next frame. These are consumed when retrieved.
+    UIEngine d_engine;
 
 public:
     SimpleUI(Window* window);
@@ -149,10 +41,7 @@ public:
     const SimpleUITheme& GetTheme() const { return d_theme; }
     void SetTheme(const SimpleUITheme& theme) { d_theme = theme; }
 
-    WidgetInfo RegisterWidget(const std::string& name,
-                              const Maths::vec4& region);
-
-    Font& GetFont() { return d_font; }
+    Font& GetFont() { return d_engine.GetFont(); }
 
     void OnEvent(Event& event);
     void OnUpdate(double dt);

--- a/Sprocket/UI/SinglePanelUI.cpp
+++ b/Sprocket/UI/SinglePanelUI.cpp
@@ -67,28 +67,15 @@ void SinglePanelUI::OnUpdate(double dt)
     d_engine.OnUpdate(dt);
 }
 
-bool SinglePanelUI::StartFrame(
-    const std::string& name,
-    Maths::vec4* region,
-    bool* active,
-    bool* draggable)
+void SinglePanelUI::StartFrame()
 {
+    std::string name = "__SinglePanelUI_Name__";
+    Maths::vec4 region = {0, 0, d_window->Width(), d_window->Height()};
+    bool active = true;
+    bool draggable = false;
+
     d_engine.StartFrame();
-    d_engine.StartPanel(name, region, active, draggable);
-
-    if(*active) {
-        float thickness = 5.0f;
-        auto border = *region;
-        border.x -= thickness;
-        border.y -= thickness;
-        border.z += 2.0f * thickness;
-        border.w += 2.0f * thickness;
-
-        d_engine.DrawQuad(d_theme.backgroundColour * 0.35f, border);
-        d_engine.DrawQuad(d_theme.backgroundColour * 0.7f, *region);
-    }
-
-    return *active;
+    d_engine.StartPanel(name, &region, &active, &draggable);
 }
 
 void SinglePanelUI::EndFrame()
@@ -143,6 +130,19 @@ void SinglePanelUI::Slider(const std::string& name,
         float r = (mouse.x - x) / width;
         *value = (1 - r) * min + r * max;
     }    
+}
+
+void SinglePanelUI::Box(const Maths::vec4& quad, const Maths::vec4& colour)
+{
+    float padding = 5.0f;
+    Maths::vec4 border = quad;
+    border.x -= padding;
+    border.y -= padding;
+    border.z += 2 * padding;
+    border.w += 2 * padding;
+
+    d_engine.DrawQuad(colour * 0.7f, border);
+    d_engine.DrawQuad(colour, quad);
 }
 
 }

--- a/Sprocket/UI/SinglePanelUI.cpp
+++ b/Sprocket/UI/SinglePanelUI.cpp
@@ -1,0 +1,148 @@
+#include "SinglePanelUI.h"
+#include "KeyboardProxy.h"
+#include "MouseProxy.h"
+#include "MouseCodes.h"
+#include "KeyboardCodes.h"
+#include "Log.h"
+#include "Maths.h"
+#include "RenderContext.h"
+#include "BufferLayout.h"
+#include "Adaptors.h"
+
+#include <functional>
+#include <sstream>
+#include <cassert>
+#include <algorithm>
+
+namespace Sprocket {
+namespace {
+
+template <typename T> T Interpolate(
+    const WidgetInfo& info,
+    const T& base,
+    const T& hovered,
+    const T& clicked)
+{
+    T ret = base;
+    double interval = 0.1;
+    
+    if (info.mouseOver) {
+        float r = std::min(info.mouseOver, interval) / (float)interval;
+        ret = (1 - r) * ret + r * hovered;
+    } else {
+        float r = std::min(info.sinceUnhovered, interval) / (float)interval;
+        ret = (1 - r) * hovered + r * ret;
+    }
+
+    if (info.mouseDown) {
+        float r = std::min(info.mouseDown, interval) / (float)interval;
+        ret = (1 - r) * ret + r * clicked;
+    } else {
+        float r = std::min(info.sinceUnlicked, interval) / (float)interval;
+        ret = (1 - r) * clicked + r * ret;
+    }
+
+    return ret;
+}
+
+}
+
+SinglePanelUI::SinglePanelUI(Window* window)
+    : d_window(window)
+    , d_engine(window)
+{
+    d_keyboard.ConsumeAll(false);
+}
+
+void SinglePanelUI::OnEvent(Event& event)
+{
+    d_keyboard.OnEvent(event);
+    d_mouse.OnEvent(event);
+    d_engine.OnEvent(event);
+}
+
+void SinglePanelUI::OnUpdate(double dt)
+{
+    d_mouse.OnUpdate();
+    d_engine.OnUpdate(dt);
+}
+
+bool SinglePanelUI::StartFrame(
+    const std::string& name,
+    Maths::vec4* region,
+    bool* active,
+    bool* draggable)
+{
+    d_engine.StartFrame();
+    d_engine.StartPanel(name, region, active, draggable);
+
+    if(*active) {
+        float thickness = 5.0f;
+        auto border = *region;
+        border.x -= thickness;
+        border.y -= thickness;
+        border.z += 2.0f * thickness;
+        border.w += 2.0f * thickness;
+
+        d_engine.DrawQuad(d_theme.backgroundColour * 0.35f, border);
+        d_engine.DrawQuad(d_theme.backgroundColour * 0.7f, *region);
+    }
+
+    return *active;
+}
+
+void SinglePanelUI::EndFrame()
+{
+    d_engine.EndPanel();
+    d_engine.EndFrame();
+}
+
+bool SinglePanelUI::Button(const std::string& name, const Maths::vec4& region)
+{
+    auto info = d_engine.Register(name, region);
+
+    Maths::vec4 hoveredRegion = info.quad;
+    hoveredRegion.x -= 10.0f;
+    hoveredRegion.z += 20.0f;
+
+    Maths::vec4 clickedRegion = info.quad;
+    clickedRegion.x += 10.0f;
+    clickedRegion.z -= 20.0f;
+
+    Maths::vec4 colour = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);
+    Maths::vec4 shape = Interpolate(info, info.quad, hoveredRegion, clickedRegion);
+    
+    d_engine.DrawQuad(colour, shape);
+    d_engine.DrawText(name, 36.0f, info.quad);
+
+    return info.onClick;
+}
+
+void SinglePanelUI::Slider(const std::string& name,
+                      const Maths::vec4& region,
+                      float* value, float min, float max)
+{
+    auto info = d_engine.Register(name, region);
+
+    float x = info.quad.x;
+    float y = info.quad.y;
+    float width = info.quad.z;
+    float height = info.quad.w;
+
+    Maths::vec4 leftColour = Interpolate(info, d_theme.baseColour, d_theme.hoveredColour, d_theme.clickedColour);
+    Maths::vec4 rightColour = d_theme.backgroundColour;
+    
+    float ratio = (*value - min) / (max - min);
+    d_engine.DrawQuad(leftColour, {x, y, ratio * width, height});
+    d_engine.DrawQuad(rightColour, {x + ratio * width, y, (1 - ratio) * width, height});
+    d_engine.DrawText(name + ": " + Maths::ToString(*value, 0), 36.0f, info.quad);
+
+    if (info.mouseDown) {
+        auto mouse = d_mouse.GetMousePos();
+        Maths::Clamp(mouse.x, x, x + width);
+        float r = (mouse.x - x) / width;
+        *value = (1 - r) * min + r * max;
+    }    
+}
+
+}

--- a/Sprocket/UI/SinglePanelUI.h
+++ b/Sprocket/UI/SinglePanelUI.h
@@ -46,10 +46,7 @@ public:
     void OnEvent(Event& event);
     void OnUpdate(double dt);
 
-    bool StartFrame(const std::string& name,
-                    Maths::vec4* region,
-                    bool* active,
-                    bool* draggable);
+    void StartFrame();
     void EndFrame();
 
     bool Button(const std::string& name,
@@ -58,6 +55,8 @@ public:
     void Slider(const std::string& name,
                 const Maths::vec4& region,
                 float* value, float min, float max);
+
+    void Box(const Maths::vec4& quad, const Maths::vec4& colour);
 };
 
 }

--- a/Sprocket/UI/SinglePanelUI.h
+++ b/Sprocket/UI/SinglePanelUI.h
@@ -1,0 +1,63 @@
+#pragma once
+#include "Window.h"
+#include "Shader.h"
+#include "Event.h"
+#include "KeyboardProxy.h"
+#include "MouseProxy.h"
+#include "StreamBuffer.h"
+#include "Font.h"
+#include "UIEngine.h"
+
+#include <vector>
+#include <unordered_map>
+#include <optional>
+#include <chrono>
+#include <deque>
+
+namespace Sprocket {
+
+struct SinglePanelUITheme
+{
+    Maths::vec4 backgroundColour;
+    Maths::vec4 baseColour;
+    Maths::vec4 hoveredColour;
+    Maths::vec4 clickedColour;
+};
+
+class SinglePanelUI
+{
+    Window* d_window;
+
+    SinglePanelUITheme d_theme;
+
+    KeyboardProxy d_keyboard;
+    MouseProxy d_mouse;
+
+    UIEngine d_engine;
+
+public:
+    SinglePanelUI(Window* window);
+
+    const SinglePanelUITheme& GetTheme() const { return d_theme; }
+    void SetTheme(const SinglePanelUITheme& theme) { d_theme = theme; }
+
+    Font& GetFont() { return d_engine.GetFont(); }
+
+    void OnEvent(Event& event);
+    void OnUpdate(double dt);
+
+    bool StartFrame(const std::string& name,
+                    Maths::vec4* region,
+                    bool* active,
+                    bool* draggable);
+    void EndFrame();
+
+    bool Button(const std::string& name,
+                const Maths::vec4& region);
+
+    void Slider(const std::string& name,
+                const Maths::vec4& region,
+                float* value, float min, float max);
+};
+
+}

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -1,0 +1,391 @@
+#include "SimpleUI.h"
+#include "KeyboardProxy.h"
+#include "MouseProxy.h"
+#include "MouseCodes.h"
+#include "KeyboardCodes.h"
+#include "Log.h"
+#include "Maths.h"
+#include "RenderContext.h"
+#include "BufferLayout.h"
+#include "Adaptors.h"
+
+#include <functional>
+#include <sstream>
+#include <cassert>
+#include <algorithm>
+
+namespace Sprocket {
+namespace {
+
+struct TextInfo
+{
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+TextInfo GetTextInfo(Font& font, float size, const std::string& text)
+{
+    TextInfo info;
+    for (char c : text) { // TODO: Take kerning into account.
+        auto glyph = font.GetGlyph(c, size);
+        info.width += glyph.advance.x;
+        if (glyph.height > info.height) {
+            info.height = (float)glyph.height;
+        }
+    }
+
+    Glyph first = font.GetGlyph(text.front(), size);
+    info.width -= first.offset.x;
+
+    Glyph last = font.GetGlyph(text.back(), size);
+    info.width += last.width;
+    info.width += last.offset.x;
+    info.width -= last.advance.x;
+
+    return info;
+}
+
+template <typename T> T Interpolate(
+    const WidgetInfo& info,
+    const T& base,
+    const T& hovered,
+    const T& clicked)
+{
+    T ret = base;
+    double interval = 0.1;
+    
+    if (info.mouseOver) {
+        float r = std::min(info.mouseOver, interval) / (float)interval;
+        ret = (1 - r) * ret + r * hovered;
+    } else {
+        float r = std::min(info.sinceUnhovered, interval) / (float)interval;
+        ret = (1 - r) * hovered + r * ret;
+    }
+
+    if (info.mouseDown) {
+        float r = std::min(info.mouseDown, interval) / (float)interval;
+        ret = (1 - r) * ret + r * clicked;
+    } else {
+        float r = std::min(info.sinceUnlicked, interval) / (float)interval;
+        ret = (1 - r) * clicked + r * ret;
+    }
+
+    return ret;
+}
+
+}
+
+UIEngine::UIEngine(Window* window)
+    : d_window(window)
+    , d_shader("Resources/Shaders/SimpleUI.vert",
+               "Resources/Shaders/SimpleUI.frag")
+    , d_font("Resources/Fonts/Coolvetica.ttf")
+{
+    d_keyboard.ConsumeAll(false);
+
+    BufferLayout layout(sizeof(BufferVertex));
+    layout.AddAttribute(DataType::FLOAT, 2);
+    layout.AddAttribute(DataType::FLOAT, 4);
+    layout.AddAttribute(DataType::FLOAT, 2);
+    d_buffer.SetBufferLayout(layout);
+}
+
+Maths::vec4 UIEngine::ApplyOffset(const Maths::vec4& region)
+{
+    if (d_currentPanel) {
+        Maths::vec4 quad = region;
+        quad.x += d_currentPanel->region.x;
+        quad.y += d_currentPanel->region.y;
+        return quad;
+    }
+    return region;
+}
+
+std::string UIEngine::MangleName(const std::string& name)
+{
+    return d_currentPanel->name + "##" + name;
+}
+
+WidgetInfo UIEngine::RegisterWidget(const std::string& name,
+                                    const Maths::vec4& region)
+{
+    assert(d_currentPanel);
+    WidgetInfo info;
+    std::size_t hash = std::hash<std::string>{}(name);
+    d_panels[d_currentPanel->hash].widgetRegions.push_back({hash, region});
+
+    if (hash == d_clicked) {
+        info.mouseDown = d_clickedTime;
+    }
+
+    info.sinceUnlicked = d_time - d_widgetTimes[hash].unclickedTime;
+    info.sinceClicked = d_time - d_widgetTimes[hash].clickedTime;
+
+    if (hash == d_hovered) {
+        info.mouseOver = d_hoveredTime;
+    }
+    
+    info.sinceUnhovered = d_time - d_widgetTimes[hash].unhoveredTime;
+    info.sinceHovered = d_time - d_widgetTimes[hash].hoveredTime;
+
+    if (d_onClick == hash) { // Consume the onCLick
+        d_onClick = 0;
+        info.onClick = true;
+    }
+
+    if (d_onHover == hash) { // Consume the onHover
+        d_onHover = 0;
+        info.onHover = true;
+    }
+
+    return info;
+}
+
+void UIEngine::OnEvent(Event& event)
+{
+    d_keyboard.OnEvent(event);
+    d_mouse.OnEvent(event);
+}
+
+void UIEngine::OnUpdate(double dt)
+{
+    d_mouse.OnUpdate();
+    d_time += dt;
+    d_clickedTime += dt;
+    d_hoveredTime += dt;
+
+    if (d_mouse.IsButtonReleased(Mouse::LEFT)) {
+        d_clickedTime = 0.0;
+        if (d_clicked > 0) {
+            d_widgetTimes[d_clicked].unclickedTime = d_time;
+            d_clicked = 0;
+        }
+    }
+}
+
+void UIEngine::StartFrame()
+{
+    d_panels.clear();
+    d_currentPanel = nullptr;
+}
+
+void UIEngine::EndFrame()
+{
+    assert(!d_currentPanel);
+
+    bool foundHovered = false;
+    bool foundClicked = false;
+
+    std::size_t moveToFront = 0;
+
+    for (const auto& panelHash : Reversed(d_panelOrder)) {
+        const auto& panel = d_panels[panelHash];
+
+        for (const auto& quad : Reversed(panel.widgetRegions)) {
+            std::size_t hash = quad.hash;
+            auto hovered = d_mouse.InRegion(quad.region.x, quad.region.y, quad.region.z, quad.region.w);
+            auto clicked = hovered && d_mouse.IsButtonClicked(Mouse::LEFT);
+
+            if (!foundClicked && ((d_clicked == hash) || clicked)) {
+                foundClicked = true;
+                moveToFront = panelHash;
+                if (d_clicked != hash) {
+                    d_widgetTimes[d_clicked].unclickedTime = d_time;
+                    d_widgetTimes[hash].clickedTime = d_time;
+                    d_clicked = hash;
+                    d_onClick = hash;
+                    d_clickedTime = 0.0;
+                }
+            }
+            
+            if (!foundHovered && hovered) {
+                foundHovered = true;
+                if (d_hovered != hash) {
+                    d_widgetTimes[d_hovered].unhoveredTime = d_time;
+                    d_widgetTimes[hash].hoveredTime = d_time;
+                    d_hovered = hash;
+                    d_onHover = hash;
+                    d_hoveredTime = 0.0;
+                }
+            }
+        }
+    }
+
+    if (foundHovered == false) {
+        d_hoveredTime = 0.0;
+        if (d_hovered > 0) {
+            d_widgetTimes[d_hovered].unhoveredTime = d_time;
+            d_hovered = 0;
+        }
+    }
+
+    Sprocket::RenderContext rc;
+    rc.AlphaBlending(true);
+    rc.FaceCulling(false);
+    rc.DepthTesting(false);
+
+    float w = (float)d_window->Width();
+    float h = (float)d_window->Height();
+    auto proj = Maths::Ortho(0, w, h, 0);
+    d_shader.Bind();
+    d_shader.LoadUniform("u_proj_matrix", proj);
+
+    d_buffer.Bind();
+    for (const auto& panelHash : d_panelOrder) {
+        const auto& panel = d_panels[panelHash];
+        d_shader.LoadUniformInt("texture_channels", 1);
+        Texture::White().Bind();
+        d_buffer.Draw(panel.quadVertices, panel.quadIndices);
+        d_font.Bind();
+        d_buffer.Draw(panel.textVertices, panel.textIndices);
+        for (const auto& cmd : panel.extraCommands) {
+            d_shader.LoadUniformInt("texture_channels", cmd.texture->GetChannels());
+            cmd.texture->Bind();
+            d_buffer.Draw(cmd.vertices, cmd.indices);
+        }
+    }
+    d_buffer.Unbind();
+
+    if (moveToFront > 0) {
+        auto toMove = std::find(d_panelOrder.begin(), d_panelOrder.end(), moveToFront);
+        d_panelOrder.erase(toMove);
+        d_panelOrder.push_back(moveToFront);
+    }
+}
+
+bool UIEngine::StartPanel(
+    const std::string& name,
+    Maths::vec4* region,
+    bool* active,
+    bool* draggable)
+{
+    assert(!d_currentPanel);
+    assert(region != nullptr);
+    assert(active != nullptr);
+
+    if (*active) {
+        std::size_t hash = std::hash<std::string>{}(name);
+
+        auto it = std::find(d_panelOrder.begin(), d_panelOrder.end(), hash);
+        if (it == d_panelOrder.end()) {
+            d_panelOrder.push_back(hash);
+        }
+        
+        auto& panel = d_panels[hash];
+        panel.name = name;
+        panel.hash = hash;
+        panel.region = *region;
+
+        d_currentPanel = &panel;
+        
+        auto info = RegisterWidget(name, *region);
+
+        if (info.mouseDown && *draggable) {
+            region->x += d_mouse.GetMouseOffset().x;
+            region->y += d_mouse.GetMouseOffset().y;
+        }
+    }
+
+    return *active;
+}
+
+void UIEngine::EndPanel()
+{
+    assert(d_currentPanel);
+    d_currentPanel = nullptr;
+}
+
+void UIEngine::DrawQuad(const Maths::vec4& colour,
+                        const Maths::vec4& region)
+{
+    assert(d_currentPanel);
+    auto copy = region;
+    float x = copy.x;
+    float y = copy.y;
+    float width = copy.z;
+    float height = copy.w;
+
+    auto& cmd = d_panels[d_currentPanel->hash];
+
+    auto col = colour;
+    col.a = 1;
+
+    std::size_t index = cmd.quadVertices.size();
+    cmd.quadVertices.push_back({{x,         y},          col});
+    cmd.quadVertices.push_back({{x + width, y},          col});
+    cmd.quadVertices.push_back({{x,         y + height}, col});
+    cmd.quadVertices.push_back({{x + width, y + height}, col});
+
+    cmd.quadIndices.push_back(index + 0);
+    cmd.quadIndices.push_back(index + 1);
+    cmd.quadIndices.push_back(index + 2);
+    cmd.quadIndices.push_back(index + 2);
+    cmd.quadIndices.push_back(index + 1);
+    cmd.quadIndices.push_back(index + 3);
+}
+
+void UIEngine::DrawText(
+    const std::string& text,
+    float size,
+    const Maths::vec4& region)
+{
+    assert(d_currentPanel);
+
+    auto copy = region;
+    Maths::vec4 colour = {1.0, 1.0, 1.0, 1.0};
+
+    Glyph first = d_font.GetGlyph(text.front(), size);
+    auto textInfo = GetTextInfo(d_font, size, text);
+
+    Maths::vec2 pen = {
+        region.x + (copy.z - textInfo.width) / 2.0f,
+        region.y + (copy.w - first.height) / 2.0f
+    };
+
+    pen.x -= first.offset.x;
+    pen.y += first.offset.y;
+    
+    for (std::size_t i = 0; i != text.size(); ++i) {
+        auto glyph = d_font.GetGlyph(text[i], size);
+
+        if (i > 0) {
+            pen.x += d_font.GetKerning(text[i-1], text[i], size);
+        }
+
+        float xPos = pen.x + glyph.offset.x;
+        float yPos = pen.y - glyph.offset.y;
+
+        float width = glyph.width;
+        float height = glyph.height;
+
+        float x = glyph.texture.x;
+        float y = glyph.texture.y;
+        float w = glyph.texture.z;
+        float h = glyph.texture.w;
+
+        pen += glyph.advance;
+
+        auto& cmd = d_panels[d_currentPanel->hash];
+
+        unsigned int index = cmd.textVertices.size();
+        cmd.textVertices.push_back({{xPos,         yPos},          colour, {x,     y    }});
+        cmd.textVertices.push_back({{xPos + width, yPos},          colour, {x + w, y    }});
+        cmd.textVertices.push_back({{xPos,         yPos + height}, colour, {x,     y + h}});
+        cmd.textVertices.push_back({{xPos + width, yPos + height}, colour, {x + w, y + h}});
+
+        cmd.textIndices.push_back(index + 0);
+        cmd.textIndices.push_back(index + 1);
+        cmd.textIndices.push_back(index + 2);
+        cmd.textIndices.push_back(index + 2);
+        cmd.textIndices.push_back(index + 1);
+        cmd.textIndices.push_back(index + 3);
+    }
+}
+
+void UIEngine::SubmitDrawCommand(const DrawCommand& cmd)
+{
+    assert(d_currentPanel);
+    d_currentPanel->extraCommands.emplace_back(cmd);
+}
+
+}

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -101,18 +101,15 @@ Maths::vec4 UIEngine::ApplyOffset(const Maths::vec4& region)
     return region;
 }
 
-std::string UIEngine::MangleName(const std::string& name)
-{
-    return d_currentPanel->name + "##" + name;
-}
-
 WidgetInfo UIEngine::RegisterWidget(const std::string& name,
                                     const Maths::vec4& region)
 {
     assert(d_currentPanel);
-    WidgetInfo info;
-    std::size_t hash = std::hash<std::string>{}(name);
+    std::string prefixedName = d_currentPanel->name + "##" + name;
+    std::size_t hash = std::hash<std::string>{}(prefixedName);
     d_panels[d_currentPanel->hash].widgetRegions.push_back({hash, region});
+
+    WidgetInfo info;
 
     if (hash == d_clicked) {
         info.mouseDown = d_clickedTime;

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -270,7 +270,8 @@ void UIEngine::DrawQuad(const Maths::vec4& colour,
 void UIEngine::DrawText(
     const std::string& text,
     float size,
-    const Maths::vec4& region)
+    const Maths::vec4& region,
+    Alignment alignment)
 {
     assert(d_currentPanel);
 
@@ -280,10 +281,17 @@ void UIEngine::DrawText(
     Glyph first = d_font.GetGlyph(text.front(), size);
     float textWidth = d_font.TextWidth(text, size);
 
-    Maths::vec2 pen = {
-        region.x + (copy.z - textWidth) / 2.0f,
-        region.y + (copy.w - first.height) / 2.0f
-    };
+    Maths::vec2 pen{region.x, region.y};
+
+    pen.y += (copy.w - first.height) / 2.0f;
+
+    if (alignment == Alignment::LEFT) {
+        pen.x += 5.0f;
+    } else if (alignment == Alignment::RIGHT) {
+        pen.x += region.z - 5.0f - textWidth;
+    } else {
+        pen.x += (copy.z - textWidth) / 2.0f;
+    }
 
     pen.x -= first.offset.x;
     pen.y += first.offset.y;

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -1,0 +1,159 @@
+#pragma once
+#include "Window.h"
+#include "Shader.h"
+#include "Event.h"
+#include "KeyboardProxy.h"
+#include "MouseProxy.h"
+#include "StreamBuffer.h"
+#include "Font.h"
+
+#include <vector>
+#include <unordered_map>
+#include <optional>
+#include <chrono>
+#include <deque>
+
+namespace Sprocket {
+
+struct BufferVertex
+{
+    Maths::vec2 position;
+    Maths::vec4 colour;
+    Maths::vec2 textureCoords = {0.0, 0.0};
+};
+
+struct QuadData
+{
+    std::size_t hash;
+    Maths::vec4 region;
+};
+
+struct DrawCommand
+{
+    std::vector<BufferVertex> vertices;
+    std::vector<unsigned int> indices;
+    const Texture* texture;
+};
+
+struct Panel
+{
+    std::string name;
+    std::size_t hash;
+    Maths::vec4 region;
+
+    std::vector<QuadData> widgetRegions;
+
+    // Render data
+    std::vector<BufferVertex> quadVertices;
+    std::vector<unsigned int> quadIndices;
+
+    std::vector<BufferVertex> textVertices;
+    std::vector<unsigned int> textIndices;
+
+    std::vector<DrawCommand> extraCommands;
+};
+
+struct WidgetTimes
+{
+    double hoveredTime = 0.0;
+    double unhoveredTime = 0.0;
+    double clickedTime = 0.0;
+    double unclickedTime = 0.0;
+};
+
+struct WidgetInfo
+// When registering a new widget with the UIEngine, the callers gets
+// this struct back. It contains, in seconds, the amount of time that
+// the current widget has been (un)hovered and (un)clicked, among
+// other pieces of info. The caller can then use this information to
+// decide how the widget should be rendered.
+{
+    double mouseOver = 0.0;
+    double sinceHovered = 0.0f;
+    double sinceUnhovered = 0.0;
+
+    double mouseDown = 0.0;
+    double sinceClicked = 0.0;
+    double sinceUnlicked = 0.0;
+    
+    bool onClick = false;
+    bool onHover = false;
+};
+
+class UIEngine
+{
+    Window* d_window;
+
+    KeyboardProxy d_keyboard;
+    MouseProxy d_mouse;
+
+    Font d_font;
+
+    // Rendering code    
+    Shader d_shader;
+    StreamBuffer d_buffer;
+    
+    // Panel info 
+    std::unordered_map<std::size_t, Panel> d_panels;
+    Panel* d_currentPanel = nullptr;
+    std::deque<std::size_t> d_panelOrder;
+
+    std::size_t d_hovered = 0;
+    std::size_t d_clicked = 0;
+        // Hashes of the currently hovered/clicked widgets.
+
+    double d_hoveredTime = 0.0;
+    double d_clickedTime = 0.0;
+        // Times (in seconds) that the current widgets have been
+        // hovered/selected.
+
+    std::unordered_map<std::size_t, WidgetTimes> d_widgetTimes;
+        // Hash -> time map keeping track of the last time each
+        // widget was unselected. Used to calculate the unhovered
+        // and unclicked times.
+
+    double d_time = 0.0;
+        // A steadily increasing timer used to set the unselected
+        // times in the maps above.
+
+    std::size_t d_onClick = 0;
+    std::size_t d_onHover = 0;
+        // Stores which widget has been clicked/hovered so that it can
+        // be acted on next frame. These are consumed when retrieved.
+
+public:
+    UIEngine(Window* window);
+
+    WidgetInfo RegisterWidget(const std::string& name,
+                              const Maths::vec4& region);
+
+    Font& GetFont() { return d_font; }
+
+    void OnEvent(Event& event);
+    void OnUpdate(double dt);
+
+    void StartFrame();
+    void EndFrame();
+
+    bool StartPanel(const std::string& name,
+                    Maths::vec4* region,
+                    bool* active,
+                    bool* draggable);
+    void EndPanel();
+
+    Maths::vec4 ApplyOffset(const Maths::vec4& region);
+        // Returns the region offsetted by the position of the current
+        // panel if there is one, or region otherwise.
+
+    std::string MangleName(const std::string& name);
+        // Returns <panel name>##<name> if there is a current panel,
+        // or name otherwise.
+
+    void DrawQuad(const Maths::vec4& colour, const Maths::vec4& quad);
+    void DrawText(const std::string& text, float size, const Maths::vec4& quad);
+        // Basic draw functions, does not take panelling into account.
+
+    void SubmitDrawCommand(const DrawCommand& cmd);
+};
+
+}

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -145,10 +145,6 @@ public:
         // Returns the region offsetted by the position of the current
         // panel if there is one, or region otherwise.
 
-    std::string MangleName(const std::string& name);
-        // Returns <panel name>##<name> if there is a current panel,
-        // or name otherwise.
-
     void DrawQuad(const Maths::vec4& colour, const Maths::vec4& quad);
     void DrawText(const std::string& text, float size, const Maths::vec4& quad);
         // Basic draw functions, does not take panelling into account.

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -83,6 +83,13 @@ struct WidgetInfo
         // The region of the widget converted to screen space coords.
 };
 
+enum class Alignment
+{
+    LEFT,
+    CENTRE,
+    RIGHT
+};
+
 class UIEngine
 {
     Window* d_window;
@@ -150,8 +157,17 @@ public:
                     bool* draggable);
     void EndPanel();
 
-    void DrawQuad(const Maths::vec4& colour, const Maths::vec4& quad);
-    void DrawText(const std::string& text, float size, const Maths::vec4& quad);
+    void DrawQuad(
+        const Maths::vec4& colour,
+        const Maths::vec4& quad
+    );
+
+    void DrawText(
+        const std::string& text,
+        float size,
+        const Maths::vec4& quad,
+        Alignment alignment = Alignment::CENTRE
+    );
         // Basic draw functions, does not take panelling into account.
 
     void SubmitDrawCommand(const DrawCommand& cmd);

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -78,6 +78,9 @@ struct WidgetInfo
     
     bool onClick = false;
     bool onHover = false;
+
+    Maths::vec4 quad;
+        // The region of the widget converted to screen space coords.
 };
 
 class UIEngine
@@ -124,8 +127,14 @@ class UIEngine
 public:
     UIEngine(Window* window);
 
-    WidgetInfo RegisterWidget(const std::string& name,
-                              const Maths::vec4& region);
+    WidgetInfo Register(const std::string& name, const Maths::vec4& region);
+        // Registers a region that can respond to hovers and clicks.
+        // The (x, y) position of the region is with respect to the
+        // position of the active panel. The widget info returned
+
+    Maths::vec4 ApplyOffset(const Maths::vec4& region);
+        // Returns the region offsetted by the position of the current
+        // panel if there is one, or region otherwise.
 
     Font& GetFont() { return d_font; }
 
@@ -140,10 +149,6 @@ public:
                     bool* active,
                     bool* draggable);
     void EndPanel();
-
-    Maths::vec4 ApplyOffset(const Maths::vec4& region);
-        // Returns the region offsetted by the position of the current
-        // panel if there is one, or region otherwise.
 
     void DrawQuad(const Maths::vec4& colour, const Maths::vec4& quad);
     void DrawText(const std::string& text, float size, const Maths::vec4& quad);


### PR DESCRIPTION
* Split core functionality out of SimpleUI and into UIEngine.
* Add another UI class, SinglePanelUI, that also uses the engine and has a different interface.
* Move the text length functionality over to the Font class.