### PR TITLE
Simplify PhysicsComponent

### DIFF
--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 project(Sprocket)
 add_subdirectory(Vendor/reactphysics3d)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
 

--- a/Sprocket/Entities/Components/PhysicsComponent.h
+++ b/Sprocket/Entities/Components/PhysicsComponent.h
@@ -1,36 +1,15 @@
 #pragma once
 #include "Maths.h"
 
-#include <variant>
-
 namespace Sprocket {
 
-struct BoxCollider
+enum class Collider
 {
-    Maths::vec3 halfExtents;
+    NONE,
+    SPHERE,
+    CAPSULE,
+    BOX
 };
-
-struct SphereCollider
-{
-    float radius;
-};
-
-struct CapsuleCollider
-{
-    float radius;
-    float height;
-};
-
-struct EmptyCollider
-{
-};
-
-using Collider = std::variant<
-    BoxCollider,
-    SphereCollider,
-    CapsuleCollider,
-    EmptyCollider
->;
 
 struct PhysicsComponent
 {
@@ -38,11 +17,17 @@ struct PhysicsComponent
     bool        gravity  = true;
     bool        frozen   = false;
 
-    Collider collider            = EmptyCollider();
-    float    mass                = 1.0f;
-    float    bounciness          = 0.5f;
-    float    frictionCoefficient = 0.3f;
-    float    rollingResistance   = 0.0f;
+    // Not all of these attributes (halfExtends, radius, height) are used
+    // by all component types.
+    Collider collider       = Collider::NONE;
+    Maths::vec3 halfExtents = {0.0, 0.0, 0.0};
+    float radius            = 1.0f;
+    float height            = 1.0f;
+
+    float mass                = 1.0f;
+    float bounciness          = 0.5f;
+    float frictionCoefficient = 0.3f;
+    float rollingResistance   = 0.0f;
 };
 
 }

