### PR TITLE
Instanced Rendering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
         "regex": "cpp",
         "typeindex": "cpp",
         "unordered_set": "cpp",
-        "valarray": "cpp"
+        "valarray": "cpp",
+        "fft": "cpp"
     }
 }

--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -20,6 +20,7 @@ EditorLayer::EditorLayer(const CoreSystems& core)
     : Layer(core)
     , d_entityRenderer(core.window, core.modelManager, core.textureManager)
     , d_skyboxRenderer(core.window)
+    , d_colliderRenderer(core.window)
     , d_skybox({
         ModelManager::LoadModel("Resources/Models/Skybox.obj"),
         CubeMap({
@@ -104,16 +105,20 @@ void EditorLayer::OnUpdate(double dt)
         });
     }
 
-    d_entityRenderer.RenderColliders(d_showColliders);
-
     d_viewport.Bind();
     if (d_playingGame) {
         d_entityRenderer.Draw(d_runtimeCamera, d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_runtimeCamera);
+        if (d_showColliders) {
+            d_colliderRenderer.Draw(d_runtimeCamera, d_lights, *d_activeScene);
+        }
     }
     else {
         d_entityRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_editorCamera.Proj(), d_editorCamera.View());
+        if (d_showColliders) {
+            d_colliderRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
+        }
     }
     d_viewport.Unbind();
 

--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -110,14 +110,14 @@ void EditorLayer::OnUpdate(double dt)
         d_entityRenderer.Draw(d_runtimeCamera, d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_runtimeCamera);
         if (d_showColliders) {
-            d_colliderRenderer.Draw(d_runtimeCamera, d_lights, *d_activeScene);
+            d_colliderRenderer.Draw(d_runtimeCamera, *d_activeScene);
         }
     }
     else {
         d_entityRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_editorCamera.Proj(), d_editorCamera.View());
         if (d_showColliders) {
-            d_colliderRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
+            d_colliderRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), *d_activeScene);
         }
     }
     d_viewport.Unbind();

--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -19,7 +19,7 @@ std::string Name(const Entity& entity)
 EditorLayer::EditorLayer(const CoreSystems& core) 
     : Layer(core)
     , d_entityRenderer(core.window, core.modelManager, core.textureManager)
