### PR TITLE
DevUI Cleanup

### DIFF
--- a/Anvil/EditorLayer.h
+++ b/Anvil/EditorLayer.h
@@ -21,7 +21,7 @@ class EditorLayer : public Layer
     ParticleManager d_particleManager;
 
     FrameBuffer d_viewport;
-    DevUI::Context d_ui;
+    DevUI::DevUI d_ui;
     bool d_isViewportHovered = false;
     bool d_isViewportFocused = false;
 

--- a/Anvil/EditorLayer.h
+++ b/Anvil/EditorLayer.h
@@ -21,7 +21,7 @@ class EditorLayer : public Layer
     ParticleManager d_particleManager;
 
     FrameBuffer d_viewport;
-    DevUI::DevUI d_ui;
+    DevUI d_ui;
     bool d_isViewportHovered = false;
     bool d_isViewportFocused = false;
 

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -14,8 +14,8 @@ namespace {
 void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
-    DevUI::GizmoMode mode,
-    DevUI::GizmoCoords coords,
+    GizmoMode mode,
+    GizmoCoords coords,
     Maths::vec3* snap = nullptr)
 {
     if (!editor.IsGameRunning()) {

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -14,7 +14,7 @@ namespace {
 void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
-    GizmoMode mode,
+    ImGuizmo::OPERATION mode,
     GizmoCoords coords,
     Maths::vec3* snap = nullptr)
 {
@@ -24,7 +24,7 @@ void ShowGuizmo(
         ImGuizmo::Manipulate(
             Maths::Cast(camera.View()),
             Maths::Cast(camera.Proj()),
-            GetMode(mode),
+            mode,
             GetCoords(coords),
             Maths::Cast(tr),
             nullptr,

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -15,7 +15,7 @@ void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
     ImGuizmo::OPERATION mode,
-    GizmoCoords coords,
+    ImGuizmo::MODE coords,
     Maths::vec3* snap = nullptr)
 {
     if (!editor.IsGameRunning()) {
@@ -25,7 +25,7 @@ void ShowGuizmo(
             Maths::Cast(camera.View()),
             Maths::Cast(camera.Proj()),
             mode,
-            GetCoords(coords),
+            coords,
             Maths::Cast(tr),
             nullptr,
             &snap->x

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -13,9 +13,9 @@ namespace {
 void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
-    DevUI::GizmoMode mode,
-    DevUI::GizmoCoords coords,
-    float* snap = nullptr)
+    GizmoMode mode,
+    GizmoCoords coords,
+    Maths::vec3* snap = nullptr)
 {
     if (!editor.IsGameRunning()) {
         auto& camera = editor.GetEditorCamera();
@@ -27,7 +27,7 @@ void ShowGuizmo(
             GetCoords(coords),
             Maths::Cast(tr),
             nullptr,
-            snap
+            &snap->x
         );
         Maths::Decompose(tr, &c.position, &c.orientation, &c.scale);
     }

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -14,7 +14,7 @@ void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
     ImGuizmo::OPERATION mode,
-    GizmoCoords coords,
+    ImGuizmo::MODE coords,
     Maths::vec3* snap = nullptr)
 {
     if (!editor.IsGameRunning()) {
@@ -24,7 +24,7 @@ void ShowGuizmo(
             Maths::Cast(camera.View()),
             Maths::Cast(camera.Proj()),
             mode,
-            GetCoords(coords),
+            coords,
             Maths::Cast(tr),
             nullptr,
             &snap->x

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -13,7 +13,7 @@ namespace {
 void ShowGuizmo(
     EditorLayer& editor,
     TransformComponent& c,
-    GizmoMode mode,
+    ImGuizmo::OPERATION mode,
     GizmoCoords coords,
     Maths::vec3* snap = nullptr)
 {
@@ -23,7 +23,7 @@ void ShowGuizmo(
         ImGuizmo::Manipulate(
             Maths::Cast(camera.View()),
             Maths::Cast(camera.Proj()),
-            GetMode(mode),
+            mode,
             GetCoords(coords),
             Maths::Cast(tr),
             nullptr,

--- a/Anvil/Panels/Inspector.h
+++ b/Anvil/Panels/Inspector.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "DevUI.h"
 
+#include <ImGuizmo.h>
+
 namespace Sprocket {
 
 class EditorLayer;

--- a/Anvil/Panels/Inspector.h
+++ b/Anvil/Panels/Inspector.h
@@ -7,8 +7,8 @@ class EditorLayer;
 
 class Inspector
 {
-    DevUI::GizmoCoords d_coords = DevUI::GizmoCoords::WORLD;
-    DevUI::GizmoMode d_mode = DevUI::GizmoMode::TRANSLATION;
+    GizmoCoords d_coords = GizmoCoords::WORLD;
+    GizmoMode d_mode = GizmoMode::TRANSLATION;
     
     bool        d_useSnap = false;
     Maths::vec3 d_snap = {0.0f, 0.0f, 0.0f};

--- a/Anvil/Panels/Inspector.h
+++ b/Anvil/Panels/Inspector.h
@@ -8,7 +8,7 @@ class EditorLayer;
 class Inspector
 {
     GizmoCoords d_coords = GizmoCoords::WORLD;
-    GizmoMode d_mode = GizmoMode::TRANSLATION;
+    ImGuizmo::OPERATION d_mode = ImGuizmo::OPERATION::TRANSLATE;
     
     bool        d_useSnap = false;
     Maths::vec3 d_snap = {0.0f, 0.0f, 0.0f};

--- a/Anvil/Panels/Inspector.h
+++ b/Anvil/Panels/Inspector.h
@@ -7,7 +7,7 @@ class EditorLayer;
 
 class Inspector
 {
-    GizmoCoords d_coords = GizmoCoords::WORLD;
+    ImGuizmo::MODE d_coords = ImGuizmo::MODE::WORLD;
     ImGuizmo::OPERATION d_mode = ImGuizmo::OPERATION::TRANSLATE;
     
     bool        d_useSnap = false;

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -20,7 +20,7 @@ void AddEntityToList(DevUI& ui, BasicSelector& selector, Entity& entity)
 {
     ui.PushID(entity.Id());
     if (ui.StartTreeNode(EntityName(entity))) {
-        if (entity.Has<SelectComponent>() && ui.Button("Select")) {
+        if (entity.Has<SelectComponent>() && ImGui::Button("Select")) {
             SPKT_LOG_INFO("Select clicked!");
             selector.SetSelected(entity);
         }
@@ -56,19 +56,19 @@ void SelectedEntityInfo(DevUI& ui,
            << "Roll: " << Maths::ToString(eulerAngles.z, 3);
         ImGui::Text(ss.str().c_str());    
 
-        if (ui.RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
+        if (ImGui::RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
             mode = GizmoMode::TRANSLATION;
         }
         ImGui::SameLine();
-        if (ui.RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
+        if (ImGui::RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
             mode = GizmoMode::ROTATION;
         }
 
-        if (ui.RadioButton("World", coords == GizmoCoords::WORLD)) {
+        if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {
             coords = GizmoCoords::WORLD;
         }
         ImGui::SameLine();
-        if (ui.RadioButton("Local", coords == GizmoCoords::LOCAL)) {
+        if (ImGui::RadioButton("Local", coords == GizmoCoords::LOCAL)) {
             coords = GizmoCoords::LOCAL;
         }
         ui.EndTreeNode();
@@ -83,7 +83,7 @@ void SelectedEntityInfo(DevUI& ui,
     }
     ImGui::Separator();
 
-    if (ui.Button("Delete Entity")) {
+    if (ImGui::Button("Delete Entity")) {
         entity.Kill();
     }
 
@@ -96,14 +96,14 @@ void SunInfoPanel(DevUI& ui,
 {
     ui.StartWindow("Sun");
 
-    if (ui.Button("Start")) { cycle.Start(); }
+    if (ImGui::Button("Start")) { cycle.Start(); }
     ImGui::SameLine();
-    if (ui.Button("Stop")) { cycle.Stop(); }
+    if (ImGui::Button("Stop")) { cycle.Stop(); }
     ImGui::Separator();
 
     if (cycle.IsRunning()) { // If running, be able to change the speed.
         float speed = cycle.GetSpeed();
-        ui.SliderFloat("Speed", &speed, 1.0f, 1000.0f);
+        ImGui::SliderFloat("Speed", &speed, 1.0f, 1000.0f, "%.3f");
         cycle.SetSpeed(speed);
     }
     else { // If not running, be able to set manually
@@ -122,7 +122,7 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
     static std::string compileStatus;
 
     ui.StartWindow("Shader");
-    if(ui.Button("Recompile")) {
+    if(ImGui::Button("Recompile")) {
         bool result = shader.Reload();
         compileStatus ="Shader compile:";
         compileStatus += (result? " SUCCESS": " FAILURE");
@@ -131,11 +131,11 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
     ImGui::Text(compileStatus.c_str());
     
     bool closed = true;
-    if(ui.CollapsingHeader("Vertex")){
+    if (ImGui::CollapsingHeader("Vertex")) {
         closed = false;
         ui.MultilineTextModifiable("", shader.VertexShaderSource());
     }
-    if(ui.CollapsingHeader("Frag")) {
+    if (ImGui::CollapsingHeader("Frag")) {
         closed = false;
         ui.MultilineTextModifiable("", shader.FragShaderSource());
     }
@@ -193,7 +193,7 @@ void EditorUI::OnUpdate(double dt)
     ss << "Entities: " << d_worldLayer->d_scene->Size();
     ImGui::Text(ss.str().c_str());
 
-    if (d_ui.CollapsingHeader("Entity List")) {
+    if (ImGui::CollapsingHeader("Entity List")) {
         d_worldLayer->d_scene->Each<SelectComponent>([&](Entity& entity) {
             AddEntityToList(d_ui, *d_worldLayer->d_selector, entity);      
         });
@@ -216,7 +216,9 @@ void EditorUI::OnUpdate(double dt)
 
     auto shadowMap = d_worldLayer->d_shadowMap.GetShadowMap();
     ImTextureID id = (void*)(intptr_t)shadowMap.Id();
-    ImGui::Image(id, ImVec2(shadowMap.Width(), shadowMap.Height()), ImVec2(0.0, 1.0), ImVec2(1.0, 0.0), ImVec4(1.0, 1.0, 1.0, 1.0), ImVec4(1.0, 1.0, 1.0, 0.5));
+    float aspect = shadowMap.Width() / shadowMap.Height();
+    float size = 500.0f;
+    ImGui::Image(id, ImVec2(aspect * size, size), ImVec2(0.0, 1.0), ImVec2(1.0, 0.0), ImVec4(1.0, 1.0, 1.0, 1.0), ImVec4(1.0, 1.0, 1.0, 0.5));
 
     d_ui.EndWindow();
 

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -37,10 +37,10 @@ void SelectedEntityInfo(DevUI& ui,
     using namespace Maths;
 
     ui.StartWindow("Selected Entity");
-    ui.Text("Name: ");
+    ImGui::Text("Name: ");
     ImGui::SameLine();
-    ui.Text(EntityName(entity));
-    ui.Text("ID: " + std::to_string(entity.Id()));
+    ImGuiXtra::Text(EntityName(entity));
+    ImGuiXtra::Text("ID: " + std::to_string(entity.Id()));
     ImGui::Separator();
     
     static GizmoMode mode = GizmoMode::TRANSLATION;
@@ -54,7 +54,7 @@ void SelectedEntityInfo(DevUI& ui,
         ss << "Pitch: " << Maths::ToString(eulerAngles.x, 3) << "\n"
            << "Yaw: " << Maths::ToString(eulerAngles.y, 3) << "\n"
            << "Roll: " << Maths::ToString(eulerAngles.z, 3);
-        ui.Text(ss.str());    
+        ImGui::Text(ss.str().c_str());    
 
         if (ui.RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
             mode = GizmoMode::TRANSLATION;
@@ -113,7 +113,7 @@ void SunInfoPanel(DevUI& ui,
     }
     
     ImGui::Separator();
-    ui.Text(cycle.ToString12Hour());
+    ImGuiXtra::Text(cycle.ToString12Hour());
     ui.EndWindow();
 }
 
@@ -128,7 +128,7 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
         compileStatus += (result? " SUCCESS": " FAILURE");
     }
 
-    ui.Text(compileStatus.c_str());
+    ImGui::Text(compileStatus.c_str());
     
     bool closed = true;
     if(ui.CollapsingHeader("Vertex")){
@@ -191,7 +191,7 @@ void EditorUI::OnUpdate(double dt)
     d_ui.StartWindow("Sprocket Editor", &open, flags);
     std::stringstream ss;
     ss << "Entities: " << d_worldLayer->d_scene->Size();
-    d_ui.Text(ss.str());
+    ImGui::Text(ss.str().c_str());
 
     if (d_ui.CollapsingHeader("Entity List")) {
         d_worldLayer->d_scene->Each<SelectComponent>([&](Entity& entity) {

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -16,7 +16,7 @@ std::string EntityName(Entity& entity)
     return "Unnamed";
 }
 
-void AddEntityToList(DevUI::Context& ui, BasicSelector& selector, Entity& entity)
+void AddEntityToList(DevUI::DevUI& ui, BasicSelector& selector, Entity& entity)
 {
     ui.PushID(entity.Id());
     if (ui.StartTreeNode(EntityName(entity))) {
@@ -29,7 +29,7 @@ void AddEntityToList(DevUI::Context& ui, BasicSelector& selector, Entity& entity
     ui.PopID();         
 }
 
-void SelectedEntityInfo(DevUI::Context& ui,
+void SelectedEntityInfo(DevUI::DevUI& ui,
                         Entity& entity,
                         const Maths::mat4& view,
                         const Maths::mat4& proj)
@@ -90,7 +90,7 @@ void SelectedEntityInfo(DevUI::Context& ui,
     ui.EndWindow();
 }
 
-void SunInfoPanel(DevUI::Context& ui,
+void SunInfoPanel(DevUI::DevUI& ui,
                   Sun& sun,
                   CircadianCycle& cycle)
 {
@@ -117,7 +117,7 @@ void SunInfoPanel(DevUI::Context& ui,
     ui.EndWindow();
 }
 
-void ShaderInfoPanel(DevUI::Context& ui, Shader& shader)
+void ShaderInfoPanel(DevUI::DevUI& ui, Shader& shader)
 {
     static std::string compileStatus;
 

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -185,21 +185,6 @@ void EditorUI::OnUpdate(double dt)
     d_ui.OnUpdate(dt);
     d_ui.StartFrame();
 
-    bool open = true;
-    int flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize;
-
-    ImGui::Begin("Sprocket Editor", &open, flags);
-    std::stringstream ss;
-    ss << "Entities: " << d_worldLayer->d_scene->Size();
-    ImGui::Text(ss.str().c_str());
-
-    if (ImGui::CollapsingHeader("Entity List")) {
-        d_worldLayer->d_scene->Each<SelectComponent>([&](Entity& entity) {
-            AddEntityToList(d_ui, *d_worldLayer->d_selector, entity);      
-        });
-    }
-    ImGui::End();
-
     mat4 view = CameraUtils::MakeView(d_worldLayer->d_camera);
     mat4 proj = CameraUtils::MakeProj(d_worldLayer->d_camera);
 
@@ -211,10 +196,11 @@ void EditorUI::OnUpdate(double dt)
     SunInfoPanel(d_ui, d_worldLayer->d_scene->GetSun(), d_worldLayer->d_cycle);
     ShaderInfoPanel(d_ui, d_worldLayer->d_entityRenderer.GetShader());
 
-    ImGui::Begin("Shadow Map", &open);
+    ImGui::Begin("Shadow Map");
     ImGuiXtra::Image(d_worldLayer->d_shadowMap.GetShadowMap(), 500.0f);
     ImGui::End();
 
-    d_ui.DemoWindow();
+    ImGui::ShowDemoWindow();
+    
     d_ui.EndFrame();
 }

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -44,7 +44,7 @@ void SelectedEntityInfo(DevUI& ui,
     ImGui::Separator();
     
     static ImGuizmo::OPERATION mode = ImGuizmo::OPERATION::TRANSLATE;
-    static GizmoCoords coords = GizmoCoords::WORLD;
+    static ImGuizmo::MODE coords = ImGuizmo::MODE::WORLD;
 
     if (entity.Has<TransformComponent>() && ImGui::TreeNode("Transform")) {
         auto& tr = entity.Get<TransformComponent>();
@@ -64,12 +64,12 @@ void SelectedEntityInfo(DevUI& ui,
             mode = ImGuizmo::OPERATION::ROTATE;
         }
 
-        if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {
-            coords = GizmoCoords::WORLD;
+        if (ImGui::RadioButton("World", coords == ImGuizmo::MODE::WORLD)) {
+            coords = ImGuizmo::MODE::WORLD;
         }
         ImGui::SameLine();
-        if (ImGui::RadioButton("Local", coords == GizmoCoords::LOCAL)) {
-            coords = GizmoCoords::LOCAL;
+        if (ImGui::RadioButton("Local", coords == ImGuizmo::MODE::LOCAL)) {
+            coords = ImGuizmo::MODE::LOCAL;
         }
         ImGui::TreePop();
     }

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -36,7 +36,7 @@ void SelectedEntityInfo(DevUI& ui,
 {
     using namespace Maths;
 
-    ui.StartWindow("Selected Entity");
+    ImGui::Begin("Selected Entity");
     ImGui::Text("Name: ");
     ImGui::SameLine();
     ImGuiXtra::Text(EntityName(entity));
@@ -48,7 +48,7 @@ void SelectedEntityInfo(DevUI& ui,
 
     if (entity.Has<TransformComponent>() && ui.StartTreeNode("Transform")) {
         auto& tr = entity.Get<TransformComponent>();
-        ui.DragFloat3("Position", &tr.position, 0.005f);
+        ImGui::DragFloat3("Position", &tr.position.x, 0.005f);
         Maths::vec3 eulerAngles = Maths::ToEuler(tr.orientation);
         std::stringstream ss;
         ss << "Pitch: " << Maths::ToString(eulerAngles.x, 3) << "\n"
@@ -87,14 +87,14 @@ void SelectedEntityInfo(DevUI& ui,
         entity.Kill();
     }
 
-    ui.EndWindow();
+    ImGui::End();
 }
 
 void SunInfoPanel(DevUI& ui,
                   Sun& sun,
                   CircadianCycle& cycle)
 {
-    ui.StartWindow("Sun");
+    ImGui::Begin("Sun");
 
     if (ImGui::Button("Start")) { cycle.Start(); }
     ImGui::SameLine();
@@ -108,20 +108,20 @@ void SunInfoPanel(DevUI& ui,
     }
     else { // If not running, be able to set manually
         float angle = cycle.GetAngle();
-        ui.DragFloat("Angle", &angle);
+        ImGui::DragFloat("Angle", &angle);
         cycle.SetAngle(angle);
     }
     
     ImGui::Separator();
     ImGuiXtra::Text(cycle.ToString12Hour());
-    ui.EndWindow();
+    ImGui::End();
 }
 
 void ShaderInfoPanel(DevUI& ui, Shader& shader)
 {
     static std::string compileStatus;
 
-    ui.StartWindow("Shader");
+    ImGui::Begin("Shader");
     if(ImGui::Button("Recompile")) {
         bool result = shader.Reload();
         compileStatus ="Shader compile:";
@@ -144,7 +144,7 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
         compileStatus.clear();
     }
 
-    ui.EndWindow();
+    ImGui::End();
 }
 
 }
@@ -188,7 +188,7 @@ void EditorUI::OnUpdate(double dt)
     bool open = true;
     int flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize;
 
-    d_ui.StartWindow("Sprocket Editor", &open, flags);
+    ImGui::Begin("Sprocket Editor", &open, flags);
     std::stringstream ss;
     ss << "Entities: " << d_worldLayer->d_scene->Size();
     ImGui::Text(ss.str().c_str());
@@ -198,8 +198,7 @@ void EditorUI::OnUpdate(double dt)
             AddEntityToList(d_ui, *d_worldLayer->d_selector, entity);      
         });
     }
-
-    d_ui.EndWindow();
+    ImGui::End();
 
     mat4 view = CameraUtils::MakeView(d_worldLayer->d_camera);
     mat4 proj = CameraUtils::MakeProj(d_worldLayer->d_camera);
@@ -212,15 +211,13 @@ void EditorUI::OnUpdate(double dt)
     SunInfoPanel(d_ui, d_worldLayer->d_scene->GetSun(), d_worldLayer->d_cycle);
     ShaderInfoPanel(d_ui, d_worldLayer->d_entityRenderer.GetShader());
 
-    d_ui.StartWindow("Shadow Map", &open);
-
+    ImGui::Begin("Shadow Map", &open);
     auto shadowMap = d_worldLayer->d_shadowMap.GetShadowMap();
     ImTextureID id = (void*)(intptr_t)shadowMap.Id();
     float aspect = shadowMap.Width() / shadowMap.Height();
     float size = 500.0f;
     ImGui::Image(id, ImVec2(aspect * size, size), ImVec2(0.0, 1.0), ImVec2(1.0, 0.0), ImVec4(1.0, 1.0, 1.0, 1.0), ImVec4(1.0, 1.0, 1.0, 0.5));
-
-    d_ui.EndWindow();
+    ImGui::End();
 
     d_ui.DemoWindow();
     d_ui.EndFrame();

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -212,11 +212,7 @@ void EditorUI::OnUpdate(double dt)
     ShaderInfoPanel(d_ui, d_worldLayer->d_entityRenderer.GetShader());
 
     ImGui::Begin("Shadow Map", &open);
-    auto shadowMap = d_worldLayer->d_shadowMap.GetShadowMap();
-    ImTextureID id = (void*)(intptr_t)shadowMap.Id();
-    float aspect = shadowMap.Width() / shadowMap.Height();
-    float size = 500.0f;
-    ImGui::Image(id, ImVec2(aspect * size, size), ImVec2(0.0, 1.0), ImVec2(1.0, 0.0), ImVec4(1.0, 1.0, 1.0, 1.0), ImVec4(1.0, 1.0, 1.0, 0.5));
+    ImGuiXtra::Image(d_worldLayer->d_shadowMap.GetShadowMap(), 500.0f);
     ImGui::End();
 
     d_ui.DemoWindow();

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -38,10 +38,10 @@ void SelectedEntityInfo(DevUI& ui,
 
     ui.StartWindow("Selected Entity");
     ui.Text("Name: ");
-    ui.SameLine();
+    ImGui::SameLine();
     ui.Text(EntityName(entity));
     ui.Text("ID: " + std::to_string(entity.Id()));
-    ui.Separator();
+    ImGui::Separator();
     
     static GizmoMode mode = GizmoMode::TRANSLATION;
     static GizmoCoords coords = GizmoCoords::WORLD;
@@ -59,7 +59,7 @@ void SelectedEntityInfo(DevUI& ui,
         if (ui.RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
             mode = GizmoMode::TRANSLATION;
         }
-        ui.SameLine();
+        ImGui::SameLine();
         if (ui.RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
             mode = GizmoMode::ROTATION;
         }
@@ -67,7 +67,7 @@ void SelectedEntityInfo(DevUI& ui,
         if (ui.RadioButton("World", coords == GizmoCoords::WORLD)) {
             coords = GizmoCoords::WORLD;
         }
-        ui.SameLine();
+        ImGui::SameLine();
         if (ui.RadioButton("Local", coords == GizmoCoords::LOCAL)) {
             coords = GizmoCoords::LOCAL;
         }
@@ -81,7 +81,7 @@ void SelectedEntityInfo(DevUI& ui,
         tr.position = GetTranslation(origin);
         tr.orientation = Normalise(ToQuat(mat3(origin)));
     }
-    ui.Separator();
+    ImGui::Separator();
 
     if (ui.Button("Delete Entity")) {
         entity.Kill();
@@ -97,9 +97,9 @@ void SunInfoPanel(DevUI& ui,
     ui.StartWindow("Sun");
 
     if (ui.Button("Start")) { cycle.Start(); }
-    ui.SameLine();
+    ImGui::SameLine();
     if (ui.Button("Stop")) { cycle.Stop(); }
-    ui.Separator();
+    ImGui::Separator();
 
     if (cycle.IsRunning()) { // If running, be able to change the speed.
         float speed = cycle.GetSpeed();
@@ -112,7 +112,7 @@ void SunInfoPanel(DevUI& ui,
         cycle.SetAngle(angle);
     }
     
-    ui.Separator();
+    ImGui::Separator();
     ui.Text(cycle.ToString12Hour());
     ui.EndWindow();
 }

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -77,7 +77,7 @@ void SelectedEntityInfo(DevUI& ui,
     if (entity.Has<TransformComponent>()) {
         auto& tr = entity.Get<TransformComponent>();
         Maths::mat4 origin = Maths::Transform(tr.position, tr.orientation);
-        ui.Gizmo(&origin, view, proj, mode, coords);
+        ImGuiXtra::Guizmo(&origin, view, proj, mode, coords);
         tr.position = GetTranslation(origin);
         tr.orientation = Normalise(ToQuat(mat3(origin)));
     }
@@ -201,6 +201,6 @@ void EditorUI::OnUpdate(double dt)
     ImGui::End();
 
     ImGui::ShowDemoWindow();
-    
+
     d_ui.EndFrame();
 }

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -16,7 +16,7 @@ std::string EntityName(Entity& entity)
     return "Unnamed";
 }
 
-void AddEntityToList(DevUI::DevUI& ui, BasicSelector& selector, Entity& entity)
+void AddEntityToList(DevUI& ui, BasicSelector& selector, Entity& entity)
 {
     ui.PushID(entity.Id());
     if (ui.StartTreeNode(EntityName(entity))) {
@@ -29,7 +29,7 @@ void AddEntityToList(DevUI::DevUI& ui, BasicSelector& selector, Entity& entity)
     ui.PopID();         
 }
 
-void SelectedEntityInfo(DevUI::DevUI& ui,
+void SelectedEntityInfo(DevUI& ui,
                         Entity& entity,
                         const Maths::mat4& view,
                         const Maths::mat4& proj)
@@ -43,8 +43,8 @@ void SelectedEntityInfo(DevUI::DevUI& ui,
     ui.Text("ID: " + std::to_string(entity.Id()));
     ui.Separator();
     
-    static DevUI::GizmoMode mode = DevUI::GizmoMode::TRANSLATION;
-    static DevUI::GizmoCoords coords = DevUI::GizmoCoords::WORLD;
+    static GizmoMode mode = GizmoMode::TRANSLATION;
+    static GizmoCoords coords = GizmoCoords::WORLD;
 
     if (entity.Has<TransformComponent>() && ui.StartTreeNode("Transform")) {
         auto& tr = entity.Get<TransformComponent>();
@@ -56,20 +56,20 @@ void SelectedEntityInfo(DevUI::DevUI& ui,
            << "Roll: " << Maths::ToString(eulerAngles.z, 3);
         ui.Text(ss.str());    
 
-        if (ui.RadioButton("Translate", mode == DevUI::GizmoMode::TRANSLATION)) {
-            mode = DevUI::GizmoMode::TRANSLATION;
+        if (ui.RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
+            mode = GizmoMode::TRANSLATION;
         }
         ui.SameLine();
-        if (ui.RadioButton("Rotate", mode == DevUI::GizmoMode::ROTATION)) {
-            mode = DevUI::GizmoMode::ROTATION;
+        if (ui.RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
+            mode = GizmoMode::ROTATION;
         }
 
-        if (ui.RadioButton("World", coords == DevUI::GizmoCoords::WORLD)) {
-            coords = DevUI::GizmoCoords::WORLD;
+        if (ui.RadioButton("World", coords == GizmoCoords::WORLD)) {
+            coords = GizmoCoords::WORLD;
         }
         ui.SameLine();
-        if (ui.RadioButton("Local", coords == DevUI::GizmoCoords::LOCAL)) {
-            coords = DevUI::GizmoCoords::LOCAL;
+        if (ui.RadioButton("Local", coords == GizmoCoords::LOCAL)) {
+            coords = GizmoCoords::LOCAL;
         }
         ui.EndTreeNode();
     }
@@ -90,7 +90,7 @@ void SelectedEntityInfo(DevUI::DevUI& ui,
     ui.EndWindow();
 }
 
-void SunInfoPanel(DevUI::DevUI& ui,
+void SunInfoPanel(DevUI& ui,
                   Sun& sun,
                   CircadianCycle& cycle)
 {
@@ -117,7 +117,7 @@ void SunInfoPanel(DevUI::DevUI& ui,
     ui.EndWindow();
 }
 
-void ShaderInfoPanel(DevUI::DevUI& ui, Shader& shader)
+void ShaderInfoPanel(DevUI& ui, Shader& shader)
 {
     static std::string compileStatus;
 

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -18,15 +18,15 @@ std::string EntityName(Entity& entity)
 
 void AddEntityToList(DevUI& ui, BasicSelector& selector, Entity& entity)
 {
-    ui.PushID(entity.Id());
-    if (ui.StartTreeNode(EntityName(entity))) {
+    ImGui::PushID(entity.Id());
+    if (ImGui::TreeNode(EntityName(entity).c_str())) {
         if (entity.Has<SelectComponent>() && ImGui::Button("Select")) {
             SPKT_LOG_INFO("Select clicked!");
             selector.SetSelected(entity);
         }
-        ui.EndTreeNode();
+        ImGui::TreePop();
     }
-    ui.PopID();         
+    ImGui::PopID();         
 }
 
 void SelectedEntityInfo(DevUI& ui,
@@ -46,7 +46,7 @@ void SelectedEntityInfo(DevUI& ui,
     static GizmoMode mode = GizmoMode::TRANSLATION;
     static GizmoCoords coords = GizmoCoords::WORLD;
 
-    if (entity.Has<TransformComponent>() && ui.StartTreeNode("Transform")) {
+    if (entity.Has<TransformComponent>() && ImGui::TreeNode("Transform")) {
         auto& tr = entity.Get<TransformComponent>();
         ImGui::DragFloat3("Position", &tr.position.x, 0.005f);
         Maths::vec3 eulerAngles = Maths::ToEuler(tr.orientation);
@@ -71,7 +71,7 @@ void SelectedEntityInfo(DevUI& ui,
         if (ImGui::RadioButton("Local", coords == GizmoCoords::LOCAL)) {
             coords = GizmoCoords::LOCAL;
         }
-        ui.EndTreeNode();
+        ImGui::TreePop();
     }
 
     if (entity.Has<TransformComponent>()) {
@@ -133,11 +133,11 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
     bool closed = true;
     if (ImGui::CollapsingHeader("Vertex")) {
         closed = false;
-        ui.MultilineTextModifiable("", shader.VertexShaderSource());
+        ImGuiXtra::MultilineTextModifiable("", &shader.VertexShaderSource());
     }
     if (ImGui::CollapsingHeader("Frag")) {
         closed = false;
-        ui.MultilineTextModifiable("", shader.FragShaderSource());
+        ImGuiXtra::MultilineTextModifiable("", &shader.FragShaderSource());
     }
     
     if(closed) {

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -43,7 +43,7 @@ void SelectedEntityInfo(DevUI& ui,
     ImGuiXtra::Text("ID: " + std::to_string(entity.Id()));
     ImGui::Separator();
     
-    static GizmoMode mode = GizmoMode::TRANSLATION;
+    static ImGuizmo::OPERATION mode = ImGuizmo::OPERATION::TRANSLATE;
     static GizmoCoords coords = GizmoCoords::WORLD;
 
     if (entity.Has<TransformComponent>() && ImGui::TreeNode("Transform")) {
@@ -56,12 +56,12 @@ void SelectedEntityInfo(DevUI& ui,
            << "Roll: " << Maths::ToString(eulerAngles.z, 3);
         ImGui::Text(ss.str().c_str());    
 
-        if (ImGui::RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
-            mode = GizmoMode::TRANSLATION;
+        if (ImGui::RadioButton("Translate", mode == ImGuizmo::OPERATION::TRANSLATE)) {
+            mode = ImGuizmo::OPERATION::TRANSLATE;
         }
         ImGui::SameLine();
-        if (ImGui::RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
-            mode = GizmoMode::ROTATION;
+        if (ImGui::RadioButton("Rotate", mode == ImGuizmo::OPERATION::ROTATE)) {
+            mode = ImGuizmo::OPERATION::ROTATE;
         }
 
         if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {

--- a/Game/EditorUI.h
+++ b/Game/EditorUI.h
@@ -7,7 +7,7 @@ class EditorUI : public Sprocket::Layer
 {
     WorldLayer* d_worldLayer;
 
-    Sprocket::DevUI::Context d_ui;
+    Sprocket::DevUI::DevUI d_ui;
 
     Sprocket::ModelManager* d_modelManager;
 

--- a/Game/EditorUI.h
+++ b/Game/EditorUI.h
@@ -7,7 +7,7 @@ class EditorUI : public Sprocket::Layer
 {
     WorldLayer* d_worldLayer;
 
-    Sprocket::DevUI::DevUI d_ui;
+    Sprocket::DevUI d_ui;
 
     Sprocket::ModelManager* d_modelManager;
 

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -3,6 +3,9 @@ Sun:
   direction: [0, 0.9808463, -0.1947833]
   colour: [0.9019608, 0.8005289, 0.6720492]
   brightness: 20.29
+Ambience:
+  colour: [1.0, 1.0, 1.0]
+  brightness: 0.03
 Entities:
   - NameComponent:
       name: Tree

--- a/Sprocket/Graphics/RenderContext.cpp
+++ b/Sprocket/Graphics/RenderContext.cpp
@@ -66,4 +66,13 @@ void RenderContext::DepthTesting(bool enabled) const
     }
 }
 
+void RenderContext::ScissorTesting(bool enabled) const
+{
+    if (enabled) {
+        glEnable(GL_SCISSOR_TEST);
+    } else {
+        glDisable(GL_SCISSOR_TEST);
+    }
+}
+
 }

--- a/Sprocket/Graphics/RenderContext.h
+++ b/Sprocket/Graphics/RenderContext.h
@@ -27,6 +27,7 @@ public:
     void AlphaBlending(bool enabled) const;
     void FaceCulling(bool enabled) const;
     void DepthTesting(bool enabled) const;
+    void ScissorTesting(bool enabled) const;
 
 };
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -36,6 +36,7 @@ public:
 
     int Width() const { return d_width; }
     int Height() const { return d_height; }
+    float AspectRatio() const { return (float)d_width / (float)d_height; }
 
     // Standard texture builders
     static const Texture& White();

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -15,9 +15,7 @@ namespace ImGuiExtra {
 bool  InputTextMultiline(const char* label, 
                          std::string* str, 
                          const ImVec2& size = ImVec2(0, 0), 
-                         ImGuiInputTextFlags flags = 0, 
-                         ImGuiInputTextCallback callback = NULL, 
-                         void* user_data = NULL);
+                         ImGuiInputTextFlags flags = 0);
 }
 
 namespace Sprocket {
@@ -232,7 +230,6 @@ void DevUI::OnUpdate(double dt)
 
 void DevUI::StartFrame()
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::NewFrame();
     ImGuizmo::BeginFrame();
 }
@@ -303,21 +300,6 @@ void DevUI::EndFrame()
     }
 }
 
-bool DevUI::StartTreeNode(const std::string& name)
-{
-    return ImGui::TreeNode(name.c_str());
-}
-
-void DevUI::EndTreeNode()
-{
-    ImGui::TreePop();
-}
-
-void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
-{
-    ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
-}
-
 void DevUI::Gizmo(Maths::mat4* matrix,
                     const Maths::mat4& view,
                     const Maths::mat4& projection,
@@ -333,69 +315,10 @@ void DevUI::Gizmo(Maths::mat4* matrix,
     );
 }
 
-void DevUI::PushID(std::size_t id)
-{
-    ImGui::PushID((int)id);
-}
-
-void DevUI::PopID()
-{
-    ImGui::PopID();
-}
-
 void DevUI::DemoWindow()
 {
     static bool show = true;
     ImGui::ShowDemoWindow(&show);
-}
-
-}
-
-
-namespace ImGuiExtra {
-
-struct InputTextCallback_UserData
-{
-    std::string*            Str;
-    ImGuiInputTextCallback  ChainCallback;
-    void*                   ChainCallbackUserData;
-};
-
-static int InputTextCallback(ImGuiInputTextCallbackData* data)
-{
-    InputTextCallback_UserData* user_data = (InputTextCallback_UserData*)data->UserData;
-    if (data->EventFlag == ImGuiInputTextFlags_CallbackResize)
-    {
-        // Resize string callback
-        // If for some reason we refuse the new length (BufTextLen) and/or capacity (BufSize) we need to set them back to what we want.
-        std::string* str = user_data->Str;
-        IM_ASSERT(data->Buf == str->c_str());
-        str->resize(data->BufTextLen);
-        data->Buf = (char*)str->c_str();
-    }
-    else if (user_data->ChainCallback)
-    {
-        // Forward to user callback, if any
-        data->UserData = user_data->ChainCallbackUserData;
-        return user_data->ChainCallback(data);
-    }
-    return 0;
-}
-
-bool ImGuiExtra::InputTextMultiline(const char* label, 
-                                    std::string* str, 
-                                    const ImVec2& size, 
-                                    ImGuiInputTextFlags flags, 
-                                    ImGuiInputTextCallback callback, 
-                                    void* user_data)
-{
-    IM_ASSERT((flags & ImGuiInputTextFlags_CallbackResize) == 0);
-    flags |= ImGuiInputTextFlags_CallbackResize;
-    InputTextCallback_UserData cb_user_data;
-    cb_user_data.Str = str;
-    cb_user_data.ChainCallback = callback;
-    cb_user_data.ChainCallbackUserData = user_data;
-    return ImGui::InputTextMultiline(label, (char*)str->c_str(), str->capacity() + 1, size, flags, InputTextCallback, &cb_user_data);
 }
 
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -303,16 +303,6 @@ void DevUI::EndFrame()
     }
 }
 
-void DevUI::StartWindow(const std::string& name, bool* open, int flags)
-{
-    ImGui::Begin(name.c_str(), open, flags);
-}
-
-void DevUI::EndWindow()
-{
-    ImGui::End();
-}
-
 bool DevUI::StartTreeNode(const std::string& name)
 {
     return ImGui::TreeNode(name.c_str());
@@ -326,28 +316,6 @@ void DevUI::EndTreeNode()
 void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
 {
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
-}
-
-void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
-{
-    static int flags = ImGuiColorEditFlags_Float
-                     | ImGuiColorEditFlags_InputRGB;
-    ImGui::ColorEdit3(name.c_str(), &colour->x, flags);
-}
-
-void DevUI::DragInt(const std::string& name, int* value, float speed)
-{
-    ImGui::DragInt(name.c_str(), value, speed);
-}
-
-void DevUI::DragFloat(const std::string& name, float* value, float speed)
-{
-    ImGui::DragFloat(name.c_str(), value, speed);
-}
-
-void DevUI::DragFloat3(const std::string& name, Maths::vec3* values, float speed)
-{
-    ImGui::DragFloat3(name.c_str(), &values->x, speed);
 }
 
 void DevUI::Gizmo(Maths::mat4* matrix,

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -338,19 +338,6 @@ bool DevUI::CollapsingHeader(const std::string& name)
     return ImGui::CollapsingHeader(name.c_str());
 }
 
-void DevUI::Text(const std::string& text)
-{
-    ImGui::Text(text.c_str());
-}
-
-void DevUI::TextModifiable(std::string& text)
-{
-    char nameStr[128] = "";
-    std::memcpy(nameStr, text.c_str(), std::strlen(text.c_str()));
-    ImGui::InputText("", nameStr, IM_ARRAYSIZE(nameStr));
-    text = std::string(nameStr);
-}
-
 void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
 {
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -315,10 +315,4 @@ void DevUI::Gizmo(Maths::mat4* matrix,
     );
 }
 
-void DevUI::DemoWindow()
-{
-    static bool show = true;
-    ImGui::ShowDemoWindow(&show);
-}
-
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -184,12 +184,10 @@ void DevUI::EndFrame()
     ImGui::Render();
 
     Sprocket::RenderContext rc;  
-    glEnable(GL_BLEND);
-    glBlendEquation(GL_FUNC_ADD);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glDisable(GL_CULL_FACE);
-    glEnable(GL_SCISSOR_TEST);
-    glDisable(GL_DEPTH_TEST);
+    rc.AlphaBlending(true);
+    rc.FaceCulling(false);
+    rc.ScissorTesting(true);
+    rc.DepthTesting(false);
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     ImDrawData* drawData = ImGui::GetDrawData();

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -142,7 +142,7 @@ struct DevUIData
     }
 };
 
-Context::Context(Window* window)
+DevUI::DevUI(Window* window)
     : d_impl(std::make_shared<DevUIData>())
 {
     IMGUI_CHECKVERSION();
@@ -159,7 +159,7 @@ Context::Context(Window* window)
     SetFontAtlas(io, d_impl->fontAtlas);
 }
 
-void Context::OnEvent(Event& event)
+void DevUI::OnEvent(Event& event)
 {
     if (event.IsConsumed()) { return; }
 
@@ -221,7 +221,7 @@ void Context::OnEvent(Event& event)
     }
 }
 
-void Context::OnUpdate(double dt)
+void DevUI::OnUpdate(double dt)
 {
     ImGuiIO& io = d_impl->context->IO;
     io.DeltaTime = (float)dt;
@@ -231,14 +231,14 @@ void Context::OnUpdate(double dt)
     ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
 }
 
-void Context::StartFrame()
+void DevUI::StartFrame()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::NewFrame();
     ImGuizmo::BeginFrame();
 }
 
-void Context::EndFrame()
+void DevUI::EndFrame()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::Render();
@@ -304,55 +304,55 @@ void Context::EndFrame()
     }
 }
 
-void Context::StartWindow(const std::string& name, bool* open, int flags)
+void DevUI::StartWindow(const std::string& name, bool* open, int flags)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::Begin(name.c_str(), open, flags);
 }
 
-void Context::EndWindow()
+void DevUI::EndWindow()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::End();
 }
 
-bool Context::StartTreeNode(const std::string& name)
+bool DevUI::StartTreeNode(const std::string& name)
 {
     ImGui::SetCurrentContext(d_impl->context);
     return ImGui::TreeNode(name.c_str());
 }
 
-void Context::EndTreeNode()
+void DevUI::EndTreeNode()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::TreePop();
 }
 
-bool Context::Button(const std::string& name)
+bool DevUI::Button(const std::string& name)
 {
     ImGui::SetCurrentContext(d_impl->context);
     return ImGui::Button(name.c_str());
 }
 
-bool Context::RadioButton(const std::string& name, bool active)
+bool DevUI::RadioButton(const std::string& name, bool active)
 {
     ImGui::SetCurrentContext(d_impl->context);
     return ImGui::RadioButton(name.c_str(), active);
 }
 
-bool Context::CollapsingHeader(const std::string& name)
+bool DevUI::CollapsingHeader(const std::string& name)
 {
     ImGui::SetCurrentContext(d_impl->context);
     return ImGui::CollapsingHeader(name.c_str());
 }
 
-void Context::Text(const std::string& text)
+void DevUI::Text(const std::string& text)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::Text(text.c_str());
 }
 
-void Context::TextModifiable(std::string& text)
+void DevUI::TextModifiable(std::string& text)
 {
     ImGui::SetCurrentContext(d_impl->context);
     char nameStr[128] = "";
@@ -361,19 +361,19 @@ void Context::TextModifiable(std::string& text)
     text = std::string(nameStr);
 }
 
-void Context::MultilineTextModifiable(const std::string_view label, std::string& text)
+void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
 }
 
-void Context::Checkbox(const std::string& name, bool* value)
+void DevUI::Checkbox(const std::string& name, bool* value)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::Checkbox(name.c_str(), value);
 }
 
-void Context::ColourPicker(const std::string& name, Maths::vec3* colour)
+void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
 {
     ImGui::SetCurrentContext(d_impl->context);
     static int flags = ImGuiColorEditFlags_Float
@@ -381,31 +381,31 @@ void Context::ColourPicker(const std::string& name, Maths::vec3* colour)
     ImGui::ColorEdit3(name.c_str(), &colour->x, flags);
 }
 
-void Context::SliderFloat(const std::string& name, float* value, float lower, float upper)
+void DevUI::SliderFloat(const std::string& name, float* value, float lower, float upper)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::SliderFloat(name.c_str(), value, lower, upper, "%.3f");
 }
 
-void Context::DragInt(const std::string& name, int* value, float speed)
+void DevUI::DragInt(const std::string& name, int* value, float speed)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragInt(name.c_str(), value, speed);
 }
 
-void Context::DragFloat(const std::string& name, float* value, float speed)
+void DevUI::DragFloat(const std::string& name, float* value, float speed)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragFloat(name.c_str(), value, speed);
 }
 
-void Context::DragFloat3(const std::string& name, Maths::vec3* values, float speed)
+void DevUI::DragFloat3(const std::string& name, Maths::vec3* values, float speed)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragFloat3(name.c_str(), &values->x, speed);
 }
 
-void Context::Gizmo(Maths::mat4* matrix,
+void DevUI::Gizmo(Maths::mat4* matrix,
                     const Maths::mat4& view,
                     const Maths::mat4& projection,
                     GizmoMode mode,
@@ -421,31 +421,31 @@ void Context::Gizmo(Maths::mat4* matrix,
     );
 }
 
-void Context::SameLine()
+void DevUI::SameLine()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::SameLine();
 }
 
-void Context::Separator()
+void DevUI::Separator()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::Separator();
 }
 
-void Context::PushID(std::size_t id)
+void DevUI::PushID(std::size_t id)
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::PushID((int)id);
 }
 
-void Context::PopID()
+void DevUI::PopID()
 {
     ImGui::SetCurrentContext(d_impl->context);
     ImGui::PopID();
 }
 
-void Context::DemoWindow()
+void DevUI::DemoWindow()
 {
     static bool show = true;
     ImGui::ShowDemoWindow(&show);

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -79,19 +79,6 @@ void SetFontAtlas(ImGuiIO& io, Texture& fontAtlas)
 
 }
 
-ImGuizmo::OPERATION GetMode(GizmoMode mode)
-{
-    switch (mode) {
-        case GizmoMode::TRANSLATION: return ImGuizmo::OPERATION::TRANSLATE;
-        case GizmoMode::ROTATION:    return ImGuizmo::OPERATION::ROTATE;
-        case GizmoMode::SCALE:       return ImGuizmo::OPERATION::SCALE;
-        default: {
-            SPKT_LOG_ERROR("Unknown GizmoMode!");
-            return ImGuizmo::OPERATION::TRANSLATE;
-        }
-    }
-}
-
 ImGuizmo::MODE GetCoords(GizmoCoords coords) 
 {
     switch (coords) {

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -21,16 +21,6 @@ bool  InputTextMultiline(const char* label,
 namespace Sprocket {
 namespace {
 
-unsigned int Cast(ImTextureID id)
-{
-    return (unsigned int)(intptr_t)id;
-}
-
-ImTextureID Cast(unsigned int id)
-{
-    return (ImTextureID)(intptr_t)id;
-}
-
 void SetBackendFlags(ImGuiIO& io)
 {
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
@@ -84,7 +74,7 @@ void SetFontAtlas(ImGuiIO& io, Texture& fontAtlas)
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&data, &width, &height);
     fontAtlas = Texture(width, height, data);
-    io.Fonts->TexID = Cast(fontAtlas.Id());
+    io.Fonts->TexID = (ImTextureID)(unsigned int)(intptr_t)fontAtlas.Id();
 }
 
 }
@@ -298,21 +288,6 @@ void DevUI::EndFrame()
             }
         }
     }
-}
-
-void DevUI::Gizmo(Maths::mat4* matrix,
-                    const Maths::mat4& view,
-                    const Maths::mat4& projection,
-                    GizmoMode mode,
-                    GizmoCoords coords)
-{
-    ImGuizmo::Manipulate(
-        Maths::Cast(view),
-        Maths::Cast(projection),
-        GetMode(mode),
-        GetCoords(coords),
-        Maths::Cast(*matrix)
-    );
 }
 
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -323,21 +323,6 @@ void DevUI::EndTreeNode()
     ImGui::TreePop();
 }
 
-bool DevUI::Button(const std::string& name)
-{
-    return ImGui::Button(name.c_str());
-}
-
-bool DevUI::RadioButton(const std::string& name, bool active)
-{
-    return ImGui::RadioButton(name.c_str(), active);
-}
-
-bool DevUI::CollapsingHeader(const std::string& name)
-{
-    return ImGui::CollapsingHeader(name.c_str());
-}
-
 void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
 {
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
@@ -353,11 +338,6 @@ void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
     static int flags = ImGuiColorEditFlags_Float
                      | ImGuiColorEditFlags_InputRGB;
     ImGui::ColorEdit3(name.c_str(), &colour->x, flags);
-}
-
-void DevUI::SliderFloat(const std::string& name, float* value, float lower, float upper)
-{
-    ImGui::SliderFloat(name.c_str(), value, lower, upper, "%.3f");
 }
 
 void DevUI::DragInt(const std::string& name, int* value, float speed)

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -21,7 +21,6 @@ bool  InputTextMultiline(const char* label,
 }
 
 namespace Sprocket {
-namespace DevUI {
 namespace {
 
 unsigned int Cast(ImTextureID id)
@@ -451,7 +450,6 @@ void DevUI::DemoWindow()
     ImGui::ShowDemoWindow(&show);
 }
 
-}
 }
 
 

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -79,18 +79,6 @@ void SetFontAtlas(ImGuiIO& io, Texture& fontAtlas)
 
 }
 
-ImGuizmo::MODE GetCoords(GizmoCoords coords) 
-{
-    switch (coords) {
-        case GizmoCoords::WORLD: return ImGuizmo::MODE::WORLD;
-        case GizmoCoords::LOCAL: return ImGuizmo::MODE::LOCAL;
-        default: {
-            SPKT_LOG_ERROR("Unknown GizmoCoords!");
-            return ImGuizmo::MODE::WORLD;
-        }
-    }
-}
-
 struct DevUIData
 {
     ImGuiContext* context;

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -188,7 +188,6 @@ void DevUI::EndFrame()
     rc.FaceCulling(false);
     rc.ScissorTesting(true);
     rc.DepthTesting(false);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     ImDrawData* drawData = ImGui::GetDrawData();
 

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -328,11 +328,6 @@ void DevUI::MultilineTextModifiable(const std::string_view label, std::string& t
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
 }
 
-void DevUI::Checkbox(const std::string& name, bool* value)
-{
-    ImGui::Checkbox(name.c_str(), value);
-}
-
 void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
 {
     static int flags = ImGuiColorEditFlags_Float

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -305,55 +305,46 @@ void DevUI::EndFrame()
 
 void DevUI::StartWindow(const std::string& name, bool* open, int flags)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::Begin(name.c_str(), open, flags);
 }
 
 void DevUI::EndWindow()
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::End();
 }
 
 bool DevUI::StartTreeNode(const std::string& name)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     return ImGui::TreeNode(name.c_str());
 }
 
 void DevUI::EndTreeNode()
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::TreePop();
 }
 
 bool DevUI::Button(const std::string& name)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     return ImGui::Button(name.c_str());
 }
 
 bool DevUI::RadioButton(const std::string& name, bool active)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     return ImGui::RadioButton(name.c_str(), active);
 }
 
 bool DevUI::CollapsingHeader(const std::string& name)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     return ImGui::CollapsingHeader(name.c_str());
 }
 
 void DevUI::Text(const std::string& text)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::Text(text.c_str());
 }
 
 void DevUI::TextModifiable(std::string& text)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     char nameStr[128] = "";
     std::memcpy(nameStr, text.c_str(), std::strlen(text.c_str()));
     ImGui::InputText("", nameStr, IM_ARRAYSIZE(nameStr));
@@ -362,19 +353,16 @@ void DevUI::TextModifiable(std::string& text)
 
 void DevUI::MultilineTextModifiable(const std::string_view label, std::string& text)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGuiExtra::InputTextMultiline(label.data(), &text, ImVec2(500, 500), 0, nullptr, nullptr);
 }
 
 void DevUI::Checkbox(const std::string& name, bool* value)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::Checkbox(name.c_str(), value);
 }
 
 void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     static int flags = ImGuiColorEditFlags_Float
                      | ImGuiColorEditFlags_InputRGB;
     ImGui::ColorEdit3(name.c_str(), &colour->x, flags);
@@ -382,25 +370,21 @@ void DevUI::ColourPicker(const std::string& name, Maths::vec3* colour)
 
 void DevUI::SliderFloat(const std::string& name, float* value, float lower, float upper)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::SliderFloat(name.c_str(), value, lower, upper, "%.3f");
 }
 
 void DevUI::DragInt(const std::string& name, int* value, float speed)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragInt(name.c_str(), value, speed);
 }
 
 void DevUI::DragFloat(const std::string& name, float* value, float speed)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragFloat(name.c_str(), value, speed);
 }
 
 void DevUI::DragFloat3(const std::string& name, Maths::vec3* values, float speed)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::DragFloat3(name.c_str(), &values->x, speed);
 }
 
@@ -410,7 +394,6 @@ void DevUI::Gizmo(Maths::mat4* matrix,
                     GizmoMode mode,
                     GizmoCoords coords)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGuizmo::Manipulate(
         Maths::Cast(view),
         Maths::Cast(projection),
@@ -420,27 +403,13 @@ void DevUI::Gizmo(Maths::mat4* matrix,
     );
 }
 
-void DevUI::SameLine()
-{
-    ImGui::SetCurrentContext(d_impl->context);
-    ImGui::SameLine();
-}
-
-void DevUI::Separator()
-{
-    ImGui::SetCurrentContext(d_impl->context);
-    ImGui::Separator();
-}
-
 void DevUI::PushID(std::size_t id)
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::PushID((int)id);
 }
 
 void DevUI::PopID()
 {
-    ImGui::SetCurrentContext(d_impl->context);
     ImGui::PopID();
 }
 

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -64,9 +64,6 @@ public:
                GizmoMode mode,
                GizmoCoords coords);
 
-    void SameLine();
-    void Separator();
-
     void PushID(std::size_t id);
     void PopID();
 

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -45,13 +45,9 @@ public:
     bool StartTreeNode(const std::string& name);
     void EndTreeNode();
 
-    bool Button(const std::string& name);
-    bool RadioButton(const std::string& name, bool active);
-    bool CollapsingHeader(const std::string& name);
     void MultilineTextModifiable(const std::string_view label, std::string &text);
     void Checkbox(const std::string& name, bool* value);
     void ColourPicker(const std::string& name, Maths::vec3* colour);
-    void SliderFloat(const std::string& name, float* value, float lower, float upper);
     void DragInt(const std::string& name, int* value, float speed = 1.0f);
     void DragFloat(const std::string& name, float* value, float speed = 1.0f);
     void DragFloat3(const std::string& name, Maths::vec3* values, float speed = 1.0f);

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -46,7 +46,6 @@ public:
     void EndTreeNode();
 
     void MultilineTextModifiable(const std::string_view label, std::string &text);
-    void Checkbox(const std::string& name, bool* value);
     void ColourPicker(const std::string& name, Maths::vec3* colour);
     void DragInt(const std::string& name, int* value, float speed = 1.0f);
     void DragFloat(const std::string& name, float* value, float speed = 1.0f);

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -11,6 +11,7 @@
 namespace Sprocket {
 
 class DevUI
+// A class that wraps the setup and rendering of ImGui.
 {
     Window* d_window;
     Shader  d_shader;

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -38,12 +38,6 @@ public:
 
     void StartFrame();
     void EndFrame();
-
-    void Gizmo(Maths::mat4* matrix,
-               const Maths::mat4& view,
-               const Maths::mat4& projection,
-               GizmoMode mode,
-               GizmoCoords coords);
 };
 
 }

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -14,7 +14,6 @@
 #include <memory>
 
 namespace Sprocket {
-namespace DevUI {
 
 struct DevUIData;
 
@@ -74,5 +73,4 @@ public:
     void DemoWindow();
 };
 
-}
 }

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -17,10 +17,8 @@ namespace Sprocket {
 
 struct DevUIData;
 
-enum class GizmoMode { TRANSLATION, ROTATION, SCALE };
 enum class GizmoCoords { WORLD, LOCAL };
 
-ImGuizmo::OPERATION GetMode(GizmoMode mode);
 ImGuizmo::MODE GetCoords(GizmoCoords coords);
 
 class DevUI

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -39,17 +39,10 @@ public:
     void StartFrame();
     void EndFrame();
 
-    void StartWindow(const std::string& name, bool* open = nullptr, int flags = 0);
-    void EndWindow();
-
     bool StartTreeNode(const std::string& name);
     void EndTreeNode();
 
     void MultilineTextModifiable(const std::string_view label, std::string &text);
-    void ColourPicker(const std::string& name, Maths::vec3* colour);
-    void DragInt(const std::string& name, int* value, float speed = 1.0f);
-    void DragFloat(const std::string& name, float* value, float speed = 1.0f);
-    void DragFloat3(const std::string& name, Maths::vec3* values, float speed = 1.0f);
 
     void Gizmo(Maths::mat4* matrix,
                const Maths::mat4& view,

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -39,19 +39,11 @@ public:
     void StartFrame();
     void EndFrame();
 
-    bool StartTreeNode(const std::string& name);
-    void EndTreeNode();
-
-    void MultilineTextModifiable(const std::string_view label, std::string &text);
-
     void Gizmo(Maths::mat4* matrix,
                const Maths::mat4& view,
                const Maths::mat4& projection,
                GizmoMode mode,
                GizmoCoords coords);
-
-    void PushID(std::size_t id);
-    void PopID();
 
     void DemoWindow();
 };

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -44,8 +44,6 @@ public:
                const Maths::mat4& projection,
                GizmoMode mode,
                GizmoCoords coords);
-
-    void DemoWindow();
 };
 
 }

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -17,10 +17,6 @@ namespace Sprocket {
 
 struct DevUIData;
 
-enum class GizmoCoords { WORLD, LOCAL };
-
-ImGuizmo::MODE GetCoords(GizmoCoords coords);
-
 class DevUI
 {
     std::shared_ptr<DevUIData> d_impl;

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -15,12 +15,18 @@
 
 namespace Sprocket {
 
-struct DevUIData;
-
 class DevUI
 {
-    std::shared_ptr<DevUIData> d_impl;
-    bool d_blockEvents = true;
+    // SPROCKET OBJECTS
+    Window* d_window;
+    Shader  d_shader;
+    Texture d_fontAtlas;
+
+    StreamBuffer d_buffer;
+        // Buffer used to store the render data created by ImGui
+        // for rendering it.
+
+    bool d_blockEvents;
 
 public:
     DevUI(Window* window);

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -7,17 +7,12 @@
 #include "Resources.h"
 #include "StreamBuffer.h"
 
-#include <imgui.h>
-#include <imgui_internal.h>
-#include <ImGuizmo.h>
-
 #include <memory>
 
 namespace Sprocket {
 
 class DevUI
 {
-    // SPROCKET OBJECTS
     Window* d_window;
     Shader  d_shader;
     Texture d_fontAtlas;

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -24,13 +24,13 @@ enum class GizmoCoords { WORLD, LOCAL };
 ImGuizmo::OPERATION GetMode(GizmoMode mode);
 ImGuizmo::MODE GetCoords(GizmoCoords coords);
 
-class Context
+class DevUI
 {
     std::shared_ptr<DevUIData> d_impl;
     bool d_blockEvents = true;
 
 public:
-    Context(Window* window);
+    DevUI(Window* window);
 
     void OnEvent(Event& event);
     void OnUpdate(double dt);

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -1,13 +1,12 @@
 #pragma once
 #include "Window.h"
-#include "Maths.h"
 #include "Shader.h"
 #include "Event.h"
 #include "Texture.h"
-#include "Resources.h"
 #include "StreamBuffer.h"
 
-#include <memory>
+#include <imgui.h>
+#include <ImGuizmo.h>
 
 namespace Sprocket {
 
@@ -18,8 +17,7 @@ class DevUI
     Texture d_fontAtlas;
 
     StreamBuffer d_buffer;
-        // Buffer used to store the render data created by ImGui
-        // for rendering it.
+        // Used to draw the render data created by ImGui.
 
     bool d_blockEvents;
 

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -48,8 +48,6 @@ public:
     bool Button(const std::string& name);
     bool RadioButton(const std::string& name, bool active);
     bool CollapsingHeader(const std::string& name);
-    void Text(const std::string& text);
-    void TextModifiable(std::string& text);
     void MultilineTextModifiable(const std::string_view label, std::string &text);
     void Checkbox(const std::string& name, bool* value);
     void ColourPicker(const std::string& name, Maths::vec3* colour);

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -59,33 +59,33 @@ void SetGuizmo()
 }
 
 void GuizmoSettings(
-    DevUI::GizmoMode& mode,
-    DevUI::GizmoCoords& coords,
+    GizmoMode& mode,
+    GizmoCoords& coords,
     bool& useSnap,
     Maths::vec3& snap)
 {
-    if (ImGui::RadioButton("Translate", mode == DevUI::GizmoMode::TRANSLATION)) {
-        mode = DevUI::GizmoMode::TRANSLATION;
+    if (ImGui::RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
+        mode = GizmoMode::TRANSLATION;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Rotate", mode == DevUI::GizmoMode::ROTATION)) {
-        mode = DevUI::GizmoMode::ROTATION;
+    if (ImGui::RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
+        mode = GizmoMode::ROTATION;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Scale", mode == DevUI::GizmoMode::SCALE)) {
-        mode = DevUI::GizmoMode::SCALE;
+    if (ImGui::RadioButton("Scale", mode == GizmoMode::SCALE)) {
+        mode = GizmoMode::SCALE;
     }
 
-    if (ImGui::RadioButton("World", coords == DevUI::GizmoCoords::WORLD)) {
-        coords = DevUI::GizmoCoords::WORLD;
+    if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {
+        coords = GizmoCoords::WORLD;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Local", coords == DevUI::GizmoCoords::LOCAL)) {
-        coords = DevUI::GizmoCoords::LOCAL;
+    if (ImGui::RadioButton("Local", coords == GizmoCoords::LOCAL)) {
+        coords = GizmoCoords::LOCAL;
     }
     ImGui::Checkbox("", &useSnap);
     ImGui::SameLine();
-    if (mode == DevUI::GizmoMode::TRANSLATION) {
+    if (mode == GizmoMode::TRANSLATION) {
         ImGui::InputFloat3("Snap", &snap.x);
     }
     else {

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -87,7 +87,7 @@ void SetGuizmo()
 
 void GuizmoSettings(
     ImGuizmo::OPERATION& mode,
-    GizmoCoords& coords,
+    ImGuizmo::MODE& coords,
     bool& useSnap,
     Maths::vec3& snap)
 {
@@ -103,12 +103,12 @@ void GuizmoSettings(
         mode = ImGuizmo::OPERATION::SCALE;
     }
 
-    if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {
-        coords = GizmoCoords::WORLD;
+    if (ImGui::RadioButton("World", coords == ImGuizmo::MODE::WORLD)) {
+        coords = ImGuizmo::MODE::WORLD;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Local", coords == GizmoCoords::LOCAL)) {
-        coords = GizmoCoords::LOCAL;
+    if (ImGui::RadioButton("Local", coords == ImGuizmo::MODE::LOCAL)) {
+        coords = ImGuizmo::MODE::LOCAL;
     }
     ImGui::Checkbox("", &useSnap);
     ImGui::SameLine();
@@ -125,13 +125,13 @@ void Guizmo(
     const Maths::mat4& view,
     const Maths::mat4& projection,
     ImGuizmo::OPERATION mode,
-    GizmoCoords coords)
+    ImGuizmo::MODE coords)
 {
     ImGuizmo::Manipulate(
         Maths::Cast(view),
         Maths::Cast(projection),
         mode,
-        GetCoords(coords),
+        coords,
         Maths::Cast(*matrix)
     );
 }

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -86,21 +86,21 @@ void SetGuizmo()
 }
 
 void GuizmoSettings(
-    GizmoMode& mode,
+    ImGuizmo::OPERATION& mode,
     GizmoCoords& coords,
     bool& useSnap,
     Maths::vec3& snap)
 {
-    if (ImGui::RadioButton("Translate", mode == GizmoMode::TRANSLATION)) {
-        mode = GizmoMode::TRANSLATION;
+    if (ImGui::RadioButton("Translate", mode == ImGuizmo::OPERATION::TRANSLATE)) {
+        mode = ImGuizmo::OPERATION::TRANSLATE;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Rotate", mode == GizmoMode::ROTATION)) {
-        mode = GizmoMode::ROTATION;
+    if (ImGui::RadioButton("Rotate", mode == ImGuizmo::OPERATION::ROTATE)) {
+        mode = ImGuizmo::OPERATION::ROTATE;
     }
     ImGui::SameLine();
-    if (ImGui::RadioButton("Scale", mode == GizmoMode::SCALE)) {
-        mode = GizmoMode::SCALE;
+    if (ImGui::RadioButton("Scale", mode == ImGuizmo::OPERATION::SCALE)) {
+        mode = ImGuizmo::OPERATION::SCALE;
     }
 
     if (ImGui::RadioButton("World", coords == GizmoCoords::WORLD)) {
@@ -112,7 +112,7 @@ void GuizmoSettings(
     }
     ImGui::Checkbox("", &useSnap);
     ImGui::SameLine();
-    if (mode == GizmoMode::TRANSLATION) {
+    if (mode == ImGuizmo::OPERATION::TRANSLATE) {
         ImGui::InputFloat3("Snap", &snap.x);
     }
     else {
@@ -124,13 +124,13 @@ void Guizmo(
     Maths::mat4* matrix,
     const Maths::mat4& view,
     const Maths::mat4& projection,
-    GizmoMode mode,
+    ImGuizmo::OPERATION mode,
     GizmoCoords coords)
 {
     ImGuizmo::Manipulate(
         Maths::Cast(view),
         Maths::Cast(projection),
-        GetMode(mode),
+        mode,
         GetCoords(coords),
         Maths::Cast(*matrix)
     );

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -6,6 +6,23 @@
 
 namespace Sprocket {
 namespace ImGuiXtra {
+namespace {
+
+static int InputTextCallback(ImGuiInputTextCallbackData* data)
+{
+    if (data->EventFlag == ImGuiInputTextFlags_CallbackResize)
+    {
+        // Resize string callback
+        // If for some reason we refuse the new length (BufTextLen) and/or capacity (BufSize) we need to set them back to what we want.
+        auto* str = static_cast<std::string*>(data->UserData);
+        IM_ASSERT(data->Buf == str->c_str());
+        str->resize(data->BufTextLen);
+        data->Buf = (char*)str->c_str();
+    }
+    return 0;
+}
+
+}
 
 void File(const std::string& name,
           Window* window,
@@ -104,6 +121,19 @@ void Euler(const std::string& name, Maths::quat* q)
     if (ImGui::DragFloat3("Orientation", &euler.x, 0.01f)) {
         *q = Maths::quat(euler);
     }
+}
+
+bool MultilineTextModifiable(const std::string_view label, std::string* text)
+{
+    return ImGui::InputTextMultiline(
+        label.data(),
+        (char*)text->c_str(),
+        text->capacity() + 1,
+        ImVec2(500, 500),
+        ImGuiInputTextFlags_CallbackResize,
+        InputTextCallback,
+        text
+    );
 }
 
 }

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -32,6 +32,11 @@ void TextModifiable(std::string& text)
     text = std::string(nameStr);
 }
 
+void Text(const std::string& text)
+{
+    ImGui::Text(text.c_str());
+}
+
 void Image(const Texture& image,
            const Maths::vec2& size,
            const Maths::vec2& uv0,

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -71,6 +71,11 @@ void Image(const Texture& image,
     );
 }
 
+void Image(const Texture& image, float size)
+{
+    Image(image, {image.AspectRatio() * size, size});
+}
+
 void SetGuizmo()
 {
     float rw = ImGui::GetWindowWidth();

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -120,6 +120,22 @@ void GuizmoSettings(
     }
 }
 
+void Guizmo(
+    Maths::mat4* matrix,
+    const Maths::mat4& view,
+    const Maths::mat4& projection,
+    GizmoMode mode,
+    GizmoCoords coords)
+{
+    ImGuizmo::Manipulate(
+        Maths::Cast(view),
+        Maths::Cast(projection),
+        GetMode(mode),
+        GetCoords(coords),
+        Maths::Cast(*matrix)
+    );
+}
+
 void Euler(const std::string& name, Maths::quat* q)
 {
     Maths::vec3 euler = Maths::ToEuler(*q);

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -6,6 +6,9 @@
 
 #include <string>
 
+#include <imgui.h>
+#include <ImGuizmo.h>
+
 namespace Sprocket {
 namespace ImGuiXtra {
 

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -18,6 +18,9 @@ void File(const std::string& name,
 // Creates a text box for modifying strings.
 void TextModifiable(std::string& text);
 
+// Wrapper that accepts std::strings
+void Text(const std::string& text);
+
 // A wrapper for ImGui::Image that uses Sprocket types.
 void Image(const Texture& image,
            const Maths::vec2& size,

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -29,6 +29,10 @@ void Image(const Texture& image,
            const Maths::vec4& tintCol = {1, 1, 1, 1},
            const Maths::vec4& borderCol = {0, 0, 0, 0});
 
+// A simplified version of the above where the texture maintains
+// aspect ratio. The size is the height in pixels.
+void Image(const Texture& image, float size);
+
 // Adds the Gizmo to the current panels draw list
 void SetGuizmo();
 void GuizmoSettings(

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -44,6 +44,7 @@ void GuizmoSettings(
 // Displays a quaternion in Euler angles form.
 void Euler(const std::string& name, Maths::quat* q);
 
+// Displays a window for a large amount of text that can be rewritten.
 bool MultilineTextModifiable(const std::string_view label, std::string* text);
 
 }

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -39,7 +39,7 @@ void Image(const Texture& image, float size);
 void SetGuizmo();
 
 void GuizmoSettings(
-    GizmoMode& mode,
+    ImGuizmo::OPERATION& mode,
     GizmoCoords& coords,
     bool& useSnap,
     Maths::vec3& snap
@@ -49,7 +49,7 @@ void Guizmo(
     Maths::mat4* matrix,
     const Maths::mat4& view,
     const Maths::mat4& projection,
-    GizmoMode mode,
+    ImGuizmo::OPERATION mode,
     GizmoCoords coords
 );
 

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -40,7 +40,7 @@ void SetGuizmo();
 
 void GuizmoSettings(
     ImGuizmo::OPERATION& mode,
-    GizmoCoords& coords,
+    ImGuizmo::MODE& coords,
     bool& useSnap,
     Maths::vec3& snap
 );
@@ -50,7 +50,7 @@ void Guizmo(
     const Maths::mat4& view,
     const Maths::mat4& projection,
     ImGuizmo::OPERATION mode,
-    GizmoCoords coords
+    ImGuizmo::MODE coords
 );
 
 // Displays a quaternion in Euler angles form.

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -2,6 +2,7 @@
 #include "Window.h"
 #include "Texture.h"
 #include "DevUI.h"
+#include "Maths.h"
 
 #include <string>
 
@@ -27,7 +28,8 @@ void Image(const Texture& image,
            const Maths::vec2& uv0 = {0, 1},
            const Maths::vec2& uv1 = {1, 0},
            const Maths::vec4& tintCol = {1, 1, 1, 1},
-           const Maths::vec4& borderCol = {0, 0, 0, 0});
+           const Maths::vec4& borderCol = {0, 0, 0, 0}
+);
 
 // A simplified version of the above where the texture maintains
 // aspect ratio. The size is the height in pixels.
@@ -35,11 +37,21 @@ void Image(const Texture& image, float size);
 
 // Adds the Gizmo to the current panels draw list
 void SetGuizmo();
+
 void GuizmoSettings(
     GizmoMode& mode,
     GizmoCoords& coords,
     bool& useSnap,
-    Maths::vec3& snap);
+    Maths::vec3& snap
+);
+
+void Guizmo(
+    Maths::mat4* matrix,
+    const Maths::mat4& view,
+    const Maths::mat4& projection,
+    GizmoMode mode,
+    GizmoCoords coords
+);
 
 // Displays a quaternion in Euler angles form.
 void Euler(const std::string& name, Maths::quat* q);

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -29,8 +29,8 @@ void Image(const Texture& image,
 // Adds the Gizmo to the current panels draw list
 void SetGuizmo();
 void GuizmoSettings(
-    DevUI::GizmoMode& mode,
-    DevUI::GizmoCoords& coords,
+    GizmoMode& mode,
+    GizmoCoords& coords,
     bool& useSnap,
     Maths::vec3& snap);
 

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -40,5 +40,7 @@ void GuizmoSettings(
 // Displays a quaternion in Euler angles form.
 void Euler(const std::string& name, Maths::quat* q);
 
+bool MultilineTextModifiable(const std::string_view label, std::string* text);
+
 }
 }


### PR DESCRIPTION
DevUI is the Sprocket wrapper for ImGui, however it was mainly just bloat. This removes a huge chunk of it, with the intention being to just use the ImGui types and functions directly rather than having it all wrapped by Sprocket. In the future, we should add a SPROCKET_INCLUDE_IMGUI compile flag so that Sprocket can be used without ImGui if needed.