--- a/Sprocket/Entities/Systems/PhysicsEngine.cpp
+++ b/Sprocket/Entities/Systems/PhysicsEngine.cpp
@@ -205,18 +205,18 @@ void PhysicsEngine::OnUpdate(EntityManager& manager, double dt)
 
 void PhysicsEngine::AddCollider(Entity entity)
 {
-    auto& colliderData = entity.Get<PhysicsComponent>();
+    auto& physics = entity.Get<PhysicsComponent>();
 
     std::shared_ptr<rp3d::CollisionShape> collider = nullptr;
-    if (auto data = std::get_if<BoxCollider>(&colliderData.collider)) {
-        collider = std::make_shared<rp3d::BoxShape>(Convert(data->halfExtents));
+    if (physics.collider == Collider::BOX) {
+        collider = std::make_shared<rp3d::BoxShape>(Convert(physics.halfExtents));
     }
-    else if (auto data = std::get_if<SphereCollider>(&colliderData.collider)) {
-        collider = std::make_shared<rp3d::SphereShape>(data->radius);
+    else if (physics.collider == Collider::SPHERE) {
+        collider = std::make_shared<rp3d::SphereShape>(physics.radius);
     }
-    else if (auto data = std::get_if<CapsuleCollider>(&colliderData.collider)) {
+    else if (physics.collider == Collider::CAPSULE) {
         collider = std::make_shared<rp3d::CapsuleShape>(
-            data->radius, data->height
+            physics.radius, physics.height
         );
     }
     else {
@@ -228,7 +228,7 @@ void PhysicsEngine::AddCollider(Entity entity)
     d_impl->entityData[entity.Id()].proxyShape = entry->addCollisionShape(
         collider.get(),
         rp3d::Transform::identity(),
-        colliderData.mass
+        physics.mass
     );
 }
 

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -177,25 +177,26 @@ void EntityRenderer::DrawCollider(const Entity& entity)
     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
     d_shader.Bind();
-    auto& colliderData = entity.Get<PhysicsComponent>();
-    if (auto data = std::get_if<BoxCollider>(&colliderData.collider)) {
-        DrawBox(entity, data);
+    auto& physics = entity.Get<PhysicsComponent>();
+    if (physics.collider == Collider::BOX) {
+        DrawBox(entity);
     }
-    else if (auto data = std::get_if<SphereCollider>(&colliderData.collider)) {
-        DrawSphere(entity, data);
+    else if (physics.collider == Collider::SPHERE) {
+        DrawSphere(entity);
     }
-    else if (auto data = std::get_if<CapsuleCollider>(&colliderData.collider)) {
-        DrawCapsule(entity, data);
+    else if (physics.collider == Collider::CAPSULE) {
+        DrawCapsule(entity);
     }
     d_shader.Unbind();
 }
 
-void EntityRenderer::DrawBox(const Entity& entity, const BoxCollider* collider)
+void EntityRenderer::DrawBox(const Entity& entity)
 {
+    const auto& physics = entity.Get<PhysicsComponent>();
     static auto s_cube = ModelManager::LoadModel("Resources/Models/Cube.obj");
 
     Maths::mat4 transform = entity.Get<TransformComponent>().Transform();
-    transform = Maths::Scale(transform, collider->halfExtents);
+    transform = Maths::Scale(transform, physics.halfExtents);
 
     s_cube.Bind();
     Texture::White().Bind();
@@ -205,12 +206,13 @@ void EntityRenderer::DrawBox(const Entity& entity, const BoxCollider* collider)
     s_cube.Unbind();
 }
 
-void EntityRenderer::DrawSphere(const Entity& entity, const SphereCollider* collider)
+void EntityRenderer::DrawSphere(const Entity& entity)
 {
+    const auto& physics = entity.Get<PhysicsComponent>();
     static auto s_sphere = ModelManager::LoadModel("Resources/Models/LowPolySphere.obj");
 
     Maths::mat4 transform = entity.Get<TransformComponent>().Transform();
-    transform = Maths::Scale(transform, collider->radius);
+    transform = Maths::Scale(transform, physics.radius);
     
     s_sphere.Bind();
     Texture::White().Bind();
@@ -220,8 +222,9 @@ void EntityRenderer::DrawSphere(const Entity& entity, const SphereCollider* coll
     s_sphere.Unbind();
 }
 
-void EntityRenderer::DrawCapsule(const Entity& entity, const CapsuleCollider* collider)
+void EntityRenderer::DrawCapsule(const Entity& entity)
 {
+    const auto& physics = entity.Get<PhysicsComponent>();
     static auto s_hemisphere = ModelManager::LoadModel("Resources/Models/Hemisphere.obj");
     static auto s_cylinder = ModelManager::LoadModel("Resources/Models/Cylinder.obj");
 
@@ -229,8 +232,8 @@ void EntityRenderer::DrawCapsule(const Entity& entity, const CapsuleCollider* co
     {  // Top Hemisphere
         s_hemisphere.Bind();
         Maths::mat4 transform = entity.Get<TransformComponent>().Transform();
-        transform = Maths::Translate(transform, {0.0, collider->height/2, 0.0});
-        transform = Maths::Scale(transform, collider->radius);
+        transform = Maths::Translate(transform, {0.0, physics.height/2, 0.0});
+        transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
         glDrawElements(GL_TRIANGLES, (int)s_hemisphere.VertexCount(), GL_UNSIGNED_INT, nullptr);
         s_hemisphere.Unbind();
@@ -239,7 +242,7 @@ void EntityRenderer::DrawCapsule(const Entity& entity, const CapsuleCollider* co
     {  // Middle Cylinder
         s_cylinder.Bind();
         Maths::mat4 transform = entity.Get<TransformComponent>().Transform();
-        transform = Maths::Scale(transform, {collider->radius, collider->height, collider->radius});
+        transform = Maths::Scale(transform, {physics.radius, physics.height, physics.radius});
         d_shader.LoadUniform("u_model_matrix", transform);
         glDrawElements(GL_TRIANGLES, (int)s_cylinder.VertexCount(), GL_UNSIGNED_INT, nullptr);
         s_cylinder.Unbind();
@@ -248,9 +251,9 @@ void EntityRenderer::DrawCapsule(const Entity& entity, const CapsuleCollider* co
     {  // Bottom Hemisphere
         s_hemisphere.Bind();
         Maths::mat4 transform = entity.Get<TransformComponent>().Transform();
-        transform = Maths::Translate(transform, {0.0, -collider->height/2, 0.0});
+        transform = Maths::Translate(transform, {0.0, -physics.height/2, 0.0});
         transform = Maths::Rotate(transform, {1, 0, 0}, Maths::Radians(180.0f));
-        transform = Maths::Scale(transform, collider->radius);
+        transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
         glDrawElements(GL_TRIANGLES, (int)s_hemisphere.VertexCount(), GL_UNSIGNED_INT, nullptr);
         s_hemisphere.Unbind();

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -20,9 +20,9 @@ class EntityRenderer
     void DrawModel    (const Entity& entity);
     void DrawCollider (const Entity& entity);
 
-    void DrawBox      (const Entity& entity, const BoxCollider* collider);
-    void DrawSphere   (const Entity& entity, const SphereCollider* collider);
-    void DrawCapsule  (const Entity& entity, const CapsuleCollider* collider);
+    void DrawBox      (const Entity& entity);
+    void DrawSphere   (const Entity& entity);
+    void DrawCapsule  (const Entity& entity);
 
 public:
     EntityRenderer(Window* window);
@@ -34,7 +34,6 @@ public:
     void BeginScene(const Entity& camera, const Lights& light);
 
     void EnableShadows(const Texture& shadowMap, const Maths::mat4& lightProjView);
-
 
     void Draw(const Entity& entity);
 

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -77,12 +77,10 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         model.material = dullGray;
         model.scale = 1.0f;
 
-        BoxCollider c;
-        c.halfExtents = {6.224951f, 0.293629f, 16.390110f};
-
         PhysicsComponent phys;
-        phys.collider = c;
         phys.frozen = true;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {6.224951f, 0.293629f, 16.390110f};
         platform.Add<PhysicsComponent>(phys);
 
         platform.Add<SelectComponent>();
@@ -121,11 +119,10 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         model.scale = 1.0f;
 
         PhysicsComponent phys;
-        phys.bounciness = 0.0f;
-        BoxCollider c;
-        c.halfExtents = {6.224951f, 0.293629f, 16.390110f};
-        phys.collider = c;
         phys.frozen = true;
+        phys.bounciness = 0.0f;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {6.224951f, 0.293629f, 16.390110f};
         platform.Add<PhysicsComponent>(phys);
 
         platform.Add<SelectComponent>();
@@ -149,11 +146,10 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         model.scale = 1.0f;
 
         PhysicsComponent phys;
-        phys.bounciness = 0.0f;
-        BoxCollider c;
-        c.halfExtents = {6.224951f, 0.293629f, 16.390110f};
-        phys.collider = c;
         phys.frozen = true;
+        phys.bounciness = 0.0f;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {6.224951f, 0.293629f, 16.390110f};
         platform.Add<PhysicsComponent>(phys);
 
         platform.Add<SelectComponent>();
@@ -178,9 +174,8 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         phys.frozen = true;
         phys.bounciness = 0.0f;
         phys.frictionCoefficient = 0.0f;
-        BoxCollider c;
-        c.halfExtents = {1.2, 1.2, 1.2};
-        phys.collider = c;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {1.2, 1.2, 1.2};
         crate.Add<PhysicsComponent>(phys);
 
         crate.Add<SelectComponent>();
@@ -206,9 +201,8 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         phys.mass = 1000.0f;
         phys.bounciness = 0.0f;
         phys.frictionCoefficient = 0.0f;
-        BoxCollider c;
-        c.halfExtents = {1.2, 1.2, 1.2};
-        phys.collider = c;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {1.2, 1.2, 1.2};
         crate.Add<PhysicsComponent>(phys);
 
         crate.Add<SelectComponent>();
@@ -234,9 +228,8 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         phys.mass = 10000.0f;
         phys.bounciness = 0.0f;
         phys.frictionCoefficient = 0.2f;
-        BoxCollider c;
-        c.halfExtents = {1.2, 1.2, 1.2};
-        phys.collider = c;
+        phys.collider = Collider::BOX;
+        phys.halfExtents = {1.2, 1.2, 1.2};
         crate.Add<PhysicsComponent>(phys);
 
         crate.Add<SelectComponent>();
@@ -262,12 +255,9 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         phys.rollingResistance = 1.0f;
         phys.frictionCoefficient = 0.4f;
         phys.bounciness = 0.0f;
-        {
-            CapsuleCollider c;
-            c.radius = 0.5f;
-            c.height = 1.0f;
-            phys.collider = c;
-        }
+        phys.collider = Collider::CAPSULE;
+        phys.radius = 0.5f;
+        phys.height = 1.0f;
         player.Add<PhysicsComponent>(phys);
 
         player.Add<PlayerComponent>();
@@ -333,13 +323,10 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         model.material = shinyGray;
         model.scale = 0.9f;
 
-        SphereCollider c;
-        c.radius = 1;
-
         PhysicsComponent phys;
-        phys.collider = c;
         phys.mass = 20.0f;
-
+        phys.collider = Collider::SPHERE;
+        phys.radius = 1;
         sphere.Add<PhysicsComponent>(phys);
 
         sphere.Add<SelectComponent>();


### PR DESCRIPTION
PhysicsComponent used to store a variant of different collider types, which added a slight bit of complexity which isn't really needed. I have also been looking into serialisation and having to serialise a variant seemed needlessly complicated.

The main reason the variant existed was because different colliders have different attributes. But since there are only a few for now and I have no current plans to enhance it just yet, I've removed the variant and just put all the different attribute types in the struct. This does lead to some redundant data in the structs, for instance all sphere colliders have a halfExtents vector now, but that's only 4 floats and we don't really have a shortage of space. This will make physics component easier to serialise.