-    , d_skyboxRenderer(core.window)
+    , d_skyboxRenderer()
     , d_colliderRenderer(core.window)
     , d_skybox({
         ModelManager::LoadModel("Resources/Models/Skybox.obj"),

--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -108,17 +108,13 @@ void EditorLayer::OnUpdate(double dt)
 
     d_viewport.Bind();
     if (d_playingGame) {
-        d_entityRenderer.BeginScene(d_runtimeCamera, d_lights, *d_activeScene);
+        d_entityRenderer.Draw(d_runtimeCamera, d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_runtimeCamera);
     }
     else {
-        d_entityRenderer.BeginScene(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
+        d_entityRenderer.Draw(d_editorCamera.Proj(), d_editorCamera.View(), d_lights, *d_activeScene);
         d_skyboxRenderer.Draw(d_skybox, d_editorCamera.Proj(), d_editorCamera.View());
     }
-
-    d_activeScene->Each<TransformComponent>([&](Entity& entity) {
-        d_entityRenderer.Draw(entity);
-    });
     d_viewport.Unbind();
 
     d_ui.StartFrame();

--- a/Anvil/EditorLayer.h
+++ b/Anvil/EditorLayer.h
@@ -14,6 +14,7 @@ class EditorLayer : public Layer
     // Rendering
     EntityRenderer d_entityRenderer;
     SkyboxRenderer d_skyboxRenderer;
+    ColliderRenderer d_colliderRenderer;
 
     FrameBuffer d_viewport;
     DevUI::Context d_ui;

--- a/Game/WorldLayer.cpp
+++ b/Game/WorldLayer.cpp
@@ -181,14 +181,11 @@ void WorldLayer::OnUpdate(double dt)
         d_postProcessor.Bind();
     }
 
-    d_entityRenderer.BeginScene(d_camera, d_lights, *d_scene);
     d_entityRenderer.EnableShadows(
         d_shadowMapRenderer.GetShadowMap(),
         d_shadowMapRenderer.GetLightProjViewMatrix()   
     );
-    d_scene->Each<TransformComponent, ModelComponent>([&](Entity& entity) {
-        d_entityRenderer.Draw(entity);
-    });
+    d_entityRenderer.Draw(d_camera, d_lights, *d_scene);
 
     if (d_paused) {
         d_postProcessor.Unbind();

--- a/Game/WorldLayer.cpp
+++ b/Game/WorldLayer.cpp
@@ -171,11 +171,7 @@ void WorldLayer::OnUpdate(double dt)
     // Create the Shadow Map
     float lambda = 5.0f; // TODO: Calculate the floor intersection point
     Maths::vec3 target = d_camera.Get<TransformComponent>().position + lambda * Maths::Forwards(d_camera.Get<TransformComponent>().orientation);
-    d_shadowMapRenderer.BeginScene(sun, target);
-    d_scene->Each<TransformComponent, ModelComponent>([&](Entity& entity) {
-        d_shadowMapRenderer.Draw(entity);
-    });
-    d_shadowMapRenderer.EndScene(); 
+    d_shadowMapRenderer.Draw(sun, target, *d_scene);
 
     if (d_paused) {
         d_postProcessor.Bind();

--- a/Resources/Shaders/Collider.frag
+++ b/Resources/Shaders/Collider.frag
@@ -1,0 +1,7 @@
+#version 400 core
+layout(location = 0) out vec4 out_colour;
+
+void main()
+{
+    out_colour = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/Resources/Shaders/Collider.vert
+++ b/Resources/Shaders/Collider.vert
@@ -1,0 +1,12 @@
+#version 400 core
+layout(location = 0) in vec3 position;
+
+uniform mat4 u_model_matrix;
+uniform mat4 u_proj_matrix;
+uniform mat4 u_view_matrix;
+
+void main()
+{
+    vec4 world_pos = u_model_matrix * vec4(position, 1.0);
+    gl_Position = u_proj_matrix * u_view_matrix * world_pos;
+}

--- a/Resources/Shaders/Entity.frag
+++ b/Resources/Shaders/Entity.frag
@@ -25,9 +25,6 @@ uniform float u_ambience_brightness;
 uniform float u_shine_dampner;
 uniform float u_reflectivity;
 
-// Highlighting
-uniform float u_brightness;
-
 // Shadows
 in vec4 p_light_space_pos;
 uniform sampler2D shadow_map;
@@ -110,8 +107,4 @@ void main()
     if (proj_coords.z > 1.0) { shadow = 0.0; }
 
     out_colour = (ambience + (1.0 - shadow) * (total_diffuse + total_specular)) * colour;
-    
-    if (u_brightness > 1) {
-        out_colour += u_brightness * vec4(0.1, 0.1, 0.1, 1.0);
-    }
 }

--- a/Resources/Shaders/Entity.frag
+++ b/Resources/Shaders/Entity.frag
@@ -4,6 +4,8 @@ in vec2  p_texture_coords;
 in vec3  p_surface_normal;
 in vec3  p_to_camera_vector;
 in vec3  p_to_light_vector[5];
+in float p_shine_damper;
+in float p_reflectivity;
 
 layout(location = 0) out vec4 out_colour;
 
@@ -20,10 +22,6 @@ uniform float u_sun_brightness;
 
 uniform vec3  u_ambience_colour;
 uniform float u_ambience_brightness;
-
-// Texture/Lighting Information
-uniform float u_shine_dampner;
-uniform float u_reflectivity;
 
 // Shadows
 in vec4 p_light_space_pos;
@@ -82,8 +80,8 @@ void main()
         // Specular lighting calculation
         float specular_factor = dot(reflected_light_direction, unit_to_camera);
         specular_factor = max(specular_factor, 0.0);
-        specular_factor = pow(specular_factor, u_shine_dampner) / attenuation;
-        total_specular = total_specular + vec4(specular_factor * u_reflectivity * u_light_colour[i], 1.0);
+        specular_factor = pow(specular_factor, p_shine_damper) / attenuation;
+        total_specular = total_specular + vec4(specular_factor * p_reflectivity * u_light_colour[i], 1.0);
     }
 
     // Shadows

--- a/Resources/Shaders/Entity.vert
+++ b/Resources/Shaders/Entity.vert
@@ -3,15 +3,18 @@
 layout(location = 0) in vec3 position;
 layout(location = 1) in vec3 normal;
 layout(location = 2) in vec2 texture_coords;
+layout(location = 3) in vec3 model_position;
+layout(location = 4) in vec4 model_orientation;
+layout(location = 5) in vec3 model_scale;
+layout(location = 6) in float shine_damper;
+layout(location = 7) in float reflectivity;
 
 out vec2  p_texture_coords;
 out vec3  p_surface_normal;
 out vec3  p_to_camera_vector;
 out vec3  p_to_light_vector[5];
-
-uniform vec3 u_model_position;
-uniform vec4 u_model_orientation;
-uniform vec3 u_model_scale;
+out float p_shine_damper;
+out float p_reflectivity;
 
 uniform mat4 u_proj_matrix;
 uniform mat4 u_view_matrix;
@@ -60,7 +63,7 @@ mat4 Transform(vec3 p, vec4 o, vec3 s)
 
 void main()
 {
-    mat4 transform = Transform(u_model_position, u_model_orientation, u_model_scale);
+    mat4 transform = Transform(model_position, model_orientation, model_scale);
     vec4 world_pos = transform * vec4(position, 1.0);
     gl_Position = u_proj_matrix * u_view_matrix * world_pos;
     
@@ -73,4 +76,7 @@ void main()
     for (int i = 0; i != 5; i++) {
         p_to_light_vector[i] = u_light_pos[i] - world_pos.xyz;
     }
+
+    p_shine_damper = shine_damper;
+    p_reflectivity = reflectivity;
 }

--- a/Resources/Shaders/GaussH.vert
+++ b/Resources/Shaders/GaussH.vert
@@ -1,13 +1,13 @@
 #version 400 core
-layout (location = 0) in vec2 position;
+layout (location = 0) in vec3 position;
 
 out vec2 blueTextureCoords[11];
 
 uniform float targetWidth;
 
 void main(void){
-	gl_Position = vec4(position, 0.0, 1.0);
-	vec2 centerTexCoords = position * 0.5 + 0.5;
+	gl_Position = vec4(position, 1.0);
+	vec2 centerTexCoords = position.xy * 0.5 + 0.5;
     float pixelSize = 1.0 / targetWidth;
 
     for (int i = -5; i <= 5; i++) {

--- a/Resources/Shaders/GaussV.vert
+++ b/Resources/Shaders/GaussV.vert
@@ -1,13 +1,13 @@
 #version 400 core
-layout (location = 0) in vec2 position;
+layout (location = 0) in vec3 position;
 
 out vec2 blueTextureCoords[11];
 
 uniform float targetHeight;
 
 void main(void){
-	gl_Position = vec4(position, 0.0, 1.0);
-	vec2 centerTexCoords = position * 0.5 + 0.5;
+	gl_Position = vec4(position, 1.0);
+	vec2 centerTexCoords = position.xy * 0.5 + 0.5;
     float pixelSize = 1.0 / targetHeight;
 
     for (int i = -5; i <= 5; i++) {

--- a/Resources/Shaders/Negative.vert
+++ b/Resources/Shaders/Negative.vert
@@ -1,13 +1,13 @@
 #version 400 core
 
-in vec2 position;
-in vec2 texCoords;
+layout (location = 0) in vec3 position;
+layout (location = 1) in vec2 texCoords;
 
 out vec2 textureCoords;
 
 void main(void){
 
-	gl_Position = vec4(position, 0.0, 1.0);
+	gl_Position = vec4(position, 1.0);
 	textureCoords = texCoords;
 	
 }

--- a/Resources/Shaders/ShadowMap.vert
+++ b/Resources/Shaders/ShadowMap.vert
@@ -3,14 +3,54 @@
 layout(location = 0) in vec3 position;
 layout(location = 1) in vec3 normal;
 layout(location = 2) in vec2 uv;
+layout(location = 3) in vec3 model_position;
+layout(location = 4) in vec4 model_orientation;
+layout(location = 5) in vec3 model_scale;
 
-uniform mat4 u_model_matrix;
 uniform mat4 u_proj_matrix;
 uniform mat4 u_view_matrix;
 
+mat4 Transform(vec3 p, vec4 o, vec3 s)
+{
+    mat4 matrix;
+
+    float oxx = o.x * o.x;
+    float oyy = o.y * o.y;
+    float ozz = o.z * o.z;
+    float oxz = o.x * o.z;
+    float oxy = o.x * o.y;
+    float oyz = o.y * o.z;
+    float owx = o.w * o.x;
+    float owy = o.w * o.y;
+    float owz = o.w * o.z;
+
+    matrix[0][0] = s.x * (1 - 2 * (oyy + ozz));
+    matrix[0][1] = s.x * (2 * (oxy + owz));
+    matrix[0][2] = s.x * (2 * (oxz - owy));
+    matrix[0][3] = 0;
+
+    matrix[1][0] = s.y * (2 * (oxy - owx));
+    matrix[1][1] = s.y * (1 - 2 * (oxx + ozz));
+    matrix[1][2] = s.y * (2 * (oyz + owx));
+    matrix[1][3] = 0;
+
+    matrix[2][0] = s.z * (2 * (oxz + owy));
+    matrix[2][1] = s.z * (2 * (oyz - owx));
+    matrix[2][2] = s.z * (1 - 2 * (oxx + oyy));
+    matrix[2][3] = 0;
+
+    matrix[3][0] = p.x;
+    matrix[3][1] = p.y;
+    matrix[3][2] = p.z;
+    matrix[3][3] = 1;
+
+    return matrix;
+}
+
 void main()
 {
+    mat4 transform = Transform(model_position, model_orientation, model_scale);
     gl_Position = u_proj_matrix *
                   u_view_matrix *
-                  u_model_matrix * vec4(position, 1.0);
+                  transform * vec4(position, 1.0);
 }

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(Sprocket STATIC
             Graphics/CubeMap.cpp
             Graphics/FrameBuffer.cpp
             Graphics/StreamBuffer.cpp
+            Graphics/VertexArray.cpp
 
             Graphics/Rendering/EntityRenderer.cpp
             Graphics/Rendering/SkyboxRenderer.cpp

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(Sprocket STATIC
             Graphics/Texture.cpp
             Graphics/CubeMap.cpp
             Graphics/FrameBuffer.cpp
+            Graphics/InstanceBuffer.cpp
             Graphics/StreamBuffer.cpp
             Graphics/VertexArray.cpp
 

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(Sprocket STATIC
             Graphics/StreamBuffer.cpp
             Graphics/VertexArray.cpp
 
+            Graphics/Rendering/ColliderRenderer.cpp
             Graphics/Rendering/EntityRenderer.cpp
             Graphics/Rendering/SkyboxRenderer.cpp
 

--- a/Sprocket/Core/ModelManager.cpp
+++ b/Sprocket/Core/ModelManager.cpp
@@ -16,7 +16,7 @@ bool IsSceneValid(const aiScene* scene)
            scene->mRootNode;
 }
 
-Model3D ProcessMesh(const aiScene* scene, aiMesh* mesh)
+std::shared_ptr<Model3D> ProcessMesh(const aiScene* scene, aiMesh* mesh)
 {    
     Vertex3DBuffer vertices;
     IndexBuffer    indices;
@@ -48,12 +48,12 @@ Model3D ProcessMesh(const aiScene* scene, aiMesh* mesh)
         }
     }
 
-    return Model3D(vertices, indices);
+    return std::make_shared<Model3D>(vertices, indices);
 }
 
 }
 
-Model3D ModelManager::LoadModel(const std::string& path)
+std::shared_ptr<Model3D> ModelManager::LoadModel(const std::string& path)
 {
     Assimp::Importer importer;
     int flags = aiProcess_Triangulate | aiProcess_FlipUVs;
@@ -61,26 +61,26 @@ Model3D ModelManager::LoadModel(const std::string& path)
 
     if (!IsSceneValid(scene)) {
         SPKT_LOG_ERROR("ERROR::ASSIMP::{}", importer.GetErrorString());
-        return Model3D();
+        return std::make_shared<Model3D>();
     }
 
     if (scene->mNumMeshes != 1) {
         SPKT_LOG_ERROR("File does not have exactly one mesh, not supported!");
-        return Model3D();
+        return std::make_shared<Model3D>();
     }
 
     return ProcessMesh(scene, scene->mMeshes[0]);
 }
 
-Model3D ModelManager::GetModel(const std::string& path)
+std::shared_ptr<Model3D> ModelManager::GetModel(const std::string& path)
 {
-    if (path == "") { return Model3D(); }
+    if (path == "") { return std::make_shared<Model3D>(); }
     
     auto it = d_loadedModels.find(path);
     if (it != d_loadedModels.end()) {
         return it->second;
     }
-    Model3D model = LoadModel(path);
+    auto model = LoadModel(path);
     d_loadedModels.emplace(path, model);
     return model;   
 }

--- a/Sprocket/Core/ModelManager.h
+++ b/Sprocket/Core/ModelManager.h
@@ -4,22 +4,23 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 namespace Sprocket {
 
 class ModelManager
 {
 public:
-    using Map = std::map<std::string, Model3D>;
+    using Map = std::map<std::string, std::shared_ptr<Model3D>>;
 
 private:
     Map d_loadedModels;
 
 public:
-    static Model3D LoadModel(const std::string& path);
+    static std::shared_ptr<Model3D> LoadModel(const std::string& path);
         // Loads a model without caching it.
 
-    Model3D GetModel(const std::string& path);
+    std::shared_ptr<Model3D> GetModel(const std::string& path);
         // Returns the model in the specified path. If it has not beed loaded
         // it will be loaded and stored internally.
 

--- a/Sprocket/Graphics/InstanceBuffer.cpp
+++ b/Sprocket/Graphics/InstanceBuffer.cpp
@@ -1,0 +1,32 @@
+#include "InstanceBuffer.h"
+
+#include <glad/glad.h>
+
+namespace Sprocket {
+
+InstanceBuffer::InstanceBuffer()
+    : d_buffer(std::make_shared<VBO>())
+{
+    d_data.reserve(1000);
+    glBindBuffer(GL_ARRAY_BUFFER, d_buffer->Value());
+    glBufferData(GL_ARRAY_BUFFER, sizeof(InstanceData) * 1000, nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void InstanceBuffer::Bind()
+{
+    glBindBuffer(GL_ARRAY_BUFFER, d_buffer->Value());
+    glBufferData(GL_ARRAY_BUFFER, sizeof(InstanceData) * d_data.size(), d_data.data(), GL_DYNAMIC_DRAW);
+}
+
+void InstanceBuffer::Clear()
+{
+    d_data.clear();
+}
+
+void InstanceBuffer::Add(const InstanceData& data)
+{
+    d_data.push_back(data);
+}
+
+}

--- a/Sprocket/Graphics/InstanceBuffer.h
+++ b/Sprocket/Graphics/InstanceBuffer.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "Maths.h"
+#include "Resources.h"
+
+#include <vector>
+
+namespace Sprocket {
+
+struct InstanceData
+{
+    Maths::vec3 position;
+    Maths::quat orientation;
+    Maths::vec3 scale;
+    float       shineDamper;
+    float       reflectivity;
+};
+
+class InstanceBuffer
+{
+    std::shared_ptr<VBO> d_buffer;
+
+    std::vector<InstanceData> d_data;
+
+public:
+    InstanceBuffer();
+
+    void Bind();
+    void Clear();
+
+    void Add(const InstanceData& data);
+
+    std::size_t Size() const { return d_data.size(); }
+};
+
+}

--- a/Sprocket/Graphics/Model2D.cpp
+++ b/Sprocket/Graphics/Model2D.cpp
@@ -16,16 +16,12 @@ Model2D::Model2D(const Vertex2DBuffer& vertices)
 
     // Set Vertex Attributes in the VAO
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex2D),
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex2D),
                           (void*)offsetof(Vertex2D, position));
 
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex2D),
                           (void*)offsetof(Vertex2D, texture));
-
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex2D),
-                          (void*)offsetof(Vertex2D, colour));
 
     glBindVertexArray(0);
 }

--- a/Sprocket/Graphics/Model2D.h
+++ b/Sprocket/Graphics/Model2D.h
@@ -8,14 +8,14 @@ namespace Sprocket {
 
 struct Vertex2D
 {
-    Maths::vec2 position;
+    Maths::vec3 position;
     Maths::vec2 texture;
-    Maths::vec3 colour;
 };
 
 using Vertex2DBuffer = std::vector<Vertex2D>;
 
-class Model2D 
+class Model2D
+// TODO: Remove this basically useless class.
 {
     std::shared_ptr<VAO> d_vao;
     std::shared_ptr<VBO> d_vertexBuffer;

--- a/Sprocket/Graphics/Model3D.cpp
+++ b/Sprocket/Graphics/Model3D.cpp
@@ -7,11 +7,8 @@ namespace Sprocket {
 Model3D::Model3D(const Vertex3DBuffer& vertices,
                  const IndexBuffer& indices)
 {
-    d_vao = std::make_shared<VAO>();
-    glBindVertexArray(d_vao->Value());
     d_vertexBuffer = LoadVertexBuffer(vertices);
     d_indexBuffer = LoadIndexBuffer(indices);
-    glBindVertexArray(0);
 
     d_vertexData = std::make_shared<Vertex3DBuffer>(vertices);
     d_indexData = std::make_shared<IndexBuffer>(indices);
@@ -23,17 +20,8 @@ Model3D::Model3D()
 
 void Model3D::Bind() const
 {
-    if (d_vao) {
-        glBindVertexArray(d_vao->Value());
-    }
-    else {
-        glBindVertexArray(0);
-    }
-}
-
-void Model3D::Unbind() const
-{
-    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer->Value());
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer->Value());
 }
 
 std::shared_ptr<VBO> Model3D::LoadVertexBuffer(const Vertex3DBuffer& vertices)
@@ -41,20 +29,6 @@ std::shared_ptr<VBO> Model3D::LoadVertexBuffer(const Vertex3DBuffer& vertices)
     auto vertexBuffer = std::make_shared<VBO>();
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer->Value());
     glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex3D) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
-
-    // Set Vertex Attributes in the VAO
-    //glEnableVertexAttribArray(0);
-    //glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-    //                      (void*)offsetof(Vertex3D, position));
-//
-    //glEnableVertexAttribArray(1);
-    //glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-    //                      (void*)offsetof(Vertex3D, normal));
-//
-    //glEnableVertexAttribArray(2);
-    //glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-    //                      (void*)offsetof(Vertex3D, textureCoords));
-
     return vertexBuffer;
 }
 
@@ -70,28 +44,8 @@ std::shared_ptr<VBO> Model3D::LoadIndexBuffer(const IndexBuffer& indices)
 bool Model3D::operator==(const Model3D& other) const
 {
     // Two models are the same if they point to the same VAO.
-    return d_vao->Value() == other.d_vao->Value();
-}
-
-void Model3D::Load() const
-{
-    // Bind the VBO, set the attrib pointers in the VAO, then unbind
-    glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer->Value());
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, position));
-
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, normal));
-
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, textureCoords));
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    // Set the index buffer pointer
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer->Value());
+    return d_vertexBuffer->Value() == other.d_vertexBuffer->Value() &&
+           d_indexBuffer->Value() == other.d_indexBuffer->Value();
 }
 
 }

