### PR TITLE
Remove camera resize code from lua

### DIFF
--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -190,11 +190,11 @@ void EditorUI::OnUpdate(double dt)
 
     d_ui.StartWindow("Sprocket Editor", &open, flags);
     std::stringstream ss;
-    ss << "Entities: " << d_worldLayer->d_entityManager.Size();
+    ss << "Entities: " << d_worldLayer->d_scene.Size();
     d_ui.Text(ss.str());
 
     if (d_ui.CollapsingHeader("Entity List")) {
-        d_worldLayer->d_entityManager.Each<SelectComponent>([&](Entity& entity) {
+        d_worldLayer->d_scene.Each<SelectComponent>([&](Entity& entity) {
             AddEntityToList(d_ui, d_worldLayer->d_selector, entity);      
         });
     }

--- a/Game/WorldLayer.h
+++ b/Game/WorldLayer.h
@@ -15,11 +15,13 @@ class WorldLayer : public Sprocket::Layer
     Mode d_mode;
 
     // Entity management and systems
+    Sprocket::CameraSystem  d_cameraSystem;
     Sprocket::BasicSelector d_selector;
     Sprocket::ScriptRunner  d_scriptRunner;
     Sprocket::PathFollower  d_pathFollower;
     Sprocket::GameGrid      d_gameGrid;
-    Sprocket::Scene d_entityManager;
+    
+    Sprocket::Scene         d_scene;
 
     Sprocket::Serialiser d_serialiser;
 

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -14302,6 +14302,7 @@ Entities:
       Active: true
     Camera:
       Projection: [1.117921, 0, 0, 0, 0, 2.11053, 0, 0, 0, 0, -1.0002, -1, 0, 0, -0.20002, 0]
+      FOV: 70
       Pitch: 0
   - Name:
       Name: Worker

--- a/Resources/Scene2.yaml
+++ b/Resources/Scene2.yaml
@@ -37,6 +37,7 @@ Entities:
       Active: true
     Camera:
       Projection: [1.187173, 0, 0, 0, 0, 2.11053, 0, 0, 0, 0, -1.0002, -1, 0, 0, -0.20002, 0]
+      FOV: 70
       Pitch: 0
   - Name:
       Name: Worker

--- a/Resources/Scripts/FirstPersonCamera.lua
+++ b/Resources/Scripts/FirstPersonCamera.lua
@@ -33,9 +33,9 @@ function OnUpdate(dt)
     local dx, dy = GetMouseOffset()
     RotateY(-10 * dx)
 
-    local pitch = GetPitch()
-    pitch = Clamp(pitch - 0.15 * dy, -89, 89)
-    SetPitch(pitch)
+    local camera = GetCameraComponent()
+    camera.pitch = Clamp(camera.pitch - 0.15 * dy, -89, 89)
+    SetCameraComponent(camera)
     
     SetPosition(pos)
 end

--- a/Resources/Scripts/FirstPersonCamera.lua
+++ b/Resources/Scripts/FirstPersonCamera.lua
@@ -1,10 +1,4 @@
-function Init()
-    ASPECT_RATIO = 16 / 9
-    FOV = 70
-    NEAR_PLANE = 0.1
-    FAR_PLANE = 1000
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
-end
+function Init() end
 
 function OnUpdate(dt)
     local pos = GetPosition()
@@ -50,8 +44,4 @@ function OnMouseButtonPressedEvent(consumed, button, action, mods) end
 
 function OnMouseScrolledEvent(consumed, xOffset, yOffset) end
 
-function OnWindowResizeEvent(consumed, width, height)
-    ASPECT_RATIO = width / height
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
-    return false
-end
+function OnWindowResizeEvent(consumed, width, height) end

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -1,12 +1,5 @@
 function Init()
     YAW = 0.0
-
-    -- Projection matrix setup
-    ASPECT_RATIO = 16 / 9
-    FOV = 70
-    NEAR_PLANE = 0.1
-    FAR_PLANE = 1000
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
 end
 
 function OnUpdate(dt)
@@ -53,8 +46,4 @@ function OnMouseButtonPressedEvent(consumed, button, action, mods) end
 
 function OnMouseScrolledEvent(consumed, xOffset, yOffset) end
 
-function OnWindowResizeEvent(consumed, width, height)
-    ASPECT_RATIO = width / height
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
-    return false
-end
+function OnWindowResizeEvent(consumed, width, height) end

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -7,9 +7,9 @@ function OnUpdate(dt)
     
     YAW = YAW - dx * 0.15
 
-    local pitch = GetPitch()
-    pitch = Clamp(pitch - 0.15 * dy, -89, 89)
-    SetPitch(pitch)
+    local camera = GetCameraComponent()
+    camera.pitch = Clamp(camera.pitch - 0.15 * dy, -89, 89)
+    SetCameraComponent(camera)
 
     MakeUpright(math.rad(YAW))
 

--- a/Resources/Scripts/Sprocket_Bindings.lua
+++ b/Resources/Scripts/Sprocket_Bindings.lua
@@ -41,3 +41,17 @@ end
 function SetPhysicsComponent(pc)
     Lua_SetPhysicsComponent(pc.velocity.x, pc.velocity.y, pc.velocity.z, pc.gravity, pc.frozen, pc.mass, pc.bounciness, pc.frictionCoefficient, pc.rollingResistance, pc.force.x, pc.force.y, pc.force.z, pc.onFloor)
 end
+
+CameraComponent = Class(function(self, fov, pitch)
+    self.fov = fov
+    self.pitch = pitch
+end)
+
+function GetCameraComponent()
+    fov, pitch = Lua_GetCameraComponent()
+    return CameraComponent(fov, pitch)
+end
+
+function SetCameraComponent(cc)
+    Lua_SetCameraComponent(cc.fov, cc.pitch)
+end

--- a/Resources/Scripts/ThirdPersonCamera.lua
+++ b/Resources/Scripts/ThirdPersonCamera.lua
@@ -11,13 +11,6 @@ function Init()
     TARGET = Vec3(0, 0, 0)
 
     HORIZ = 0 -- Parametrized yaw
-
-    -- Projection matrix setup
-    ASPECT_RATIO = 16 / 9
-    FOV = 70
-    NEAR_PLANE = 0.1
-    FAR_PLANE = 1000
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
 end
 
 function OnUpdate(dt)
@@ -82,8 +75,4 @@ function OnMouseScrolledEvent(consumed, xOffset, yOffset)
     return true
 end
 
-function OnWindowResizeEvent(consumed, width, height)
-    ASPECT_RATIO = width / height
-    SetPerspectiveCamera(ASPECT_RATIO, FOV, NEAR_PLANE, FAR_PLANE)
-    return false
-end
+function OnWindowResizeEvent(consumed, width, height) end

--- a/Resources/WorkshopScene.yaml
+++ b/Resources/WorkshopScene.yaml
@@ -130,6 +130,7 @@ Entities:
       Active: false
     Camera:
       Projection: [1.187173, 0, 0, 0, 0, 2.11053, 0, 0, 0, 0, -1.0002, -1, 0, 0, -0.20002, 0]
+      FOV: 70
       Pitch: 0
   - Name:
       Name: Observer Camera
@@ -141,6 +142,7 @@ Entities:
       Active: true
     Camera:
       Projection: [1.187173, 0, 0, 0, 0, 2.11053, 0, 0, 0, 0, -1.0002, -1, 0, 0, -0.20002, 0]
+      FOV: 70
       Pitch: 0
   - Name:
       Name: Player
@@ -172,6 +174,7 @@ Entities:
       Yaw: 0
     Camera:
       Projection: [1.187173, 0, 0, 0, 0, 2.11053, 0, 0, 0, 0, -1.0002, -1, 0, 0, -0.20002, 0]
+      FOV: 70
       Pitch: 0
     Select: true
   - Name:

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(Sprocket STATIC
             Scene/Serialiser.cpp
 
             Scene/Systems/BasicSelector.cpp
+            Scene/Systems/CameraSystem.cpp
             Scene/Systems/Selector.cpp
             Scene/Systems/PhysicsEngine.cpp
             Scene/Systems/ScriptRunner.cpp

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -64,6 +64,7 @@ struct ScriptComponent
 struct CameraComponent
 {
     Maths::mat4 projection;
+    float       fov = 70.0f;
     float       pitch = 0.0f;
 };
 

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -13,13 +13,13 @@ class EntitySystem
 public:
     EntitySystem() = default;
 
-    virtual void OnStartup(Scene& manager) {};
+    virtual void OnStartup(Scene& scene) {};
         // Called once when the EntityManager starts up.
     
-    virtual void OnUpdate(Scene& manager, double dt) {};
+    virtual void OnUpdate(Scene& scene, double dt) {};
         // Called every tick of the game loop.
 
-    virtual void OnEvent(Event& event) {};
+    virtual void OnEvent(Scene& scene, Event& event) {};
         // Called with every event so systems can consume them.
 
 private:

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -32,7 +32,7 @@ void Scene::OnUpdate(double dt)
 void Scene::OnEvent(Event& event)
 {
     for (auto system : d_systems) {
-        system->OnEvent(event);
+        system->OnEvent(*this, event);
     }
 }
 

--- a/Sprocket/Scene/Serialiser.cpp
+++ b/Sprocket/Scene/Serialiser.cpp
@@ -71,6 +71,7 @@ void Serialiser::Serialise(const std::string& file)
             const auto& camera = entity.Get<CameraComponent>();
             out << YAML::Key << "Camera" << YAML::BeginMap;
             out << YAML::Key << "Projection" << YAML::Value << camera.projection;
+            out << YAML::Key << "FOV" << YAML::Value << camera.fov;
             out << YAML::Key << "Pitch" << YAML::Value << camera.pitch;
             out << YAML::EndMap;
         }
@@ -161,6 +162,7 @@ void Serialiser::Deserialise(const std::string& file)
         if (auto camera = entity["Camera"]) {
             CameraComponent cc;
             cc.projection = camera["Projection"].as<Maths::mat4>();
+            cc.pitch = camera["FOV"].as<float>();
             cc.pitch = camera["Pitch"].as<float>();
             e.Add(cc);
         }

--- a/Sprocket/Scene/Serialiser.cpp
+++ b/Sprocket/Scene/Serialiser.cpp
@@ -70,7 +70,6 @@ void Serialiser::Serialise(const std::string& file)
         if (entity.Has<CameraComponent>()) {
             const auto& camera = entity.Get<CameraComponent>();
             out << YAML::Key << "Camera" << YAML::BeginMap;
-            out << YAML::Key << "Projection" << YAML::Value << camera.projection;
             out << YAML::Key << "FOV" << YAML::Value << camera.fov;
             out << YAML::Key << "Pitch" << YAML::Value << camera.pitch;
             out << YAML::EndMap;
@@ -161,7 +160,7 @@ void Serialiser::Deserialise(const std::string& file)
 
         if (auto camera = entity["Camera"]) {
             CameraComponent cc;
-            cc.projection = camera["Projection"].as<Maths::mat4>();
+            // Projection does not need to be stored
             cc.pitch = camera["FOV"].as<float>();
             cc.pitch = camera["Pitch"].as<float>();
             e.Add(cc);

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -6,14 +6,23 @@
 
 namespace Sprocket {
 
-void CameraSystem::OnEvent(Scene& scene, Event& event)
+void CameraSystem::OnUpdate(Scene& scene, double dt)
+{
+    scene.Each<CameraComponent>([&](Entity& entity) {
+        auto& camera = entity.Get<CameraComponent>();
+        camera.projection = Maths::Perspective(
+            d_aspectRatio,
+            camera.fov,
+            0.1f,
+            1000.0f
+        );
+    });
+}
+
+void CameraSystem::OnEvent(Event& event)
 {
     if (auto e = event.As<WindowResizeEvent>()) {
-        float aspectRatio = e->AspectRatio();
-
-        scene.Each<CameraComponent>([&](Entity& entity) {
-
-        });
+        d_aspectRatio = e->AspectRatio();
     }
 }
 

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -6,23 +6,31 @@
 
 namespace Sprocket {
 
-void CameraSystem::OnUpdate(Scene& scene, double dt)
+CameraSystem::CameraSystem(float aspectRatio)
+    : d_aspectRatio(aspectRatio)
+{}
+
+void CameraSystem::OnStartup(Scene& scene)
 {
-    scene.Each<CameraComponent>([&](Entity& entity) {
+    scene.OnAdd<CameraComponent>([&](Entity& entity) {
         auto& camera = entity.Get<CameraComponent>();
         camera.projection = Maths::Perspective(
-            d_aspectRatio,
-            camera.fov,
-            0.1f,
-            1000.0f
+            d_aspectRatio, camera.fov, 0.1f, 1000.0f
         );
     });
 }
 
-void CameraSystem::OnEvent(Event& event)
+void CameraSystem::OnEvent(Scene& scene, Event& event)
 {
     if (auto e = event.As<WindowResizeEvent>()) {
         d_aspectRatio = e->AspectRatio();
+
+        scene.Each<CameraComponent>([&](Entity& entity) {
+            auto& camera = entity.Get<CameraComponent>();
+            camera.projection = Maths::Perspective(
+                d_aspectRatio, camera.fov, 0.1f, 1000.0f
+            );
+        });
     }
 }
 

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -1,0 +1,20 @@
+#include "CameraSystem.h"
+#include "Components.h"
+#include "WindowEvent.h"
+#include "Scene.h"
+#include "Entity.h"
+
+namespace Sprocket {
+
+void CameraSystem::OnEvent(Scene& scene, Event& event)
+{
+    if (auto e = event.As<WindowResizeEvent>()) {
+        float aspectRatio = e->AspectRatio();
+
+        scene.Each<CameraComponent>([&](Entity& entity) {
+
+        });
+    }
+}
+
+}

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -8,10 +8,9 @@ class CameraSystem : public EntitySystem
     float d_aspectRatio;
 
 public:
-    CameraSystem(float aspectRatio) : d_aspectRatio(aspectRatio) {}
-
-    void OnUpdate(Scene& scene, double dt) override;
-    void OnEvent(Event& event) override;
+    CameraSystem(float aspectRatio);
+    void OnStartup(Scene& scene) override;
+    void OnEvent(Scene& scene, Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "EntitySystem.h"
+
+namespace Sprocket {
+
+class CameraSystem : public EntitySystem
+{
+public:
+    void OnEvent(Scene& scene, Event& event) override;
+};
+
+}

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -5,8 +5,13 @@ namespace Sprocket {
 
 class CameraSystem : public EntitySystem
 {
+    float d_aspectRatio;
+
 public:
-    void OnEvent(Scene& scene, Event& event) override;
+    CameraSystem(float aspectRatio) : d_aspectRatio(aspectRatio) {}
+
+    void OnUpdate(Scene& scene, double dt) override;
+    void OnEvent(Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -101,7 +101,7 @@ void GameGrid::OnUpdate(Sprocket::Scene&, double)
     }
 }
 
-void GameGrid::OnEvent(Event& event)
+void GameGrid::OnEvent(Scene& scene, Event& event)
 {
     if (event.IsConsumed()) { return; }
 

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -38,7 +38,7 @@ public:
 
     void OnStartup(Scene& scene) override;
     void OnUpdate(Scene& scene, double dt) override;
-    void OnEvent(Event& event) override;
+    void OnEvent(Scene& scene, Event& event) override;
 
     Entity At(int x, int z) const;
 

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -40,7 +40,7 @@ void ScriptRunner::OnUpdate(Scene& scene, double dt)
     });
 }
 
-void ScriptRunner::OnEvent(Event& event)
+void ScriptRunner::OnEvent(Scene& scene, Event& event)
 {
     d_keyboard.OnEvent(event);
     d_mouse.OnEvent(event);

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -20,7 +20,7 @@ public:
 
     void OnStartup(Scene& scene) override;
     void OnUpdate(Scene& scene, double dt) override;
-    void OnEvent(Event& event) override;
+    void OnEvent(Scene& scene, Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/Selector.cpp
+++ b/Sprocket/Scene/Systems/Selector.cpp
@@ -33,7 +33,7 @@ void Selector::OnUpdate(Scene& manager, double dt)
     d_mouse.OnUpdate();
 }
 
-void Selector::OnEvent(Event& event)
+void Selector::OnEvent(Scene& scene, Event& event)
 {
     if (!d_enabled) { return; }
 

--- a/Sprocket/Scene/Systems/Selector.h
+++ b/Sprocket/Scene/Systems/Selector.h
@@ -41,7 +41,7 @@ public:
 
     void OnStartup(Scene& scene) override;
     void OnUpdate(Scene& scene, double dt) override;
-    void OnEvent(Event& event) override;
+    void OnEvent(Scene& scene, Event& event) override;
 
     void Enable(bool newEnabled);
 

--- a/Sprocket/Scripting/LuaCamera.cpp
+++ b/Sprocket/Scripting/LuaCamera.cpp
@@ -10,28 +10,30 @@ namespace Sprocket {
 
 void RegisterCameraFunctions(lua_State* L)
 {
-    lua_register(L, "GetPitch", &Lua::GetPitch);
-    lua_register(L, "SetPitch", &Lua::SetPitch);
+    lua_register(L, "Lua_GetCameraComponent", &Lua::GetCameraComponent);
+    lua_register(L, "Lua_SetCameraComponent", &Lua::SetCameraComponent);
 }
 
 namespace Lua {
 
-int GetPitch(lua_State* L)
+int GetCameraComponent(lua_State* L)
 {
     if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+    assert(GetEntity(L)->Has<CameraComponent>());
 
-    auto c = GetEntity(L)->Get<CameraComponent>();
+    const auto& c = GetEntity(L)->Get<CameraComponent>();
+    lua_pushnumber(L, c.fov);
     lua_pushnumber(L, c.pitch);
-    return 1;
+    return 2;
 }
 
-int SetPitch(lua_State* L)
+int SetCameraComponent(lua_State* L)
 {
-    if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+    if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
 
-    float x = (float)lua_tonumber(L, 1);
     auto& c = GetEntity(L)->Get<CameraComponent>();
-    c.pitch = x;
+    c.fov = (float)lua_tonumber(L, 1);
+    c.pitch = (float)lua_tonumber(L, 2);
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaCamera.cpp
+++ b/Sprocket/Scripting/LuaCamera.cpp
@@ -12,8 +12,6 @@ void RegisterCameraFunctions(lua_State* L)
 {
     lua_register(L, "GetPitch", &Lua::GetPitch);
     lua_register(L, "SetPitch", &Lua::SetPitch);
-    lua_register(L, "SetPerspectiveCamera", &Lua::SetPerspectiveCamera);
-    lua_register(L, "SetOrthographicCamera", &Lua::SetOrthographicCamera);
 }
 
 namespace Lua {
@@ -34,35 +32,6 @@ int SetPitch(lua_State* L)
     float x = (float)lua_tonumber(L, 1);
     auto& c = GetEntity(L)->Get<CameraComponent>();
     c.pitch = x;
-    return 0;
-}
-
-int SetPerspectiveCamera(lua_State* L)
-{
-    if (!CheckArgCount(L, 4)) { return luaL_error(L, "Bad number of args"); }
-    
-    float aspectRatio = (float)lua_tonumber(L, 1);
-    float fov = (float)lua_tonumber(L, 2);
-    float nearPlane = (float)lua_tonumber(L, 3);
-    float farPlane = (float)lua_tonumber(L, 4);
-    auto& c = GetEntity(L)->Get<CameraComponent>();
-    c.projection = Maths::Perspective(aspectRatio, fov, nearPlane, farPlane);
-    return 0;
-}
-
-int SetOrthographicCamera(lua_State* L)
-{
-    if (!CheckArgCount(L, 6)) { return luaL_error(L, "Bad number of args"); }
-
-    float leftEdge = (float)lua_tonumber(L, 1);
-    float rightEdge = (float)lua_tonumber(L, 2);
-    float bottomEdge = (float)lua_tonumber(L, 3);
-    float topEdge = (float)lua_tonumber(L, 4);
-    float nearEdge = (float)lua_tonumber(L, 5);
-    float farEdge = (float)lua_tonumber(L, 6);
-    auto& c = GetEntity(L)->Get<CameraComponent>();
-    c.projection = Maths::Ortho(
-        leftEdge, rightEdge, bottomEdge, topEdge, nearEdge, farEdge);
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaCamera.h
+++ b/Sprocket/Scripting/LuaCamera.h
@@ -20,13 +20,5 @@ int SetPitch(lua_State* L);
     // Args: 1 - The new value for the pitch.
     // Rets: 0
 
-int SetPerspectiveCamera(lua_State* L);
-    // Args: 4 - Aspect ratio, FoV, near plane and far plane
-    // Rets: 0
-
-int SetOrthographicCamera(lua_State* L);
-    // Args: 6 - Left, right, bottom, top, near and far
-    // Rets: 0
-
 }
 }

--- a/Sprocket/Scripting/LuaCamera.h
+++ b/Sprocket/Scripting/LuaCamera.h
@@ -9,15 +9,12 @@ void RegisterCameraFunctions(lua_State* L);
 
 namespace Lua {
 
-// Functions that will be reigstered with all Lua engines for accessing
-// and setting the camera component.
-
-int GetPitch(lua_State* L);
+int GetCameraComponent(lua_State* L);
     // Args: 0
-    // Rets: 1 - The pitch value on the CameraComponent.
+    // Rets: 2 - Pitch and FOV
 
-int SetPitch(lua_State* L);
-    // Args: 1 - The new value for the pitch.
+int SetCameraComponent(lua_State* L);
+    // Args: 2 - See above
     // Rets: 0
 
 }

--- a/Sprocket/Scripting/LuaEngine.h
+++ b/Sprocket/Scripting/LuaEngine.h
@@ -36,6 +36,7 @@ public:
 
     // Keyboard Events
 
+    // Setters
     void SetEntity(const Entity& e);
     void SetKeyboard(KeyboardProxy* k);
     void SetMouse(MouseProxy* m);

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -28,10 +28,11 @@
 
 #include "Scene/Systems/BasicSelector.h"
 #include "Scene/Systems/Selector.h"
+#include "Scene/Systems/CameraSystem.h"
 #include "Scene/Systems/PhysicsEngine.h"
-#include "Scene/Systems/ScriptRunner.h"
 #include "Scene/Systems/GameGrid.h"
 #include "Scene/Systems/PathFollower.h"
+#include "Scene/Systems/ScriptRunner.h"
 
 // EVENTS
 #include "Events/Event.h"

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -23,6 +23,7 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
     , d_entityManager({
         &d_physicsEngine,
         &d_selector,
+        &d_cameraSystem,
         &d_scriptRunner
     })
     , d_serialiser(&d_entityManager)
@@ -74,15 +75,8 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
 
 void WorldLayer::OnEvent(Sprocket::Event& event)
 {
-    using namespace Sprocket;
-
-    if (auto e = event.As<WindowResizeEvent>()) {
+    if (auto e = event.As<Sprocket::WindowResizeEvent>()) {
         d_postProcessor.SetScreenSize(e->Width(), e->Height());
-
-        // We only do the player camera here as the observer and editor
-        // projection matrices are updated via scripts.
-        //d_playerCamera.Get<CameraComponent>().projection =
-        //    Maths::Perspective(e->AspectRatio(), 70, 0.1f, 1000.0f);
     }
 
     d_entityManager.OnEvent(event);
@@ -95,9 +89,9 @@ void WorldLayer::OnUpdate(double dt)
     d_entityRenderer.BeginScene(d_activeCamera, d_lights);
 
     if (!d_paused) {
+        d_entityManager.OnUpdate(dt);
         d_lights.sun.direction = {Maths::Sind(d_sunAngle), Maths::Cosd(d_sunAngle), 0.0f};
         d_core.window->SetCursorVisibility(d_mouseRequired);
-        d_entityManager.OnUpdate(dt);
 
         d_entityManager.Each<TransformComponent, PhysicsComponent>([&](Entity& entity) {
             auto& transform = entity.Get<TransformComponent>();

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -18,6 +18,7 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
         })
     })
     , d_physicsEngine(Sprocket::Maths::vec3(0.0, -9.81, 0.0))
+    , d_cameraSystem(core.window->AspectRatio())
     , d_selector(core.window, &d_physicsEngine)
     , d_entityManager({
         &d_physicsEngine,

--- a/Workshop/WorldLayer.h
+++ b/Workshop/WorldLayer.h
@@ -27,6 +27,7 @@ class WorldLayer : public Sprocket::Layer
     // Entity management and systems
     Sprocket::PhysicsEngine  d_physicsEngine;
     Sprocket::Selector       d_selector;
+    Sprocket::CameraSystem   d_cameraSystem;
     Sprocket::ScriptRunner   d_scriptRunner;
     Sprocket::Scene  d_entityManager;
 


### PR DESCRIPTION
- Change `LuaCamera` API to only expose getters and setters for the `CameraComponent` excluding the projection matrix.
- Added `CameraSystem` which is responsible for setting the projection matrix and handling window resizing.
- Remove `SetOrthographicCamera` and `SetPerspectiveCamera` from Lua.
- Remove all projection related code from the Lua scripts.
- The projection matrix on a camera component is no longer serialised as it gets set by the `CameraSystem` according to the screen size.
- `EntitySystem::OnEvent` now takes the `Scene` as a parameter.