--- a/Sprocket/Graphics/Model3D.cpp
+++ b/Sprocket/Graphics/Model3D.cpp
@@ -43,17 +43,17 @@ std::shared_ptr<VBO> Model3D::LoadVertexBuffer(const Vertex3DBuffer& vertices)
     glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex3D) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
 
     // Set Vertex Attributes in the VAO
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, position));
-
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, normal));
-
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
-                          (void*)offsetof(Vertex3D, textureCoords));
+    //glEnableVertexAttribArray(0);
+    //glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+    //                      (void*)offsetof(Vertex3D, position));
+//
+    //glEnableVertexAttribArray(1);
+    //glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+    //                      (void*)offsetof(Vertex3D, normal));
+//
+    //glEnableVertexAttribArray(2);
+    //glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+    //                      (void*)offsetof(Vertex3D, textureCoords));
 
     return vertexBuffer;
 }

--- a/Sprocket/Graphics/Model3D.cpp
+++ b/Sprocket/Graphics/Model3D.cpp
@@ -73,4 +73,25 @@ bool Model3D::operator==(const Model3D& other) const
     return d_vao->Value() == other.d_vao->Value();
 }
 
+void Model3D::Load() const
+{
+    // Bind the VBO, set the attrib pointers in the VAO, then unbind
+    glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer->Value());
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, position));
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, normal));
+
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, textureCoords));
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    // Set the index buffer pointer
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer->Value());
+}
+
 }

--- a/Sprocket/Graphics/Model3D.cpp
+++ b/Sprocket/Graphics/Model3D.cpp
@@ -6,12 +6,17 @@ namespace Sprocket {
 
 Model3D::Model3D(const Vertex3DBuffer& vertices,
                  const IndexBuffer& indices)
+    : d_vertexBuffer(std::make_shared<VBO>())
+    , d_indexBuffer(std::make_shared<VBO>())
+    , d_count(indices.size())
 {
-    d_vertexBuffer = LoadVertexBuffer(vertices);
-    d_indexBuffer = LoadIndexBuffer(indices);
+    glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer->Value());
+    glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex3D) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    d_vertexData = std::make_shared<Vertex3DBuffer>(vertices);
-    d_indexData = std::make_shared<IndexBuffer>(indices);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer->Value());
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(unsigned int) * indices.size(), indices.data(), GL_STATIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 Model3D::Model3D()
@@ -22,23 +27,6 @@ void Model3D::Bind() const
 {
     glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer->Value());
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer->Value());
-}
-
-std::shared_ptr<VBO> Model3D::LoadVertexBuffer(const Vertex3DBuffer& vertices)
-{
-    auto vertexBuffer = std::make_shared<VBO>();
-    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer->Value());
-    glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex3D) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
-    return vertexBuffer;
-}
-
-std::shared_ptr<VBO> Model3D::LoadIndexBuffer(const IndexBuffer& indices)
-{
-    auto indexBuffer = std::make_shared<VBO>();
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer->Value());
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(unsigned int) * indices.size(), indices.data(), GL_STATIC_DRAW);
-
-    return indexBuffer;
 }
 
 bool Model3D::operator==(const Model3D& other) const

--- a/Sprocket/Graphics/Model3D.h
+++ b/Sprocket/Graphics/Model3D.h
@@ -23,12 +23,7 @@ class Model3D
     std::shared_ptr<VBO> d_vertexBuffer;
     std::shared_ptr<VBO> d_indexBuffer;
 
-    // CPU STORAGE
-    std::shared_ptr<Vertex3DBuffer> d_vertexData;
-    std::shared_ptr<IndexBuffer>    d_indexData;
-
-    std::shared_ptr<VBO> LoadVertexBuffer(const Vertex3DBuffer& vertices);
-    std::shared_ptr<VBO> LoadIndexBuffer(const IndexBuffer& indices);
+    std::size_t d_count;
 
 public:
     Model3D(const Vertex3DBuffer& vertices,
@@ -36,16 +31,12 @@ public:
 
     Model3D(); // Empty model
 
-    std::size_t VertexCount() const { return d_indexData->size(); }
+    std::size_t VertexCount() const { return d_count; }
 
     // Binds the vertex buffer and index buffer. This will set the index
     // buffer in the currently bound vertex array but does not set any
     // attrib pointers.
     void Bind() const;
-
-    // CPU STORAGE ACCESS
-    const Vertex3DBuffer& VertexBufferData() const { return *d_vertexData.get(); }
-    const IndexBuffer& IndexBufferData() const { return *d_indexData.get(); }
 
     bool operator==(const Model3D& other) const;
 };

--- a/Sprocket/Graphics/Model3D.h
+++ b/Sprocket/Graphics/Model3D.h
@@ -20,7 +20,6 @@ using IndexBuffer = std::vector<unsigned int>;
 class Model3D
 {
     // GPU STORAGE
-    std::shared_ptr<VAO> d_vao;
     std::shared_ptr<VBO> d_vertexBuffer;
     std::shared_ptr<VBO> d_indexBuffer;
 
@@ -39,13 +38,10 @@ public:
 
     std::size_t VertexCount() const { return d_indexData->size(); }
 
-    // GPU STORAGE ACCESS
+    // Binds the vertex buffer and index buffer. This will set the index
+    // buffer in the currently bound vertex array but does not set any
+    // attrib pointers.
     void Bind() const;
-    void Unbind() const;
-
-    // Sets the attrib pointers and index buffer in the current bound
-    // VAO to this model.
-    void Load() const;
 
     // CPU STORAGE ACCESS
     const Vertex3DBuffer& VertexBufferData() const { return *d_vertexData.get(); }

--- a/Sprocket/Graphics/Model3D.h
+++ b/Sprocket/Graphics/Model3D.h
@@ -43,6 +43,10 @@ public:
     void Bind() const;
     void Unbind() const;
 
+    // Sets the attrib pointers and index buffer in the current bound
+    // VAO to this model.
+    void Load() const;
+
     // CPU STORAGE ACCESS
     const Vertex3DBuffer& VertexBufferData() const { return *d_vertexData.get(); }
     const IndexBuffer& IndexBufferData() const { return *d_indexData.get(); }

--- a/Sprocket/Graphics/PostProcessing/Effect.cpp
+++ b/Sprocket/Graphics/PostProcessing/Effect.cpp
@@ -10,29 +10,23 @@ Vertex2DBuffer GetQuad()
 {
     return Vertex2DBuffer{
         {
-            Maths::vec2{-1.0f, -1.0f},
-            Maths::vec2{0.0f, 0.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{-1.0f, -1.0f, 0.0f},
+            Maths::vec2{0.0f, 0.0f}
         }, {
-            Maths::vec2{1.0f, -1.0f},
-            Maths::vec2{1.0f, 0.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{1.0f, -1.0f, 0.0f},
+            Maths::vec2{1.0f, 0.0f}
         }, {
-            Maths::vec2{1.0f, 1.0f},
-            Maths::vec2{1.0f, 1.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{1.0f, 1.0f, 0.0f},
+            Maths::vec2{1.0f, 1.0f}
         }, {
-            Maths::vec2{1.0f, 1.0f},
-            Maths::vec2{1.0f, 1.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{1.0f, 1.0f, 0.0f},
+            Maths::vec2{1.0f, 1.0f}
         }, {
-            Maths::vec2{-1.0f, 1.0f},
-            Maths::vec2{0.0f, 1.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{-1.0f, 1.0f, 0.0f},
+            Maths::vec2{0.0f, 1.0f}
         }, {
-            Maths::vec2{-1.0f, -1.0f},
-            Maths::vec2{0.0f, 0.0f},
-            Maths::vec3{1.0f, 1.0f, 1.0f}
+            Maths::vec3{-1.0f, -1.0f, 0.0f},
+            Maths::vec2{0.0f, 0.0f}
         }
     };
 }

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -1,0 +1,172 @@
+#include "ColliderRenderer.h"
+#include "Maths.h"
+#include "ModelManager.h"
+#include "RenderContext.h"
+#include "CameraUtils.h"
+#include "Components.h"
+#include "Scene.h"
+
+#include <glad/glad.h>
+
+namespace Sprocket {
+
+ColliderRenderer::ColliderRenderer(Window* window)
+    : d_vao(std::make_unique<VertexArray>())
+    , d_window(window)
+    , d_shader("Resources/Shaders/Entity.vert", "Resources/Shaders/Entity.frag")
+{
+}
+
+void ColliderRenderer::Draw(
+    const Maths::mat4& proj,
+    const Maths::mat4& view,
+    const Lights& lights,
+    Scene& scene)
+{
+    unsigned int MAX_NUM_LIGHTS = 5;
+
+    d_shader.Bind();
+    d_shader.LoadUniform("u_proj_matrix", proj);
+    d_shader.LoadUniform("u_view_matrix", view);
+
+    // Load sun to shader
+    const auto& sun = scene.GetSun();
+    d_shader.LoadUniform("u_sun_direction", sun.direction);
+    d_shader.LoadUniform("u_sun_colour", sun.colour);
+    d_shader.LoadUniform("u_sun_brightness", sun.brightness);
+
+    // Load ambience to shader
+    d_shader.LoadUniform("u_ambience_colour", lights.ambience.colour);
+    d_shader.LoadUniform("u_ambience_brightness", lights.ambience.brightness);
+    
+    // Load point lights to shader
+    for (std::size_t i = 0; i != MAX_NUM_LIGHTS; ++i) {
+		d_shader.LoadUniform(ArrayName("u_light_pos", i), {0.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_colour", i), {0.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_attenuation", i), {1.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_brightness", i), 0.0f);
+	}
+    std::size_t i = 0;
+    scene.Each<TransformComponent, LightComponent>([&](Entity& entity) {
+        if (i < MAX_NUM_LIGHTS) {
+            auto position = entity.Get<TransformComponent>().position;
+            auto light = entity.Get<LightComponent>();
+            d_shader.LoadUniform(ArrayName("u_light_pos", i), position);
+			d_shader.LoadUniform(ArrayName("u_light_colour", i), light.colour);
+			d_shader.LoadUniform(ArrayName("u_light_attenuation", i), light.attenuation);
+            d_shader.LoadUniform(ArrayName("u_light_brightness", i), light.brightness);
+        }
+        ++i;
+    });
+
+    scene.Each<TransformComponent>([&](Entity& entity) {
+        Draw(entity);
+    });
+    d_shader.Unbind();
+}
+
+void ColliderRenderer::Draw(const Entity& camera, const Lights& lights, Scene& scene)
+{
+    Maths::mat4 proj = CameraUtils::MakeProj(camera);
+    Maths::mat4 view = CameraUtils::MakeView(camera);
+    Draw(proj, view, lights, scene);
+}
+
+void ColliderRenderer::Draw(const Entity& entity)
+{    
+    RenderContext rc;  // New render context for colliders.
+    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
+    d_shader.Bind();
+    if (entity.Has<BoxCollider3DComponent>()) {
+        DrawBox(entity);
+    }
+    if (entity.Has<SphereCollider3DComponent>()) {
+        DrawSphere(entity);
+    }
+    if (entity.Has<CapsuleCollider3DComponent>()) {
+        DrawCapsule(entity);
+    }
+    d_shader.Unbind();
+}
+
+void ColliderRenderer::DrawBox(const Entity& entity)
+{
+    const auto& physics = entity.Get<BoxCollider3DComponent>();
+    static auto s_cube = ModelManager::LoadModel("Resources/Models/Cube.obj");
+
+    auto tr = entity.Get<TransformComponent>();
+    Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
+    transform *= Maths::Transform(physics.position, physics.orientation);
+    transform = Maths::Scale(transform, physics.halfExtents);
+    if (physics.applyScale) {
+        transform = Maths::Scale(transform, tr.scale);
+    }
+
+    Texture::White().Bind();
+    d_shader.LoadUniform("u_model_matrix", transform);
+    d_vao->SetModel(s_cube);
+    d_vao->Draw();
+    Texture::White().Unbind();
+}
+
+void ColliderRenderer::DrawSphere(const Entity& entity)
+{
+    const auto& physics = entity.Get<SphereCollider3DComponent>();
+    static auto s_sphere = ModelManager::LoadModel("Resources/Models/LowPolySphere.obj");
+
+    auto tr = entity.Get<TransformComponent>();
+    Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
+    transform *= Maths::Transform(physics.position, physics.orientation);
+    transform = Maths::Scale(transform, physics.radius);
+    
+    Texture::White().Bind();
+    d_shader.LoadUniform("u_model_matrix", transform);
+    d_vao->SetModel(s_sphere);
+    d_vao->Draw();
+    Texture::White().Unbind();
+}
+
+void ColliderRenderer::DrawCapsule(const Entity& entity)
+{
+    const auto& physics = entity.Get<CapsuleCollider3DComponent>();
+    static auto s_hemisphere = ModelManager::LoadModel("Resources/Models/Hemisphere.obj");
+    static auto s_cylinder = ModelManager::LoadModel("Resources/Models/Cylinder.obj");
+
+    Texture::White().Bind();
+    {  // Top Hemisphere
+        auto tr = entity.Get<TransformComponent>();
+        Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
+        transform *= Maths::Transform(physics.position, physics.orientation);
+        transform = Maths::Translate(transform, {0.0, physics.height/2, 0.0});
+        transform = Maths::Scale(transform, physics.radius);
+        d_shader.LoadUniform("u_model_matrix", transform);
+        d_vao->SetModel(s_hemisphere);
+        d_vao->Draw();
+    }
+
+    {  // Middle Cylinder
+        auto tr = entity.Get<TransformComponent>();
+        Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
+        transform *= Maths::Transform(physics.position, physics.orientation);
+        transform = Maths::Scale(transform, {physics.radius, physics.height, physics.radius});
+        d_shader.LoadUniform("u_model_matrix", transform);
+        d_vao->SetModel(s_cylinder);
+        d_vao->Draw();
+    }
+
+    {  // Bottom Hemisphere
+        auto tr = entity.Get<TransformComponent>();
+        Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
+        transform *= Maths::Transform(physics.position, physics.orientation);
+        transform = Maths::Translate(transform, {0.0, -physics.height/2, 0.0});
+        transform = Maths::Rotate(transform, {1, 0, 0}, Maths::Radians(180.0f));
+        transform = Maths::Scale(transform, physics.radius);
+        d_shader.LoadUniform("u_model_matrix", transform);
+        d_vao->SetModel(s_hemisphere);
+        d_vao->Draw();
+    }
+    Texture::White().Unbind();   
+}
+
+}

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -13,54 +13,23 @@ namespace Sprocket {
 ColliderRenderer::ColliderRenderer(Window* window)
     : d_vao(std::make_unique<VertexArray>())
     , d_window(window)
-    , d_shader("Resources/Shaders/Entity.vert", "Resources/Shaders/Entity.frag")
+    , d_shader("Resources/Shaders/Collider.vert", "Resources/Shaders/Collider.frag")
 {
 }
 
 void ColliderRenderer::Draw(
     const Maths::mat4& proj,
     const Maths::mat4& view,
-    const Lights& lights,
     Scene& scene)
 {
     RenderContext rc;
     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    
+
     unsigned int MAX_NUM_LIGHTS = 5;
 
     d_shader.Bind();
     d_shader.LoadUniform("u_proj_matrix", proj);
     d_shader.LoadUniform("u_view_matrix", view);
-
-    // Load sun to shader
-    const auto& sun = scene.GetSun();
-    d_shader.LoadUniform("u_sun_direction", sun.direction);
-    d_shader.LoadUniform("u_sun_colour", sun.colour);
-    d_shader.LoadUniform("u_sun_brightness", sun.brightness);
-
-    // Load ambience to shader
-    d_shader.LoadUniform("u_ambience_colour", lights.ambience.colour);
-    d_shader.LoadUniform("u_ambience_brightness", lights.ambience.brightness);
-    
-    // Load point lights to shader
-    for (std::size_t i = 0; i != MAX_NUM_LIGHTS; ++i) {
-		d_shader.LoadUniform(ArrayName("u_light_pos", i), {0.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_colour", i), {0.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_attenuation", i), {1.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_brightness", i), 0.0f);
-	}
-    std::size_t i = 0;
-    scene.Each<TransformComponent, LightComponent>([&](Entity& entity) {
-        if (i < MAX_NUM_LIGHTS) {
-            auto position = entity.Get<TransformComponent>().position;
-            auto light = entity.Get<LightComponent>();
-            d_shader.LoadUniform(ArrayName("u_light_pos", i), position);
-			d_shader.LoadUniform(ArrayName("u_light_colour", i), light.colour);
-			d_shader.LoadUniform(ArrayName("u_light_attenuation", i), light.attenuation);
-            d_shader.LoadUniform(ArrayName("u_light_brightness", i), light.brightness);
-        }
-        ++i;
-    });
 
     Texture::White().Bind();
     
@@ -134,11 +103,11 @@ void ColliderRenderer::Draw(
     d_shader.Unbind();
 }
 
-void ColliderRenderer::Draw(const Entity& camera, const Lights& lights, Scene& scene)
+void ColliderRenderer::Draw(const Entity& camera, Scene& scene)
 {
     Maths::mat4 proj = CameraUtils::MakeProj(camera);
     Maths::mat4 view = CameraUtils::MakeView(camera);
-    Draw(proj, view, lights, scene);
+    Draw(proj, view, scene);
 }
 
 }

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.h
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Window.h"
 #include "Entity.h"
-#include "Light.h"
 #include "Shader.h"
 #include "Texture.h"
 #include "ModelManager.h"
@@ -22,8 +21,8 @@ class ColliderRenderer
 public:
     ColliderRenderer(Window* window);
 
-    void Draw(const Entity& camera, const Lights& lights, Scene& scene);
-    void Draw(const Maths::mat4& proj, const Maths::mat4& view, const Lights& lights, Scene& scene);
+    void Draw(const Entity& camera, Scene& scene);
+    void Draw(const Maths::mat4& proj, const Maths::mat4& view, Scene& scene);
 
     Shader& GetShader() { return d_shader; }
 };

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.h
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.h
@@ -19,17 +19,11 @@ class ColliderRenderer
 
     std::unique_ptr<VertexArray> d_vao;
 
-    void DrawBox      (const Entity& entity);
-    void DrawSphere   (const Entity& entity);
-    void DrawCapsule  (const Entity& entity);
-
 public:
     ColliderRenderer(Window* window);
 
     void Draw(const Entity& camera, const Lights& lights, Scene& scene);
     void Draw(const Maths::mat4& proj, const Maths::mat4& view, const Lights& lights, Scene& scene);
-
-    void Draw(const Entity& entity);
 
     Shader& GetShader() { return d_shader; }
 };

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.h
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.h
@@ -11,29 +11,23 @@
 
 namespace Sprocket {
 
-class EntityRenderer
+class ColliderRenderer
 {
-    Window*         d_window;
-    ModelManager*   d_modelManager;
-    TextureManager* d_textureManager;
+    Window* d_window;
 
     Shader  d_shader;
 
     std::unique_ptr<VertexArray> d_vao;
 
-    void DrawModel    (const Entity& entity);
+    void DrawBox      (const Entity& entity);
+    void DrawSphere   (const Entity& entity);
+    void DrawCapsule  (const Entity& entity);
 
 public:
-    EntityRenderer(
-        Window* window,
-        ModelManager* modelManager,
-        TextureManager* textureManager
-    );
+    ColliderRenderer(Window* window);
 
     void Draw(const Entity& camera, const Lights& lights, Scene& scene);
     void Draw(const Maths::mat4& proj, const Maths::mat4& view, const Lights& lights, Scene& scene);
-
-    void EnableShadows(const Texture& shadowMap, const Maths::mat4& lightProjView);
 
     void Draw(const Entity& entity);
 

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -163,7 +163,7 @@ void EntityRenderer::DrawModel(const Entity& entity)
 
     d_vao->SetModel(model);
     d_vao->Draw();
-    
+
     texture.Unbind();
 }
 
@@ -198,12 +198,11 @@ void EntityRenderer::DrawBox(const Entity& entity)
         transform = Maths::Scale(transform, tr.scale);
     }
 
-    s_cube->Bind();
     Texture::White().Bind();
     d_shader.LoadUniform("u_model_matrix", transform);
-    glDrawElements(GL_TRIANGLES, (int)s_cube->VertexCount(), GL_UNSIGNED_INT, nullptr);
+    d_vao->SetModel(s_cube);
+    d_vao->Draw();
     Texture::White().Unbind();
-    s_cube->Unbind();
 }
 
 void EntityRenderer::DrawSphere(const Entity& entity)
@@ -216,12 +215,11 @@ void EntityRenderer::DrawSphere(const Entity& entity)
     transform *= Maths::Transform(physics.position, physics.orientation);
     transform = Maths::Scale(transform, physics.radius);
     
-    s_sphere->Bind();
     Texture::White().Bind();
     d_shader.LoadUniform("u_model_matrix", transform);
-    glDrawElements(GL_TRIANGLES, (int)s_sphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
+    d_vao->SetModel(s_sphere);
+    d_vao->Draw();
     Texture::White().Unbind();
-    s_sphere->Unbind();
 }
 
 void EntityRenderer::DrawCapsule(const Entity& entity)
@@ -232,30 +230,27 @@ void EntityRenderer::DrawCapsule(const Entity& entity)
 
     Texture::White().Bind();
     {  // Top Hemisphere
-        s_hemisphere->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
         transform = Maths::Translate(transform, {0.0, physics.height/2, 0.0});
         transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_hemisphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_hemisphere->Unbind();
+        d_vao->SetModel(s_hemisphere);
+        d_vao->Draw();
     }
 
     {  // Middle Cylinder
-        s_cylinder->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
         transform = Maths::Scale(transform, {physics.radius, physics.height, physics.radius});
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_cylinder->VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_cylinder->Unbind();
+        d_vao->SetModel(s_cylinder);
+        d_vao->Draw();
     }
 
     {  // Bottom Hemisphere
-        s_hemisphere->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
@@ -263,8 +258,8 @@ void EntityRenderer::DrawCapsule(const Entity& entity)
         transform = Maths::Rotate(transform, {1, 0, 0}, Maths::Radians(180.0f));
         transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_hemisphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_hemisphere->Unbind();
+        d_vao->SetModel(s_hemisphere);
+        d_vao->Draw();
     }
     Texture::White().Unbind();   
 }

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -84,16 +84,15 @@ void EntityRenderer::Draw(
     }
 
     d_shader.Bind();
-    d_instanceBuffer->Clear();
 
-    std::string currentModelStr;
+    std::string currentModel;
     std::string currentTexture;
     scene.Each<TransformComponent, ModelComponent>([&](Entity& entity) {
         const auto& tc = entity.Get<TransformComponent>();
         const auto& mc = entity.Get<ModelComponent>();
         if (mc.model.empty()) { return; }
 
-        bool changedModel = mc.model != currentModelStr;
+        bool changedModel = mc.model != currentModel;
         bool changedTexture = mc.texture != currentTexture;
 
         if (changedModel || changedTexture) {
@@ -104,7 +103,7 @@ void EntityRenderer::Draw(
 
         if (changedModel) {
             d_vao->SetModel(d_modelManager->GetModel(mc.model));
-            currentModelStr = mc.model;
+            currentModel = mc.model;
         }
 
         if (changedTexture) {

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -95,10 +95,12 @@ void EntityRenderer::Draw(
 
         if (mc.model != currentModelStr) {
             d_vao->SetModel(d_modelManager->GetModel(mc.model));
+            currentModelStr = mc.model;
         }
 
         if (mc.texture != currentTextureStr) {
             d_textureManager->GetTexture(mc.texture).Bind();
+            currentTextureStr = mc.texture;
         }
 
         d_shader.LoadUniform("u_model_position", tc.position);

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -53,7 +53,7 @@ void EntityRenderer::EnableShadows(
     glActiveTexture(GL_TEXTURE0);
 }
 
-void EntityRenderer::BeginScene(
+void EntityRenderer::Draw(
     const Maths::mat4& proj,
     const Maths::mat4& view,
     const Lights& lights,
@@ -94,14 +94,18 @@ void EntityRenderer::BeginScene(
         }
         ++i;
     });
+
+    scene.Each<TransformComponent>([&](Entity& entity) {
+        Draw(entity);
+    });
     d_shader.Unbind();
 }
 
-void EntityRenderer::BeginScene(const Entity& camera, const Lights& lights, Scene& scene)
+void EntityRenderer::Draw(const Entity& camera, const Lights& lights, Scene& scene)
 {
     Maths::mat4 proj = CameraUtils::MakeProj(camera);
     Maths::mat4 view = CameraUtils::MakeView(camera);
-    BeginScene(proj, view, lights, scene);
+    Draw(proj, view, lights, scene);
 }
 
 void EntityRenderer::Draw(const Entity& entity)

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -26,7 +26,8 @@ bool ShouldOutlineEntity(const Entity& entity)
 EntityRenderer::EntityRenderer(Window* window,
                                ModelManager* modelManager,
                                TextureManager* textureManager)
-    : d_window(window)
+    : d_vao(std::make_unique<VertexArray>())
+    , d_window(window)
     , d_modelManager(modelManager)
     , d_textureManager(textureManager)
     , d_shader("Resources/Shaders/Entity.vert", "Resources/Shaders/Entity.frag")
@@ -159,9 +160,10 @@ void EntityRenderer::DrawModel(const Entity& entity)
 
     glActiveTexture(GL_TEXTURE0);
     texture.Bind();
-    model.Bind();
-    glDrawElements(GL_TRIANGLES, (int)model.VertexCount(), GL_UNSIGNED_INT, nullptr);
-    model.Unbind();
+
+    d_vao->SetModel(model);
+    d_vao->Draw();
+    
     texture.Unbind();
 }
 
@@ -196,12 +198,12 @@ void EntityRenderer::DrawBox(const Entity& entity)
         transform = Maths::Scale(transform, tr.scale);
     }
 
-    s_cube.Bind();
+    s_cube->Bind();
     Texture::White().Bind();
     d_shader.LoadUniform("u_model_matrix", transform);
-    glDrawElements(GL_TRIANGLES, (int)s_cube.VertexCount(), GL_UNSIGNED_INT, nullptr);
+    glDrawElements(GL_TRIANGLES, (int)s_cube->VertexCount(), GL_UNSIGNED_INT, nullptr);
     Texture::White().Unbind();
-    s_cube.Unbind();
+    s_cube->Unbind();
 }
 
 void EntityRenderer::DrawSphere(const Entity& entity)
@@ -214,12 +216,12 @@ void EntityRenderer::DrawSphere(const Entity& entity)
     transform *= Maths::Transform(physics.position, physics.orientation);
     transform = Maths::Scale(transform, physics.radius);
     
-    s_sphere.Bind();
+    s_sphere->Bind();
     Texture::White().Bind();
     d_shader.LoadUniform("u_model_matrix", transform);
-    glDrawElements(GL_TRIANGLES, (int)s_sphere.VertexCount(), GL_UNSIGNED_INT, nullptr);
+    glDrawElements(GL_TRIANGLES, (int)s_sphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
     Texture::White().Unbind();
-    s_sphere.Unbind();
+    s_sphere->Unbind();
 }
 
 void EntityRenderer::DrawCapsule(const Entity& entity)
@@ -230,30 +232,30 @@ void EntityRenderer::DrawCapsule(const Entity& entity)
 
     Texture::White().Bind();
     {  // Top Hemisphere
-        s_hemisphere.Bind();
+        s_hemisphere->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
         transform = Maths::Translate(transform, {0.0, physics.height/2, 0.0});
         transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_hemisphere.VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_hemisphere.Unbind();
+        glDrawElements(GL_TRIANGLES, (int)s_hemisphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
+        s_hemisphere->Unbind();
     }
 
     {  // Middle Cylinder
-        s_cylinder.Bind();
+        s_cylinder->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
         transform = Maths::Scale(transform, {physics.radius, physics.height, physics.radius});
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_cylinder.VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_cylinder.Unbind();
+        glDrawElements(GL_TRIANGLES, (int)s_cylinder->VertexCount(), GL_UNSIGNED_INT, nullptr);
+        s_cylinder->Unbind();
     }
 
     {  // Bottom Hemisphere
-        s_hemisphere.Bind();
+        s_hemisphere->Bind();
         auto tr = entity.Get<TransformComponent>();
         Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(physics.position, physics.orientation);
@@ -261,8 +263,8 @@ void EntityRenderer::DrawCapsule(const Entity& entity)
         transform = Maths::Rotate(transform, {1, 0, 0}, Maths::Radians(180.0f));
         transform = Maths::Scale(transform, physics.radius);
         d_shader.LoadUniform("u_model_matrix", transform);
-        glDrawElements(GL_TRIANGLES, (int)s_hemisphere.VertexCount(), GL_UNSIGNED_INT, nullptr);
-        s_hemisphere.Unbind();
+        glDrawElements(GL_TRIANGLES, (int)s_hemisphere->VertexCount(), GL_UNSIGNED_INT, nullptr);
+        s_hemisphere->Unbind();
     }
     Texture::White().Unbind();   
 }

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -40,6 +40,11 @@ void EntityRenderer::Draw(
     const Lights& lights,
     Scene& scene)
 {
+    RenderContext rc;
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glEnable(GL_DEPTH_TEST);
+
     unsigned int MAX_NUM_LIGHTS = 5;
 
     d_shader.Bind();
@@ -57,12 +62,6 @@ void EntityRenderer::Draw(
     d_shader.LoadUniform("u_ambience_brightness", lights.ambience.brightness);
     
     // Load point lights to shader
-    for (std::size_t i = 0; i != MAX_NUM_LIGHTS; ++i) {
-		d_shader.LoadUniform(ArrayName("u_light_pos", i), {0.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_colour", i), {0.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_attenuation", i), {1.0f, 0.0f, 0.0f});
-        d_shader.LoadUniform(ArrayName("u_light_brightness", i), 0.0f);
-	}
     std::size_t i = 0;
     scene.Each<TransformComponent, LightComponent>([&](Entity& entity) {
         if (i < MAX_NUM_LIGHTS) {
@@ -72,13 +71,21 @@ void EntityRenderer::Draw(
 			d_shader.LoadUniform(ArrayName("u_light_colour", i), light.colour);
 			d_shader.LoadUniform(ArrayName("u_light_attenuation", i), light.attenuation);
             d_shader.LoadUniform(ArrayName("u_light_brightness", i), light.brightness);
+            ++i;
         }
+    });
+    while (i < MAX_NUM_LIGHTS) {
+        d_shader.LoadUniform(ArrayName("u_light_pos", i), {0.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_colour", i), {0.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_attenuation", i), {1.0f, 0.0f, 0.0f});
+        d_shader.LoadUniform(ArrayName("u_light_brightness", i), 0.0f);
         ++i;
+    }
+
+    scene.Each<TransformComponent, ModelComponent>([&](Entity& entity) {
+        DrawModel(entity);
     });
 
-    scene.Each<TransformComponent>([&](Entity& entity) {
-        Draw(entity);
-    });
     d_shader.Unbind();
 }
 
@@ -89,45 +96,18 @@ void EntityRenderer::Draw(const Entity& camera, const Lights& lights, Scene& sce
     Draw(proj, view, lights, scene);
 }
 
-void EntityRenderer::Draw(const Entity& entity)
-{    
-    RenderContext rc; 
-
-    if (entity.Has<ModelComponent>()) {
-        DrawModel(entity);
-    }
-}
-
 void EntityRenderer::DrawModel(const Entity& entity)
 {
-    glEnable(GL_CULL_FACE);
-    glCullFace(GL_BACK);
-    glEnable(GL_DEPTH_TEST);
+    const auto tr = entity.Get<TransformComponent>();
+    const auto& modelComp = entity.Get<ModelComponent>();
+    if (modelComp.model.empty()) { return; }
 
-    auto& modelComp = entity.Get<ModelComponent>();
-
-    if (modelComp.model.empty()) {
-        return;
-    }
-
-    auto tr = entity.Get<TransformComponent>();
     Maths::mat4 transform = Maths::Transform(tr.position, tr.orientation, tr.scale);
 
     d_shader.Bind();
     d_shader.LoadUniform("u_model_matrix", transform);
 	d_shader.LoadUniform("u_shine_dampner", modelComp.shineDamper);
 	d_shader.LoadUniform("u_reflectivity", modelComp.reflectivity);
-
-    float brightness = 1.0f;
-    if (entity.Has<SelectComponent>()) {
-        auto data = entity.Get<SelectComponent>();
-        if (data.selected) {
-            brightness = 1.5f;
-        } else if (data.hovered) {
-            brightness = 1.25f;
-        }
-    }
-    d_shader.LoadUniform("u_brightness", brightness);
 
     auto model = d_modelManager->GetModel(modelComp.model);
     auto texture = d_textureManager->GetTexture(modelComp.texture);

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -21,8 +21,6 @@ class EntityRenderer
 
     std::unique_ptr<VertexArray> d_vao;
 
-    void DrawModel    (const Entity& entity);
-
 public:
     EntityRenderer(
         Window* window,

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -42,8 +42,8 @@ public:
 
     bool ShowColliders() const { return d_renderColliders; }
 
-    void BeginScene(const Entity& camera, const Lights& lights, Scene& scene);
-    void BeginScene(const Maths::mat4& proj, const Maths::mat4& view, const Lights& lights, Scene& scene);
+    void Draw(const Entity& camera, const Lights& lights, Scene& scene);
+    void Draw(const Maths::mat4& proj, const Maths::mat4& view, const Lights& lights, Scene& scene);
 
     void EnableShadows(const Texture& shadowMap, const Maths::mat4& lightProjView);
 

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -20,6 +20,8 @@ class EntityRenderer
     Shader  d_shader;
 
     std::unique_ptr<VertexArray> d_vao;
+    
+    std::shared_ptr<InstanceBuffer> d_instanceBuffer;
 
 public:
     EntityRenderer(

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -35,8 +35,6 @@ public:
 
     void EnableShadows(const Texture& shadowMap, const Maths::mat4& lightProjView);
 
-    void Draw(const Entity& entity);
-
     Shader& GetShader() { return d_shader; }
 };
 

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -7,6 +7,7 @@
 #include "ModelManager.h"
 #include "TextureManager.h"
 #include "Components.h"
+#include "VertexArray.h"
 
 namespace Sprocket {
 
@@ -19,6 +20,8 @@ class EntityRenderer
     Shader  d_shader;
 
     bool d_renderColliders;
+
+    std::unique_ptr<VertexArray> d_vao;
 
     void DrawModel    (const Entity& entity);
     void DrawCollider (const Entity& entity);

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
@@ -10,6 +10,7 @@ SkyboxRenderer::SkyboxRenderer(Window* window)
     : d_window(window)
     , d_shader("Resources/Shaders/Skybox.vert",
                "Resources/Shaders/Skybox.frag")
+    , d_vao(std::make_unique<VertexArray>())
 {
 }
 
@@ -28,11 +29,15 @@ void SkyboxRenderer::Draw(const Skybox& skybox,
     d_shader.LoadUniform("projectionMatrix", proj);
     d_shader.LoadUniform("viewMatrix", view2);
 
-    skybox.model->Bind();
+    //skybox.model->Bind();
     skybox.texture.Bind();
-    glDrawElements(GL_TRIANGLES, skybox.model->VertexCount(), GL_UNSIGNED_INT, (const void*)0);
+
+    d_vao->SetModel(skybox.model);
+    d_vao->Draw();
+
+    //glDrawElements(GL_TRIANGLES, skybox.model->VertexCount(), GL_UNSIGNED_INT, (const void*)0);
     skybox.texture.Unbind();
-    skybox.model->Unbind();
+    //skybox.model->Unbind();
 
     d_shader.Unbind();
 }

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
@@ -1,14 +1,10 @@
 #include "SkyboxRenderer.h"
-#include "RenderContext.h"
 #include "CameraUtils.h"
-
-#include <glad/glad.h>
 
 namespace Sprocket {
     
-SkyboxRenderer::SkyboxRenderer(Window* window)
-    : d_window(window)
-    , d_shader("Resources/Shaders/Skybox.vert",
+SkyboxRenderer::SkyboxRenderer()
+    : d_shader("Resources/Shaders/Skybox.vert",
                "Resources/Shaders/Skybox.frag")
     , d_vao(std::make_unique<VertexArray>())
 {
@@ -18,35 +14,20 @@ void SkyboxRenderer::Draw(const Skybox& skybox,
                           const Maths::mat4& proj,
                           const Maths::mat4& view)
 {
-    RenderContext rc;
-    glDisable(GL_CULL_FACE);
-    glDepthMask(true);
-
     d_shader.Bind();
-
-    Maths::mat4 view2 = Maths::mat4(Maths::mat3(view));
-    
     d_shader.LoadUniform("projectionMatrix", proj);
-    d_shader.LoadUniform("viewMatrix", view2);
+    d_shader.LoadUniform("viewMatrix", view);
 
-    //skybox.model->Bind();
     skybox.texture.Bind();
-
     d_vao->SetModel(skybox.model);
     d_vao->Draw();
-
-    //glDrawElements(GL_TRIANGLES, skybox.model->VertexCount(), GL_UNSIGNED_INT, (const void*)0);
-    skybox.texture.Unbind();
-    //skybox.model->Unbind();
-
-    d_shader.Unbind();
 }
 
-void SkyboxRenderer::Draw(const Skybox& skybox,
-                          const Entity& camera)
+void SkyboxRenderer::Draw(const Skybox& skybox, const Entity& camera)
 {
     Maths::mat4 view = CameraUtils::MakeView(camera);
     Maths::mat4 proj = CameraUtils::MakeProj(camera);
+    Maths::mat4 view2 = Maths::mat4(Maths::mat3(view));
     Draw(skybox, proj, view);
 }
 

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
@@ -28,11 +28,11 @@ void SkyboxRenderer::Draw(const Skybox& skybox,
     d_shader.LoadUniform("projectionMatrix", proj);
     d_shader.LoadUniform("viewMatrix", view2);
 
-    skybox.model.Bind();
+    skybox.model->Bind();
     skybox.texture.Bind();
-    glDrawElements(GL_TRIANGLES, skybox.model.VertexCount(), GL_UNSIGNED_INT, (const void*)0);
+    glDrawElements(GL_TRIANGLES, skybox.model->VertexCount(), GL_UNSIGNED_INT, (const void*)0);
     skybox.texture.Unbind();
-    skybox.model.Unbind();
+    skybox.model->Unbind();
 
     d_shader.Unbind();
 }

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.h
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.h
@@ -3,7 +3,9 @@
 #include "Skybox.h"
 #include "Entity.h"
 #include "Shader.h"
+#include "VertexArray.h"
 
+#include <memory>
 
 namespace Sprocket {
 
@@ -14,6 +16,8 @@ class SkyboxRenderer
 
     Shader d_shader;
         // Shader used to draw entities.
+
+    std::unique_ptr<VertexArray> d_vao;
 
 public:
     SkyboxRenderer(Window* window);

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.h
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Window.h"
 #include "Skybox.h"
 #include "Entity.h"
 #include "Shader.h"
@@ -11,16 +10,13 @@ namespace Sprocket {
 
 class SkyboxRenderer
 {
-    Window* d_window;
-        // Non-owning pointer to the window to draw in.
-
     Shader d_shader;
         // Shader used to draw entities.
 
     std::unique_ptr<VertexArray> d_vao;
 
 public:
-    SkyboxRenderer(Window* window);
+    SkyboxRenderer();
 
     void Draw(const Skybox& skybox, const Entity& camera);
     void Draw(const Skybox& skybox, const Maths::mat4& proj, const Maths::mat4& view);

--- a/Sprocket/Graphics/Shader.cpp
+++ b/Sprocket/Graphics/Shader.cpp
@@ -122,6 +122,11 @@ void Shader::LoadUniform(const std::string& name, const Maths::vec4& vector) con
 	glUniform4f(GetUniformLocation(name), vector.x, vector.y, vector.z, vector.w);
 }
 
+void Shader::LoadUniform(const std::string& name, const Maths::quat& quat) const
+{
+	glUniform4f(GetUniformLocation(name), quat.x, quat.y, quat.z, quat.w);
+}
+
 void Shader::LoadUniform(const std::string& name, const Maths::mat4& matrix) const
 {
 	glUniformMatrix4fv(GetUniformLocation(name), 1, GL_FALSE, &matrix[0][0]);

--- a/Sprocket/Graphics/Shader.h
+++ b/Sprocket/Graphics/Shader.h
@@ -48,6 +48,7 @@ public:
     void LoadUniform(const std::string& name, const Maths::vec2& vector) const;
     void LoadUniform(const std::string& name, const Maths::vec3& vector) const;
     void LoadUniform(const std::string& name, const Maths::vec4& vector) const;
+    void LoadUniform(const std::string& name, const Maths::quat& quat) const;
     void LoadUniform(const std::string& name, const Maths::mat4& matrix) const;
 };
 

--- a/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
+++ b/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
@@ -41,11 +41,11 @@ void ShadowMapRenderer::Draw(const Entity& entity)
 
     auto model = d_modelManager->GetModel(modelComponent.model);
 
-    model.Bind();
+    model->Bind();
     glCullFace(GL_FRONT);
-    glDrawElements(GL_TRIANGLES, (int)model.VertexCount(), GL_UNSIGNED_INT, nullptr);
+    glDrawElements(GL_TRIANGLES, (int)model->VertexCount(), GL_UNSIGNED_INT, nullptr);
     glCullFace(GL_BACK);
-    model.Unbind();
+    model->Unbind();
 }
 
 void ShadowMapRenderer::EndScene()

--- a/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
+++ b/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
@@ -12,6 +12,7 @@ ShadowMapRenderer::ShadowMapRenderer(Window* window, ModelManager* modelManager)
     , d_lightViewMatrix() // Will be populated after starting a scene.
     , d_lightProjMatrix(Maths::Ortho(-25.0f, 25.0f, -25.0f, 25.0f, -20.0f, 20.0f))
     , d_shadowMap(window, 4096, 4096)
+    , d_vao(std::make_unique<VertexArray>())
 {
 }
 
@@ -41,11 +42,15 @@ void ShadowMapRenderer::Draw(const Entity& entity)
 
     auto model = d_modelManager->GetModel(modelComponent.model);
 
-    model->Bind();
+    //model->Bind();
     glCullFace(GL_FRONT);
-    glDrawElements(GL_TRIANGLES, (int)model->VertexCount(), GL_UNSIGNED_INT, nullptr);
+
+    d_vao->SetModel(model);
+    d_vao->Draw();
+
+    //glDrawElements(GL_TRIANGLES, (int)model->VertexCount(), GL_UNSIGNED_INT, nullptr);
     glCullFace(GL_BACK);
-    model->Unbind();
+    //model->Unbind();
 }
 
 void ShadowMapRenderer::EndScene()

--- a/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
+++ b/Sprocket/Graphics/Shadows/ShadowMapRenderer.cpp
@@ -11,7 +11,7 @@ ShadowMapRenderer::ShadowMapRenderer(Window* window, ModelManager* modelManager)
     , d_shader("Resources/Shaders/ShadowMap.vert", "Resources/Shaders/ShadowMap.frag")
     , d_lightViewMatrix() // Will be populated after starting a scene.
     , d_lightProjMatrix(Maths::Ortho(-25.0f, 25.0f, -25.0f, 25.0f, -20.0f, 20.0f))
-    , d_shadowMap(window, 4096, 4096)
+    , d_shadowMap(window, 8192, 8192)
     , d_vao(std::make_unique<VertexArray>())
     , d_instanceBuffer(std::make_shared<InstanceBuffer>())
 {

--- a/Sprocket/Graphics/Shadows/ShadowMapRenderer.h
+++ b/Sprocket/Graphics/Shadows/ShadowMapRenderer.h
@@ -27,20 +27,12 @@ class ShadowMapRenderer
     DepthBuffer d_shadowMap;
 
     std::unique_ptr<VertexArray> d_vao;
+    std::shared_ptr<InstanceBuffer> d_instanceBuffer;
 
 public:
     ShadowMapRenderer(Window* window, ModelManager* modelManager);
 
-    void BeginScene(const Sun& sun, const Maths::vec3& centre);
-        // Called before any draw calls. The light is the light
-        // casting the shadow and the centre is the middle of the
-        // shadow box.
-
-    void Draw(const Entity& entity);
-        // Draw the entity.
-
-    void EndScene();
-        // Called after all draw calls.
+    void Draw(const Sun& sun, const Maths::vec3& centre, Scene& scene);
 
     Maths::mat4 GetLightProjViewMatrix() const;
     Texture     GetShadowMap() const;

--- a/Sprocket/Graphics/Shadows/ShadowMapRenderer.h
+++ b/Sprocket/Graphics/Shadows/ShadowMapRenderer.h
@@ -7,6 +7,7 @@
 #include "ModelManager.h"
 #include "TextureManager.h"
 #include "Scene.h"
+#include "VertexArray.h"
 
 #include <memory>
 
@@ -24,6 +25,8 @@ class ShadowMapRenderer
     Maths::mat4 d_lightProjMatrix;
 
     DepthBuffer d_shadowMap;
+
+    std::unique_ptr<VertexArray> d_vao;
 
 public:
     ShadowMapRenderer(Window* window, ModelManager* modelManager);

--- a/Sprocket/Graphics/VertexArray.cpp
+++ b/Sprocket/Graphics/VertexArray.cpp
@@ -44,7 +44,7 @@ void VertexArray::SetInstances(std::shared_ptr<InstanceBuffer> instanceData)
 
     glEnableVertexAttribArray(4);
     glVertexAttribDivisor(4, 1);
-    glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
                           (void*)offsetof(InstanceData, orientation));
 
     glEnableVertexAttribArray(5);

--- a/Sprocket/Graphics/VertexArray.cpp
+++ b/Sprocket/Graphics/VertexArray.cpp
@@ -1,0 +1,42 @@
+#include "VertexArray.h"
+
+#include <glad/glad.h>
+
+namespace Sprocket {
+
+VertexArray::VertexArray()
+    : d_vao(std::make_shared<VAO>())
+{
+}
+
+void VertexArray::SetModel(std::shared_ptr<Model3D> model)
+{
+    d_model = model;
+
+    glBindVertexArray(d_vao->Value());
+    
+    model->Bind();
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, position));
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, normal));
+
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex3D),
+                          (void*)offsetof(Vertex3D, textureCoords));
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glBindVertexArray(0);
+}
+
+void VertexArray::Draw() const
+{
+    glBindVertexArray(d_vao->Value());
+    glDrawElements(GL_TRIANGLES, (int)d_model->VertexCount(), GL_UNSIGNED_INT, nullptr);
+}
+
+}

--- a/Sprocket/Graphics/VertexArray.cpp
+++ b/Sprocket/Graphics/VertexArray.cpp
@@ -12,9 +12,7 @@ VertexArray::VertexArray()
 void VertexArray::SetModel(std::shared_ptr<Model3D> model)
 {
     d_model = model;
-
     glBindVertexArray(d_vao->Value());
-    
     model->Bind();
 
     glEnableVertexAttribArray(0);
@@ -33,10 +31,54 @@ void VertexArray::SetModel(std::shared_ptr<Model3D> model)
     glBindVertexArray(0);
 }
 
+void VertexArray::SetInstances(std::shared_ptr<InstanceBuffer> instanceData)
+{
+    d_instances = instanceData;
+    glBindVertexArray(d_vao->Value());
+    instanceData->Bind();
+
+    glEnableVertexAttribArray(3);
+    glVertexAttribDivisor(3, 1);
+    glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+                          (void*)offsetof(InstanceData, position));
+
+    glEnableVertexAttribArray(4);
+    glVertexAttribDivisor(4, 1);
+    glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+                          (void*)offsetof(InstanceData, orientation));
+
+    glEnableVertexAttribArray(5);
+    glVertexAttribDivisor(5, 1);
+    glVertexAttribPointer(5, 3, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+                          (void*)offsetof(InstanceData, scale));
+
+    glEnableVertexAttribArray(6);
+    glVertexAttribDivisor(6, 1);
+    glVertexAttribPointer(6, 1, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+                          (void*)offsetof(InstanceData, shineDamper));
+
+    glEnableVertexAttribArray(7);
+    glVertexAttribDivisor(7, 1);
+    glVertexAttribPointer(7, 1, GL_FLOAT, GL_FALSE, sizeof(InstanceData),
+                          (void*)offsetof(InstanceData, reflectivity));
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glBindVertexArray(0);
+}
+
 void VertexArray::Draw() const
 {
+    if (!d_model) { return; }
+
     glBindVertexArray(d_vao->Value());
-    glDrawElements(GL_TRIANGLES, (int)d_model->VertexCount(), GL_UNSIGNED_INT, nullptr);
+
+    if (d_instances) {
+        glDrawElementsInstanced(GL_TRIANGLES, (int)d_model->VertexCount(), GL_UNSIGNED_INT, nullptr, d_instances->Size());
+    }
+    else {
+        glDrawElements(GL_TRIANGLES, (int)d_model->VertexCount(), GL_UNSIGNED_INT, nullptr);
+    }
+
 }
 
 }

--- a/Sprocket/Graphics/VertexArray.h
+++ b/Sprocket/Graphics/VertexArray.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Resources.h"
 #include "Model3D.h"
+#include "InstanceBuffer.h"
 
 #include <memory>
 
@@ -11,11 +12,13 @@ class VertexArray
     std::shared_ptr<VAO> d_vao;
 
     std::shared_ptr<Model3D> d_model;
+    std::shared_ptr<InstanceBuffer> d_instances;
 
 public:
     VertexArray();
 
     void SetModel(std::shared_ptr<Model3D> model);
+    void SetInstances(std::shared_ptr<InstanceBuffer> instanceData);
 
     void Draw() const;
 };

--- a/Sprocket/Graphics/VertexArray.h
+++ b/Sprocket/Graphics/VertexArray.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Resources.h"
+#include "Model3D.h"
+
+#include <memory>
+
+namespace Sprocket {
+
+class VertexArray
+{
+    std::shared_ptr<VAO> d_vao;
+
+    std::shared_ptr<Model3D> d_model;
+
+public:
+    VertexArray();
+
+    void SetModel(std::shared_ptr<Model3D> model);
+
+    void Draw() const;
+};
+
+}

--- a/Sprocket/Objects/Skybox.h
+++ b/Sprocket/Objects/Skybox.h
@@ -2,11 +2,13 @@
 #include "Model3D.h"
 #include "CubeMap.h"
 
+#include <memory>
+
 namespace Sprocket {
 
 struct Skybox
 {
-    Model3D model;
+    std::shared_ptr<Model3D> model;
     CubeMap texture;
 };
 

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -44,7 +44,7 @@ void Scene::OnUpdate(double dt)
 
     if (d_sinceLastSort > 5.0) {
         d_registry.sort<ModelComponent>([](const auto& lhs, const auto& rhs) {
-            return lhs.model < rhs.model;
+            return lhs.model < rhs.model || (lhs.model == rhs.model && lhs.texture < rhs.texture);
         });
         d_sinceLastSort -= 5.0f;
         SPKT_LOG_INFO("Sorted");

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -41,13 +41,11 @@ void Scene::OnStartup()
 void Scene::OnUpdate(double dt)
 {
     d_sinceLastSort += dt;
-
     if (d_sinceLastSort > 5.0) {
         d_registry.sort<ModelComponent>([](const auto& lhs, const auto& rhs) {
             return lhs.model < rhs.model || (lhs.model == rhs.model && lhs.texture < rhs.texture);
         });
         d_sinceLastSort -= 5.0f;
-        SPKT_LOG_INFO("Sorted");
     }
 
     for (auto system : d_systems) {

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -40,6 +40,16 @@ void Scene::OnStartup()
 
 void Scene::OnUpdate(double dt)
 {
+    d_sinceLastSort += dt;
+
+    if (d_sinceLastSort > 5.0) {
+        d_registry.sort<ModelComponent>([](const auto& lhs, const auto& rhs) {
+            return lhs.model < rhs.model;
+        });
+        d_sinceLastSort -= 5.0f;
+        SPKT_LOG_INFO("Sorted");
+    }
+
     for (auto system : d_systems) {
         system->OnUpdate(*this, dt);
     }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -42,6 +42,8 @@ private:
 
     Sun d_sun;
 
+    double d_sinceLastSort = 0.0f;
+
     template <typename T> void OnAddCB(entt::registry& r, entt::entity e);
     template <typename T> void OnUpdateCB(entt::registry& r, entt::entity e);
     template <typename T> void OnRemoveCB(entt::registry& r, entt::entity e);

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -79,6 +79,7 @@
 
 #include "Graphics/Shadows/ShadowMapRenderer.h"
 
+#include "Graphics/Rendering/ColliderRenderer.h"
 #include "Graphics/Rendering/EntityRenderer.h"
 #include "Graphics/Rendering/SkyboxRenderer.h"
 

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -70,6 +70,7 @@
 #include "Graphics/CubeMap.h"
 #include "Graphics/FrameBuffer.h"
 #include "Graphics/StreamBuffer.h"
+#include "Graphics/VertexArray.h"
 
 #include "Graphics/PostProcessing/PostProcessor.h"
 #include "Graphics/PostProcessing/Effect.h"

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -69,6 +69,7 @@
 #include "Graphics/Texture.h"
 #include "Graphics/CubeMap.h"
 #include "Graphics/FrameBuffer.h"
+#include "Graphics/InstanceBuffer.h"
 #include "Graphics/StreamBuffer.h"
 #include "Graphics/VertexArray.h"
 

--- a/Workshop/EditorUI.cpp
+++ b/Workshop/EditorUI.cpp
@@ -186,13 +186,13 @@ void EditorUI::OnUpdate(double dt)
     d_ui.SameLine();
     d_ui.Text(d_worldLayer->d_physicsEngine->Running() ? "YES" : "NO");
 
-    if (d_ui.Button("Show Colliders")) {
-        auto entityRenderer = &d_worldLayer->d_entityRenderer;
-        bool wireframe = entityRenderer->ShowColliders();
-        entityRenderer->RenderColliders(!wireframe);
-    }
-    d_ui.SameLine();
-    d_ui.Text(d_worldLayer->d_entityRenderer.ShowColliders() ? "YES" : "NO");
+    //if (d_ui.Button("Show Colliders")) {
+    //    auto entityRenderer = &d_worldLayer->d_entityRenderer;
+    //    bool wireframe = entityRenderer->ShowColliders();
+    //    entityRenderer->RenderColliders(!wireframe);
+    //}
+    //d_ui.SameLine();
+    //d_ui.Text(d_worldLayer->d_entityRenderer.ShowColliders() ? "YES" : "NO");
 
     std::stringstream ss;
     ss << "Entities: " << d_worldLayer->d_scene->Size();

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -4,7 +4,7 @@ WorldLayer::WorldLayer(const Sprocket::CoreSystems& core)
     : Sprocket::Layer(core)
     , d_mode(Mode::OBSERVER)
     , d_entityRenderer(core.window, core.modelManager, core.textureManager)
-    , d_skyboxRenderer(core.window)
+    , d_skyboxRenderer()
     , d_postProcessor(core.window->Width(), core.window->Height())
     , d_skybox({
         Sprocket::ModelManager::LoadModel("Resources/Models/Skybox.obj"),

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -106,10 +106,6 @@ void WorldLayer::OnUpdate(double dt)
 
     d_entityRenderer.Draw(d_activeCamera, d_lights, *d_scene);
     d_skyboxRenderer.Draw(d_skybox, d_activeCamera);
-
-    d_scene->Each<TransformComponent, ModelComponent>([&](Entity& entity) {
-        d_entityRenderer.Draw(entity);
-    });
     
     if (d_paused) {
         d_postProcessor.Unbind();

--- a/Workshop/WorldLayer.cpp
+++ b/Workshop/WorldLayer.cpp
@@ -80,7 +80,6 @@ void WorldLayer::OnUpdate(double dt)
 {
     using namespace Sprocket;
     
-    d_entityRenderer.BeginScene(d_activeCamera, d_lights, *d_scene);
 
     if (!d_paused) {
         d_scene->OnUpdate(dt);
@@ -105,6 +104,7 @@ void WorldLayer::OnUpdate(double dt)
         d_postProcessor.Bind();
     }
 
+    d_entityRenderer.Draw(d_activeCamera, d_lights, *d_scene);
     d_skyboxRenderer.Draw(d_skybox, d_activeCamera);
 
     d_scene->Each<TransformComponent, ModelComponent>([&](Entity& entity) {


### PR DESCRIPTION
## Instanced Rendering
`EntityRenderer` and `ShadowMapRenderer` now utilise instanced rendering. With this, there is now only one draw call per Model3D/Texture pair. This is achieved by adding each entity to a buffer, and only rendering when the model or texture changes. To ensure that we minimise draw calls, the renderable entities are periodically sorted.

This is a fairly large overhaul of all rendering systems. Most of them have been massively simplified without removing features.

### Details
- Renderers no longer have a `BeginScene` and `Draw` function that accepts a single entity. Now the `BeginScene` has been renamed to `Draw` and takes a scene object. This performs the loops over entities and can be more optimised.
- Split collider rendering out into a separate `ColliderRenderer`. Both `ColliderRenderer` and `EntityRenderer` are now far simpler as a result.
- Added a `VertexArray` class. Models no longer store VAOs; instead each renderer owns a VertexArray and loads a model into it before drawing. This is so that we can load instancing data into the VertexArray which is separate from the Model data.
- Added `InstanceBuffer` which is the structure that contains the VBO of instance data.
- Transform matrices are now calculated on the GPU rather than the CPU. To do this, the position, orientation and scale values are passed in the instance buffer rather than the matrix being a uniform.
- Deprecated `Model2D` since only the post processing pipeline uses it. This will be removed after refactoring this system.
- Removed the CPU storage for `Model3D` as it is not used. This was going to be used for another attempt at batch rendering, however this previous attempt failed and I didn't clean this up.