### PR TITLE
Switch to DSA OpenGL Functions

### DIFF
--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -222,7 +222,7 @@ void EditorLayer::OnUpdate(double dt)
         d_isViewportHovered = ImGui::IsWindowHovered();
         d_isViewportFocused = ImGui::IsWindowFocused();
         d_ui.BlockEvents(!d_isViewportFocused || !d_isViewportHovered);
-        ImGuiXtra::Image(d_viewport.GetTexture(), {0.8f * w, 0.8f * h});
+        ImGuiXtra::Image(d_viewport.GetColour(), {0.8f * w, 0.8f * h});
         ImGuiXtra::SetGuizmo();
         ImGui::End();
     }

--- a/Game/EditorUI.cpp
+++ b/Game/EditorUI.cpp
@@ -196,7 +196,7 @@ void EditorUI::OnUpdate(double dt)
     ShaderInfoPanel(d_ui, d_worldLayer->d_entityRenderer.GetShader());
 
     ImGui::Begin("Shadow Map");
-    ImGuiXtra::Image(d_worldLayer->d_shadowMap.GetShadowMap(), 500.0f);
+    //ImGuiXtra::Image(d_worldLayer->d_shadowMap.GetShadowMap(), 500.0f);
     ImGui::End();
 
     ImGui::ShowDemoWindow();

--- a/Resources/Shaders/Entity_PBR.frag
+++ b/Resources/Shaders/Entity_PBR.frag
@@ -22,7 +22,7 @@ in Data
 } p_data;
 
 // Material Info
-uniform sampler2D texture_sampler;
+uniform sampler2D u_albedo_map;
 uniform sampler2D u_normal_map;
 uniform sampler2D u_metallic_map;
 uniform sampler2D u_roughness_map;
@@ -117,7 +117,7 @@ vec3 calculate_light(
 
 void main()
 {
-    vec3 albedo = u_use_albedo_map > 0.5 ? texture(texture_sampler, p_data.texture_coords).xyz : u_albedo;
+    vec3 albedo = u_use_albedo_map > 0.5 ? texture(u_albedo_map, p_data.texture_coords).xyz : u_albedo;
 
     float metallic = u_use_metallic_map > 0.5 ? texture(u_metallic_map, p_data.texture_coords).r : u_metallic;
     float roughness = u_use_roughness_map > 0.5 ? texture(u_roughness_map, p_data.texture_coords).r : u_roughness;
@@ -134,7 +134,7 @@ void main()
     vec3 F0 = vec3(0.04);
     F0 = mix(F0, albedo, metallic);
 
-        // Shadows
+    // Shadows
     vec3 proj_coords = p_data.light_space_pos.xyz / p_data.light_space_pos.w;
     proj_coords = 0.5 * proj_coords + 0.5;
     float current_depth = proj_coords.z;

--- a/Sprocket/Graphics/CubeMap.cpp
+++ b/Sprocket/Graphics/CubeMap.cpp
@@ -6,9 +6,9 @@
 namespace Sprocket {
     
 CubeMap::CubeMap(const std::array<std::string, 6>& faceFiles)
-    : d_texture(std::make_shared<TEX>())
 {
-    glBindTexture(GL_TEXTURE_CUBE_MAP, d_texture->Value());
+    glGenTextures(1, &d_id);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, d_id);
 
     for (unsigned int i = 0; i != faceFiles.size(); ++i) {
         int bpp;
@@ -31,10 +31,15 @@ CubeMap::CubeMap(const std::array<std::string, 6>& faceFiles)
     glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 }
 
+CubeMap::~CubeMap()
+{
+    glDeleteTextures(1, &d_id);
+}
+
 void CubeMap::Bind() const
 {
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, d_texture->Value());
+    glBindTexture(GL_TEXTURE_CUBE_MAP, d_id);
 }
 
 void CubeMap::Unbind() const

--- a/Sprocket/Graphics/CubeMap.h
+++ b/Sprocket/Graphics/CubeMap.h
@@ -2,18 +2,20 @@
 #include "Resources.h"
 
 #include <array>
+#include <cstdint>
 
 namespace Sprocket {
 
 class CubeMap
 {
-    std::shared_ptr<TEX> d_texture;
+    std::uint32_t d_id;
 
     int d_width;
     int d_height;
 
 public:
     CubeMap(const std::array<std::string, 6>& faceFiles);
+    ~CubeMap();
 
     void Bind() const;
     void Unbind() const;

--- a/Sprocket/Graphics/DepthBuffer.cpp
+++ b/Sprocket/Graphics/DepthBuffer.cpp
@@ -28,6 +28,11 @@ DepthBuffer::DepthBuffer(Window* window, int width, int height)
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
+DepthBuffer::~DepthBuffer()
+{
+    glDeleteFramebuffers(1, &d_fbo);
+}
+
 void DepthBuffer::Bind() const
 {
     glBindTexture(GL_TEXTURE_2D, 0);

--- a/Sprocket/Graphics/DepthBuffer.cpp
+++ b/Sprocket/Graphics/DepthBuffer.cpp
@@ -7,7 +7,7 @@ namespace Sprocket {
 DepthBuffer::DepthBuffer(Window* window, int width, int height)
     : d_window(window)
     , d_fbo(std::make_shared<FBO>())
-    , d_depth(std::make_shared<TEX>())
+    , d_depth(std::make_shared<Texture>(width, height, Texture::Channels::DEPTH))
     , d_width(width)
     , d_height(height)
 {
@@ -15,17 +15,10 @@ DepthBuffer::DepthBuffer(Window* window, int width, int height)
     glDrawBuffer(GL_NONE);
     glReadBuffer(GL_NONE);
 
-    glBindTexture(GL_TEXTURE_2D, d_depth->Value());
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, width, height, 0,
-                 GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glBindTexture(GL_TEXTURE_2D, d_depth->Id());
     float borderColour[] = {1.0f, 1.0f, 1.0f, 1.0f};
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColour);
-
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, d_depth->Value(), 0);
+    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, d_depth->Id(), 0);
     
      // Validate the framebuffer.
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {

--- a/Sprocket/Graphics/DepthBuffer.cpp
+++ b/Sprocket/Graphics/DepthBuffer.cpp
@@ -6,12 +6,12 @@ namespace Sprocket {
 
 DepthBuffer::DepthBuffer(Window* window, int width, int height)
     : d_window(window)
-    , d_fbo(std::make_shared<FBO>())
     , d_depth(std::make_shared<Texture>(width, height, Texture::Channels::DEPTH))
     , d_width(width)
     , d_height(height)
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo->Value());
+    glGenFramebuffers(1, &d_fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo);
     glDrawBuffer(GL_NONE);
     glReadBuffer(GL_NONE);
 
@@ -31,7 +31,7 @@ DepthBuffer::DepthBuffer(Window* window, int width, int height)
 void DepthBuffer::Bind() const
 {
     glBindTexture(GL_TEXTURE_2D, 0);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, d_fbo->Value());
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, d_fbo);
     glViewport(0, 0, d_width, d_height);
 }
 

--- a/Sprocket/Graphics/DepthBuffer.h
+++ b/Sprocket/Graphics/DepthBuffer.h
@@ -11,7 +11,7 @@ class DepthBuffer
     Window* d_window; 
 
     std::shared_ptr<FBO> d_fbo;
-    std::shared_ptr<TEX> d_depth; // TODO: Switch to an RBO
+    std::shared_ptr<Texture> d_depth;
 
     int d_width;
     int d_height;
@@ -25,7 +25,7 @@ public:
     int Width() const { return d_width; }
     int Height() const { return d_height; }
 
-    Texture GetShadowMap() const { return Texture(d_width, d_height, d_depth); }
+    std::shared_ptr<Texture> GetShadowMap() const { return d_depth; }
 };
 
 }

--- a/Sprocket/Graphics/DepthBuffer.h
+++ b/Sprocket/Graphics/DepthBuffer.h
@@ -11,7 +11,7 @@ class DepthBuffer
     Window* d_window; 
 
     std::uint32_t d_fbo;
-    
+
     std::shared_ptr<Texture> d_depth;
 
     int d_width;
@@ -22,6 +22,7 @@ class DepthBuffer
 
 public:
     DepthBuffer(Window* window, int width, int height);
+    ~DepthBuffer();
 
     void Bind() const;
     void Unbind() const;

--- a/Sprocket/Graphics/DepthBuffer.h
+++ b/Sprocket/Graphics/DepthBuffer.h
@@ -16,6 +16,9 @@ class DepthBuffer
     int d_width;
     int d_height;
 
+    DepthBuffer(const DepthBuffer&) = delete;
+    DepthBuffer& operator=(const DepthBuffer&) = delete;
+
 public:
     DepthBuffer(Window* window, int width, int height);
 

--- a/Sprocket/Graphics/DepthBuffer.h
+++ b/Sprocket/Graphics/DepthBuffer.h
@@ -10,7 +10,8 @@ class DepthBuffer
 {
     Window* d_window; 
 
-    std::shared_ptr<FBO> d_fbo;
+    std::uint32_t d_fbo;
+    
     std::shared_ptr<Texture> d_depth;
 
     int d_width;

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -10,23 +10,14 @@ FrameBuffer::FrameBuffer(int width, int height)
     , d_width(width)
     , d_height(height)
 {
-    glGenFramebuffers(1, &d_fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo);
-
-    glFramebufferTexture2D(
-        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-        GL_TEXTURE_2D, d_texture->Id(), 0);
-
-    glFramebufferTexture2D(
-        GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-        GL_TEXTURE_2D, d_depth->Id(), 0);
+    glCreateFramebuffers(1, &d_fbo);
+    glNamedFramebufferTexture(d_fbo, GL_COLOR_ATTACHMENT0, d_texture->Id(), 0);
+    glNamedFramebufferTexture(d_fbo, GL_DEPTH_ATTACHMENT, d_depth->Id(), 0);
 
     // Validate the framebuffer.
-    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    if (glCheckNamedFramebufferStatus(d_fbo, GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         SPKT_LOG_ERROR("Created FBO is not complete!");
     }
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 FrameBuffer::~FrameBuffer()

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -6,20 +6,20 @@ namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
     : d_fbo(std::make_shared<FBO>())
-    , d_texture(std::make_shared<TEX>())
     , d_depthBuffer(std::make_shared<RBO>())
     , d_width(width)
     , d_height(height)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, d_fbo->Value());
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glGenTextures(1, &d_texture);
+    glBindTexture(GL_TEXTURE_2D, d_texture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0,
                  GL_RGB, GL_UNSIGNED_BYTE, nullptr);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture->Value(), 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture, 0);
 
     // Add depth buffer.
     glBindRenderbuffer(GL_RENDERBUFFER, d_depthBuffer->Value());
@@ -48,7 +48,7 @@ void FrameBuffer::Unbind() const
 
 void FrameBuffer::BindTexture() const
 {
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glBindTexture(GL_TEXTURE_2D, d_texture);
 }
 
 void FrameBuffer::UnbindTexture() const
@@ -61,7 +61,7 @@ void FrameBuffer::SetScreenSize(int width, int height)
     d_width = width;
     d_height = height;
 
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glBindTexture(GL_TEXTURE_2D, d_texture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
     glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -6,19 +6,20 @@ namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
     : d_texture(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
-    , d_depthBuffer(std::make_shared<RBO>())
+    , d_depth(std::make_shared<Texture>(width, height, Texture::Channels::DEPTH))
     , d_width(width)
     , d_height(height)
 {
     glGenFramebuffers(1, &d_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, d_fbo);
 
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture->Id(), 0);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+        GL_TEXTURE_2D, d_texture->Id(), 0);
 
-    // Add depth buffer.
-    glBindRenderbuffer(GL_RENDERBUFFER, d_depthBuffer->Value());
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, d_depthBuffer->Value());
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+        GL_TEXTURE_2D, d_depth->Id(), 0);
 
     // Validate the framebuffer.
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
@@ -62,11 +63,11 @@ void FrameBuffer::SetScreenSize(int width, int height)
 
     glBindTexture(GL_TEXTURE_2D, d_texture->Id());
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+    
+    glBindTexture(GL_TEXTURE_2D, d_depth->Id());
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+    
     glBindTexture(GL_TEXTURE_2D, 0);
-
-    glBindRenderbuffer(GL_RENDERBUFFER, d_depthBuffer->Value());
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
 }

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -6,20 +6,14 @@ namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
     : d_fbo(std::make_shared<FBO>())
+    , d_texture(std::make_shared<Texture>(width, height, nullptr))
     , d_depthBuffer(std::make_shared<RBO>())
     , d_width(width)
     , d_height(height)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, d_fbo->Value());
-    glGenTextures(1, &d_texture);
-    glBindTexture(GL_TEXTURE_2D, d_texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0,
-                 GL_RGB, GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture, 0);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture->Id(), 0);
 
     // Add depth buffer.
     glBindRenderbuffer(GL_RENDERBUFFER, d_depthBuffer->Value());
@@ -48,7 +42,7 @@ void FrameBuffer::Unbind() const
 
 void FrameBuffer::BindTexture() const
 {
-    glBindTexture(GL_TEXTURE_2D, d_texture);
+    glBindTexture(GL_TEXTURE_2D, d_texture->Id());
 }
 
 void FrameBuffer::UnbindTexture() const
@@ -61,7 +55,7 @@ void FrameBuffer::SetScreenSize(int width, int height)
     d_width = width;
     d_height = height;
 
-    glBindTexture(GL_TEXTURE_2D, d_texture);
+    glBindTexture(GL_TEXTURE_2D, d_texture->Id());
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
     glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -6,7 +6,7 @@ namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
     : d_fbo(std::make_shared<FBO>())
-    , d_texture(std::make_shared<Texture>(width, height, nullptr))
+    , d_texture(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
     , d_depthBuffer(std::make_shared<RBO>())
     , d_width(width)
     , d_height(height)

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -5,13 +5,13 @@
 namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
-    : d_fbo(std::make_shared<FBO>())
-    , d_texture(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
+    : d_texture(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
     , d_depthBuffer(std::make_shared<RBO>())
     , d_width(width)
     , d_height(height)
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo->Value());
+    glGenFramebuffers(1, &d_fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo);
 
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, d_texture->Id(), 0);
 
@@ -28,9 +28,14 @@ FrameBuffer::FrameBuffer(int width, int height)
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
+FrameBuffer::~FrameBuffer()
+{
+    glDeleteFramebuffers(1, &d_fbo);
+}
+
 void FrameBuffer::Bind() const
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo->Value());
+    glBindFramebuffer(GL_FRAMEBUFFER, d_fbo);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glEnable(GL_DEPTH_TEST);
 }

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -5,13 +5,13 @@
 namespace Sprocket {
 
 FrameBuffer::FrameBuffer(int width, int height)
-    : d_texture(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
+    : d_colour(std::make_shared<Texture>(width, height, Texture::Channels::RGBA))
     , d_depth(std::make_shared<Texture>(width, height, Texture::Channels::DEPTH))
     , d_width(width)
     , d_height(height)
 {
     glCreateFramebuffers(1, &d_fbo);
-    glNamedFramebufferTexture(d_fbo, GL_COLOR_ATTACHMENT0, d_texture->Id(), 0);
+    glNamedFramebufferTexture(d_fbo, GL_COLOR_ATTACHMENT0, d_colour->Id(), 0);
     glNamedFramebufferTexture(d_fbo, GL_DEPTH_ATTACHMENT, d_depth->Id(), 0);
 
     // Validate the framebuffer.
@@ -39,7 +39,7 @@ void FrameBuffer::Unbind() const
 
 void FrameBuffer::BindTexture() const
 {
-    glBindTexture(GL_TEXTURE_2D, d_texture->Id());
+    glBindTexture(GL_TEXTURE_2D, d_colour->Id());
 }
 
 void FrameBuffer::UnbindTexture() const
@@ -51,14 +51,8 @@ void FrameBuffer::SetScreenSize(int width, int height)
 {
     d_width = width;
     d_height = height;
-
-    glBindTexture(GL_TEXTURE_2D, d_texture->Id());
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
-    
-    glBindTexture(GL_TEXTURE_2D, d_depth->Id());
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
-    
-    glBindTexture(GL_TEXTURE_2D, 0);
+    d_colour->Resize(width, height);
+    d_depth->Resize(width, height);
 }
 
 }

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -8,7 +8,7 @@ class FrameBuffer
 {
     std::uint32_t d_fbo;
 
-    std::shared_ptr<Texture> d_texture;
+    std::shared_ptr<Texture> d_colour;
     std::shared_ptr<Texture> d_depth;
 
     int d_width;
@@ -30,7 +30,8 @@ public:
     void BindTexture() const;
     void UnbindTexture() const;
 
-    std::shared_ptr<Texture> GetTexture() const { return d_texture; }
+    std::shared_ptr<Texture> GetColour() const { return d_colour; }
+    std::shared_ptr<Texture> GetDepth() const { return d_depth; }
 
     void SetScreenSize(int width, int height);
         // Resized the internal textures to match the new screen size.

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -9,7 +9,7 @@ class FrameBuffer
     std::uint32_t d_fbo;
 
     std::shared_ptr<Texture> d_texture;
-    std::shared_ptr<RBO>     d_depthBuffer;
+    std::shared_ptr<Texture> d_depth;
 
     int d_width;
     int d_height;

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -6,7 +6,8 @@ namespace Sprocket {
 
 class FrameBuffer
 {
-    std::shared_ptr<FBO>     d_fbo;
+    std::uint32_t d_fbo;
+
     std::shared_ptr<Texture> d_texture;
     std::shared_ptr<RBO>     d_depthBuffer;
 
@@ -18,6 +19,7 @@ class FrameBuffer
 
 public:
     FrameBuffer(int width, int height);
+    ~FrameBuffer();
 
     void Bind() const;
     void Unbind() const;

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -13,6 +13,9 @@ class FrameBuffer
     int d_width;
     int d_height;
 
+    FrameBuffer(const FrameBuffer&) = delete;
+    FrameBuffer& operator=(const FrameBuffer&) = delete;
+
 public:
     FrameBuffer(int width, int height);
 

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -6,9 +6,9 @@ namespace Sprocket {
 
 class FrameBuffer
 {
-    std::shared_ptr<FBO> d_fbo;
-    std::uint32_t        d_texture;
-    std::shared_ptr<RBO> d_depthBuffer;
+    std::shared_ptr<FBO>     d_fbo;
+    std::shared_ptr<Texture> d_texture;
+    std::shared_ptr<RBO>     d_depthBuffer;
 
     int d_width;
     int d_height;
@@ -28,7 +28,7 @@ public:
     void BindTexture() const;
     void UnbindTexture() const;
 
-    std::uint32_t GetTexture() const { return d_texture; }
+    std::uint32_t GetTexture() const { return d_texture->Id(); }
 
     void SetScreenSize(int width, int height);
         // Resized the internal textures to match the new screen size.

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -28,7 +28,7 @@ public:
     void BindTexture() const;
     void UnbindTexture() const;
 
-    std::uint32_t GetTexture() const { return d_texture->Id(); }
+    std::shared_ptr<Texture> GetTexture() const { return d_texture; }
 
     void SetScreenSize(int width, int height);
         // Resized the internal textures to match the new screen size.

--- a/Sprocket/Graphics/FrameBuffer.h
+++ b/Sprocket/Graphics/FrameBuffer.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class FrameBuffer
 {
     std::shared_ptr<FBO> d_fbo;
-    std::shared_ptr<TEX> d_texture;
+    std::uint32_t        d_texture;
     std::shared_ptr<RBO> d_depthBuffer;
 
     int d_width;
@@ -28,7 +28,7 @@ public:
     void BindTexture() const;
     void UnbindTexture() const;
 
-    Texture GetTexture() const { return Texture(d_width, d_height, d_texture); }
+    std::uint32_t GetTexture() const { return d_texture; }
 
     void SetScreenSize(int width, int height);
         // Resized the internal textures to match the new screen size.

--- a/Sprocket/Graphics/Mesh.cpp
+++ b/Sprocket/Graphics/Mesh.cpp
@@ -83,15 +83,11 @@ Mesh::Mesh(const VertexBuffer& vertices, const IndexBuffer& indices)
     , d_vertexCount(indices.size())
     , d_layout(sizeof(Vertex), 0)
 {
-    glGenBuffers(1, &d_vertexBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, d_vertexBuffer);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glCreateBuffers(1, &d_vertexBuffer);
+    glNamedBufferData(d_vertexBuffer, sizeof(Vertex) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
 
-    glGenBuffers(1, &d_indexBuffer);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_indexBuffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(unsigned int) * indices.size(), indices.data(), GL_STATIC_DRAW);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glCreateBuffers(1, &d_indexBuffer);
+    glNamedBufferData(d_indexBuffer, sizeof(unsigned int) * indices.size(), indices.data(), GL_STATIC_DRAW);
 
     d_layout.AddAttribute(DataType::FLOAT, 3);
     d_layout.AddAttribute(DataType::FLOAT, 2);

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -34,7 +34,7 @@ EntityRenderer::EntityRenderer(AssetManager* assetManager)
     , d_instanceBuffer(GetInstanceBuffer())
 {
     d_shader.Bind();
-    d_shader.LoadSampler("texture_sampler", ALBEDO_SLOT);
+    d_shader.LoadSampler("u_albedo_map", ALBEDO_SLOT);
     d_shader.LoadSampler("u_normal_map", NORMAL_SLOT);
     d_shader.LoadSampler("u_metallic_map", METALLIC_SLOT);
     d_shader.LoadSampler("u_roughness_map", ROUGHNESS_SLOT);

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -38,7 +38,7 @@ EntityRenderer::EntityRenderer(AssetManager* assetManager)
 void EntityRenderer::EnableShadows(const ShadowMap& shadowMap)
 {
     glActiveTexture(GL_TEXTURE4);
-    shadowMap.GetShadowMap().Bind();
+    shadowMap.GetShadowMap()->Bind();
  
     d_shader.Bind();
     d_shader.LoadSampler("shadow_map", 4);

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -12,6 +12,15 @@ namespace Sprocket {
 
 class EntityRenderer
 {
+    // PBR Texture Slots
+    static constexpr int ALBEDO_SLOT = 0;
+    static constexpr int NORMAL_SLOT = 1;
+    static constexpr int METALLIC_SLOT = 2;
+    static constexpr int ROUGHNESS_SLOT = 3;
+
+    // Shadow Map Texture Slot
+    static constexpr int SHADOW_MAP_SLOT = 4;
+
     AssetManager*    d_assetManager;
     ParticleManager* d_particleManager;
 

--- a/Sprocket/Graphics/Resources.cpp
+++ b/Sprocket/Graphics/Resources.cpp
@@ -20,12 +20,6 @@ unsigned int GenerateBuffer(ResourceType type)
         case ResourceType::Texture: {
             glGenTextures(1, &buf);
         } break;
-        case ResourceType::FrameBuffer: {
-            glGenFramebuffers(1, &buf);
-        } break;
-        case ResourceType::RenderBuffer: {
-            glGenRenderbuffers(1, &buf);
-        } break;
         default: {
             SPKT_LOG_FATAL("Unknown Resource type!");
             throw std::runtime_error("Unknown Resource type!");
@@ -45,12 +39,6 @@ void DeleteBuffer(ResourceType type, unsigned int buf)
         } break;
         case ResourceType::Texture: {
             glDeleteTextures(1, &buf);
-        } break;
-        case ResourceType::FrameBuffer: {
-            glDeleteFramebuffers(1, &buf);
-        } break;
-        case ResourceType::RenderBuffer: {
-            glDeleteRenderbuffers(1, &buf);
         } break;
         default: {
             SPKT_LOG_FATAL("Unknown Resource type!");

--- a/Sprocket/Graphics/Resources.cpp
+++ b/Sprocket/Graphics/Resources.cpp
@@ -17,9 +17,6 @@ unsigned int GenerateBuffer(ResourceType type)
         case ResourceType::VBO: {
             glGenBuffers(1, &buf);
         } break;
-        case ResourceType::Texture: {
-            glGenTextures(1, &buf);
-        } break;
         default: {
             SPKT_LOG_FATAL("Unknown Resource type!");
             throw std::runtime_error("Unknown Resource type!");
@@ -36,9 +33,6 @@ void DeleteBuffer(ResourceType type, unsigned int buf)
         } break;
         case ResourceType::VBO: {
             glDeleteBuffers(1, &buf);
-        } break;
-        case ResourceType::Texture: {
-            glDeleteTextures(1, &buf);
         } break;
         default: {
             SPKT_LOG_FATAL("Unknown Resource type!");

--- a/Sprocket/Graphics/Resources.h
+++ b/Sprocket/Graphics/Resources.h
@@ -10,8 +10,6 @@ enum class ResourceType
     VAO,
     VBO,
     Texture,
-    FrameBuffer,
-    RenderBuffer
 };
 
 unsigned int GenerateBuffer(ResourceType type);
@@ -41,8 +39,6 @@ private:
 using VAO = Resource<ResourceType::VAO>;
 using VBO = Resource<ResourceType::VBO>;
 using TEX = Resource<ResourceType::Texture>;
-using FBO = Resource<ResourceType::FrameBuffer>;
-using RBO = Resource<ResourceType::RenderBuffer>;
 
 template <ResourceType Type>
 Resource<Type>::Resource()

--- a/Sprocket/Graphics/Resources.h
+++ b/Sprocket/Graphics/Resources.h
@@ -5,12 +5,7 @@
 
 namespace Sprocket {
 
-enum class ResourceType
-{
-    VAO,
-    VBO,
-    Texture,
-};
+enum class ResourceType { VAO, VBO };
 
 unsigned int GenerateBuffer(ResourceType type);
 void DeleteBuffer(ResourceType type, unsigned int buf);
@@ -38,7 +33,6 @@ private:
 
 using VAO = Resource<ResourceType::VAO>;
 using VBO = Resource<ResourceType::VBO>;
-using TEX = Resource<ResourceType::Texture>;
 
 template <ResourceType Type>
 Resource<Type>::Resource()

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -90,7 +90,7 @@ Maths::mat4 ShadowMap::GetLightProjViewMatrix() const
     return d_lightProjMatrix * d_lightViewMatrix;
 }
 
-Texture ShadowMap::GetShadowMap() const
+std::shared_ptr<Texture> ShadowMap::GetShadowMap() const
 {
     return d_shadowMap.GetShadowMap();
 }

--- a/Sprocket/Graphics/ShadowMap.h
+++ b/Sprocket/Graphics/ShadowMap.h
@@ -35,7 +35,7 @@ public:
     void Draw(const Sun& sun, const Maths::vec3& centre, Scene& scene);
 
     Maths::mat4 GetLightProjViewMatrix() const;
-    Texture     GetShadowMap() const;
+    std::shared_ptr<Texture>     GetShadowMap() const;
 };
 
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -31,18 +31,6 @@ Texture::Texture(int width, int height, const unsigned char* data)
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-Texture::Texture(int width, int height, const std::vector<unsigned char>& data)
-    : Texture(width, height, data.data())
-{
-}
-
-Texture::Texture(int width, int height, std::shared_ptr<TEX> texture)
-    : d_texture(texture)
-    , d_width(width)
-    , d_height(height)
-{
-}
-
 Texture::Texture(int width, int height, Channels channels)
     : d_texture(std::make_shared<TEX>())
     , d_width(width)
@@ -102,7 +90,15 @@ void Texture::Unbind() const
 
 const Texture& Texture::White()
 {
-    static const Texture white(1, 1, {0xff, 0xff, 0xff, 0xff});
+    auto GetData = []() {
+        std::vector<unsigned char> data;
+        data.push_back(0xff);
+        data.push_back(0xff);
+        data.push_back(0xff);
+        data.push_back(0xff);
+        return data;
+    };
+    static const Texture white(1, 1, GetData().data());
     return white;
 }
 

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -94,20 +94,6 @@ void Texture::Unbind() const
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-const Texture& Texture::White()
-{
-    auto GetData = []() {
-        std::vector<unsigned char> data;
-        data.push_back(0xff);
-        data.push_back(0xff);
-        data.push_back(0xff);
-        data.push_back(0xff);
-        return data;
-    };
-    static const Texture white(1, 1, GetData().data());
-    return white;
-}
-
 unsigned int Texture::Id() const
 {
     return d_id;

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -45,21 +45,21 @@ Texture::Texture(int width, int height, Channels channels)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
+    auto a = GL_RGBA;
+    auto b = GL_RGBA;
+    auto type = GL_UNSIGNED_BYTE;
+    
     if (channels == Channels::RED) {
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        a = GL_RED;
+        b = GL_RED;
+    }
+    else if (channels == Channels::DEPTH) {
+        a = GL_DEPTH_COMPONENT16;
+        b = GL_DEPTH_COMPONENT;
     }
 
-    if (channels == Channels::DEPTH) {
-        glTexImage2D(GL_TEXTURE_2D,
-                    0, GL_DEPTH_COMPONENT16, width, height,
-                    0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, nullptr);
-    }
-    else {
-        glTexImage2D(GL_TEXTURE_2D,
-                    0, c, width, height,
-                    0, c, GL_UNSIGNED_BYTE, nullptr);
-    }
-                 
+    glTexImage2D(GL_TEXTURE_2D, 0, a, width, height, 0, b, type, nullptr);    
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
@@ -125,11 +125,14 @@ void Texture::SetSubTexture(
 {
     Bind();
 
+    auto c = GL_RGBA;
     if (d_channels == Channels::RED) {
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        c = GL_RED;
     }
-
-    auto c = d_channels == Channels::RGBA ? GL_RGBA : GL_RED;
+    else if (d_channels == Channels::DEPTH) {
+        c = GL_DEPTH_COMPONENT;
+    }
     glTexSubImage2D(GL_TEXTURE_2D,
                     0, region.x, region.y, region.z, region.w, 
                     c, GL_UNSIGNED_BYTE, (void*)data);

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -78,9 +78,9 @@ void Texture::Resize(int width, int height)
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void Texture::Bind() const
+void Texture::Bind(int slot) const
 {
-    glBindTexture(GL_TEXTURE_2D, d_id);
+    glBindTextureUnit(slot, d_id);
 }
 
 void Texture::Unbind() const

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -61,9 +61,16 @@ Texture::Texture(int width, int height, Channels channels)
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     }
 
-    glTexImage2D(GL_TEXTURE_2D,
-                 0, c, width, height,
-                 0, c, GL_UNSIGNED_BYTE, nullptr);
+    if (channels == Channels::DEPTH) {
+        glTexImage2D(GL_TEXTURE_2D,
+                    0, GL_DEPTH_COMPONENT16, width, height,
+                    0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, nullptr);
+    }
+    else {
+        glTexImage2D(GL_TEXTURE_2D,
+                    0, c, width, height,
+                    0, c, GL_UNSIGNED_BYTE, nullptr);
+    }
                  
     glBindTexture(GL_TEXTURE_2D, 0);
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -24,12 +24,6 @@ Texture::Texture(int width, int height, const unsigned char* data)
 
     glTextureStorage2D(d_id, 1, GL_RGBA8, width, height);
     glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
-
-    //glTexImage2D(GL_TEXTURE_2D,
-    //             0, GL_RGBA, d_width, d_height,
-    //             0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-//
-    //glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 Texture::Texture(int width, int height, Channels channels)
@@ -37,33 +31,12 @@ Texture::Texture(int width, int height, Channels channels)
     , d_height(height)
     , d_channels(channels)
 {
-    auto c = channels == Channels::RGBA ? GL_RGBA : GL_RED;
-
     glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
     glTextureParameteri(d_id, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTextureParameteri(d_id, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTextureParameteri(d_id, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTextureParameteri(d_id, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-
-    auto a = GL_RGBA;
-    auto b = GL_RGBA;
-    auto type = GL_UNSIGNED_BYTE;
-    
-    if (channels == Channels::RED) {
-        a = GL_RED;
-        b = GL_RED;
-    }
-    else if (channels == Channels::DEPTH) {
-        a = GL_DEPTH_COMPONENT16;
-        b = GL_DEPTH_COMPONENT;
-    }
-
-    glBindTexture(GL_TEXTURE_2D, d_id);
-    //glTexStorage2D(GL_TEXTURE_2D, 1, a, width, height);
-    //glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, a, type, nullptr);  
-    //glGenerateMipmap(GL_TEXTURE_2D);
-    glTexImage2D(GL_TEXTURE_2D, 0, a, width, height, 0, b, type, nullptr);    
-    glBindTexture(GL_TEXTURE_2D, 0);
+    Resize(width, height);
 }
 
 Texture::Texture()
@@ -86,6 +59,29 @@ std::shared_ptr<Texture> Texture::FromFile(const std::string file)
     int width, height, bpp;
     unsigned char* data = stbi_load(file.c_str(), &width, &height, &bpp, 4);
     return std::make_shared<Texture>(width, height, data);
+}
+
+void Texture::Resize(int width, int height)
+{
+    int ifmt, fmt;
+    switch (d_channels) {
+        case Channels::RGBA: {
+            ifmt = GL_RGBA;
+            fmt = GL_RGBA;
+        } break;
+        case Channels::RED: {
+            ifmt = GL_RED;
+            fmt = GL_RED;
+        } break;
+        case Channels::DEPTH: {
+            ifmt = GL_DEPTH_COMPONENT16;
+            fmt = GL_DEPTH_COMPONENT;
+        } break;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, d_id);
+    glTexImage2D(GL_TEXTURE_2D, 0, ifmt, width, height, 0, fmt, GL_UNSIGNED_BYTE, nullptr);
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 void Texture::Bind() const

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -13,15 +13,11 @@ Texture::Texture(int width, int height, const unsigned char* data)
     : d_width(width)
     , d_height(height)
 {
-    assert(width > 0);
-    assert(height > 0);
-
     glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
     glTextureParameteri(d_id, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTextureParameteri(d_id, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTextureParameteri(d_id, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTextureParameteri(d_id, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-
     glTextureStorage2D(d_id, 1, GL_RGBA8, width, height);
     glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
 }
@@ -48,9 +44,7 @@ Texture::Texture()
 
 Texture::~Texture()
 {
-    if (d_id > 0) {
-        glDeleteTextures(1, &d_id);
-    }
+    if (d_id > 0) { glDeleteTextures(1, &d_id); }
 }
 
 std::shared_ptr<Texture> Texture::FromFile(const std::string file)
@@ -108,8 +102,6 @@ void Texture::SetSubTexture(
     const Maths::ivec4& region,
     const unsigned char* data)
 {
-    Bind();
-
     auto c = GL_RGBA;
     if (d_channels == Channels::RED) {
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -118,11 +110,12 @@ void Texture::SetSubTexture(
     else if (d_channels == Channels::DEPTH) {
         c = GL_DEPTH_COMPONENT;
     }
-    glTexSubImage2D(GL_TEXTURE_2D,
-                    0, region.x, region.y, region.z, region.w, 
-                    c, GL_UNSIGNED_BYTE, (void*)data);
 
-    Unbind();
+    glTextureSubImage2D(
+        d_id, 0,
+        region.x, region.y, region.z, region.w,
+        c, GL_UNSIGNED_BYTE, data
+    );
 }
 
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -16,19 +16,20 @@ Texture::Texture(int width, int height, const unsigned char* data)
     assert(width > 0);
     assert(height > 0);
 
-    glGenTextures(1, &d_id);
-    glBindTexture(GL_TEXTURE_2D, d_id);
+    glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
+    glTextureParameteri(d_id, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTextureParameteri(d_id, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTextureParameteri(d_id, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTextureParameteri(d_id, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTextureStorage2D(d_id, 1, GL_RGBA8, width, height);
+    glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
-    glTexImage2D(GL_TEXTURE_2D,
-                 0, GL_RGBA, d_width, d_height,
-                 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-
-    glBindTexture(GL_TEXTURE_2D, 0);
+    //glTexImage2D(GL_TEXTURE_2D,
+    //             0, GL_RGBA, d_width, d_height,
+    //             0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+//
+    //glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 Texture::Texture(int width, int height, Channels channels)
@@ -38,19 +39,17 @@ Texture::Texture(int width, int height, Channels channels)
 {
     auto c = channels == Channels::RGBA ? GL_RGBA : GL_RED;
 
-    glGenTextures(1, &d_id);
-    glBindTexture(GL_TEXTURE_2D, d_id);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
+    glTextureParameteri(d_id, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTextureParameteri(d_id, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTextureParameteri(d_id, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTextureParameteri(d_id, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
     auto a = GL_RGBA;
     auto b = GL_RGBA;
     auto type = GL_UNSIGNED_BYTE;
     
     if (channels == Channels::RED) {
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         a = GL_RED;
         b = GL_RED;
     }
@@ -59,6 +58,10 @@ Texture::Texture(int width, int height, Channels channels)
         b = GL_DEPTH_COMPONENT;
     }
 
+    glBindTexture(GL_TEXTURE_2D, d_id);
+    //glTexStorage2D(GL_TEXTURE_2D, 1, a, width, height);
+    //glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, a, type, nullptr);  
+    //glGenerateMipmap(GL_TEXTURE_2D);
     glTexImage2D(GL_TEXTURE_2D, 0, a, width, height, 0, b, type, nullptr);    
     glBindTexture(GL_TEXTURE_2D, 0);
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -10,14 +10,14 @@
 namespace Sprocket {
 
 Texture::Texture(int width, int height, const unsigned char* data)
-    : d_texture(std::make_shared<TEX>())
-    , d_width(width)
+    : d_width(width)
     , d_height(height)
 {
     assert(width > 0);
     assert(height > 0);
 
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glGenTextures(1, &d_id);
+    glBindTexture(GL_TEXTURE_2D, d_id);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -32,14 +32,14 @@ Texture::Texture(int width, int height, const unsigned char* data)
 }
 
 Texture::Texture(int width, int height, Channels channels)
-    : d_texture(std::make_shared<TEX>())
-    , d_width(width)
+    : d_width(width)
     , d_height(height)
     , d_channels(channels)
 {
     auto c = channels == Channels::RGBA ? GL_RGBA : GL_RED;
 
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glGenTextures(1, &d_id);
+    glBindTexture(GL_TEXTURE_2D, d_id);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -64,10 +64,17 @@ Texture::Texture(int width, int height, Channels channels)
 }
 
 Texture::Texture()
-    : d_texture(Texture::White().d_texture)
-    , d_width(Texture::White().d_width)
-    , d_height(Texture::White().d_height)
+    : d_id(0)
+    , d_width(0)
+    , d_height(0)
 {
+}
+
+Texture::~Texture()
+{
+    if (d_id > 0) {
+        glDeleteTextures(1, &d_id);
+    }
 }
 
 std::shared_ptr<Texture> Texture::FromFile(const std::string file)
@@ -80,7 +87,7 @@ std::shared_ptr<Texture> Texture::FromFile(const std::string file)
 
 void Texture::Bind() const
 {
-    glBindTexture(GL_TEXTURE_2D, d_texture->Value());
+    glBindTexture(GL_TEXTURE_2D, d_id);
 }
 
 void Texture::Unbind() const
@@ -104,12 +111,12 @@ const Texture& Texture::White()
 
 unsigned int Texture::Id() const
 {
-    return d_texture->Value();
+    return d_id;
 }
 
 bool Texture::operator==(const Texture& other) const
 {
-    return d_texture->Value() == other.d_texture->Value();
+    return d_id == other.d_id;
 }
 
 void Texture::SetSubTexture(

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -83,11 +83,6 @@ void Texture::Bind(int slot) const
     glBindTextureUnit(slot, d_id);
 }
 
-void Texture::Unbind() const
-{
-    glBindTexture(GL_TEXTURE_2D, 0);
-}
-
 unsigned int Texture::Id() const
 {
     return d_id;

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -14,7 +14,7 @@ public:
     enum class Channels { RGBA, RED, DEPTH };
 
 private:
-    std::shared_ptr<TEX> d_texture;
+    std::uint32_t d_id;
 
     int d_width;
     int d_height;
@@ -29,6 +29,7 @@ public:
     Texture(int width, int height, const unsigned char* data);
     Texture(int width, int height, Channels channels = Channels::RGBA);
     Texture();
+    ~Texture();
 
     static std::shared_ptr<Texture> FromFile(const std::string file);
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -32,7 +32,7 @@ public:
 
     static std::shared_ptr<Texture> FromFile(const std::string file);
 
-    void Bind() const;
+    void Bind(int slot) const;
     void Unbind() const;
 
     unsigned int Id() const;

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -19,8 +19,7 @@ private:
     int d_width;
     int d_height;
 
-    Channels d_channels = Channels::RGBA;
-        // TODO: Generalise other constructors to expose this.
+    Channels d_channels;
 
     Texture(const Texture&) = delete;
     Texture& operator=(const Texture&) = delete;

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -34,6 +34,8 @@ public:
 
     void Bind() const;
     void Unbind() const;
+    
+    unsigned int Id() const;
 
     int Width() const { return d_width; }
     int Height() const { return d_height; }
@@ -45,7 +47,8 @@ public:
     void SetSubTexture(const Maths::ivec4& region,
                        const unsigned char* data);
 
-    unsigned int Id() const;
+    void Resize(int width, int height);
+
 
     int GetChannels() const { return d_channels == Channels::RGBA ? 4 : 1; }
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -27,8 +27,6 @@ private:
 
 public:
     Texture(int width, int height, const unsigned char* data);
-    Texture(int width, int height, const std::vector<unsigned char>& data);
-    Texture(int width, int height, std::shared_ptr<TEX> texture);
     Texture(int width, int height, Channels channels = Channels::RGBA);
     Texture();
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -34,25 +34,23 @@ public:
 
     void Bind() const;
     void Unbind() const;
-    
+
     unsigned int Id() const;
 
     int Width() const { return d_width; }
     int Height() const { return d_height; }
     float AspectRatio() const { return (float)d_width / (float)d_height; }
 
+    int GetChannels() const { return d_channels == Channels::RGBA ? 4 : 1; }
+    bool operator==(const Texture& other) const;
+
     // Standard texture builders
     static const Texture& White();
 
-    void SetSubTexture(const Maths::ivec4& region,
-                       const unsigned char* data);
-
+    // Mutable Texture Functions
+    void SetSubTexture(const Maths::ivec4& region, const unsigned char* data);
     void Resize(int width, int height);
 
-
-    int GetChannels() const { return d_channels == Channels::RGBA ? 4 : 1; }
-
-    bool operator==(const Texture& other) const;
 };
 
 }

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -44,9 +44,6 @@ public:
     int GetChannels() const { return d_channels == Channels::RGBA ? 4 : 1; }
     bool operator==(const Texture& other) const;
 
-    // Standard texture builders
-    static const Texture& White();
-
     // Mutable Texture Functions
     void SetSubTexture(const Maths::ivec4& region, const unsigned char* data);
     void Resize(int width, int height);

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -11,7 +11,7 @@ namespace Sprocket {
 class Texture
 {
 public:
-    enum class Channels { RGBA, RED };
+    enum class Channels { RGBA, RED, DEPTH };
 
 private:
     std::shared_ptr<TEX> d_texture;
@@ -29,7 +29,7 @@ public:
     Texture(int width, int height, const unsigned char* data);
     Texture(int width, int height, const std::vector<unsigned char>& data);
     Texture(int width, int height, std::shared_ptr<TEX> texture);
-    Texture(int width, int height, Channels channels);
+    Texture(int width, int height, Channels channels = Channels::RGBA);
     Texture();
 
     static std::shared_ptr<Texture> FromFile(const std::string file);

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -33,7 +33,6 @@ public:
     static std::shared_ptr<Texture> FromFile(const std::string file);
 
     void Bind(int slot) const;
-    void Unbind() const;
 
     unsigned int Id() const;
 

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -193,7 +193,7 @@ void DevUI::EndFrame()
     d_shader.LoadMat4("ProjMtx", proj);
 
     d_buffer.Bind();
-    d_fontAtlas->Bind();
+    d_fontAtlas->Bind(0);
 
     // Render command lists
     int width = (int)drawData->DisplaySize.x;

--- a/Sprocket/UI/Font/Font.h
+++ b/Sprocket/UI/Font/Font.h
@@ -46,7 +46,6 @@ public:
     float GetKerning(char left, char right, float size);
 
     void Bind(int slot) const { d_atlas.Bind(slot); }
-    void Unbind() const { d_atlas.Unbind(); }
 
     float TextWidth(const std::string& text, float size);
 

--- a/Sprocket/UI/Font/Font.h
+++ b/Sprocket/UI/Font/Font.h
@@ -45,7 +45,7 @@ public:
     Glyph GetGlyph(char c, float size);
     float GetKerning(char left, char right, float size);
 
-    void Bind() const { d_atlas.Bind(); }
+    void Bind(int slot) const { d_atlas.Bind(slot); }
     void Unbind() const { d_atlas.Unbind(); }
 
     float TextWidth(const std::string& text, float size);

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -28,7 +28,6 @@ public:
     std::size_t Height() const { return d_texture->Height(); }
 
     void Bind(int slot) const { d_texture->Bind(slot); }
-    void Unbind() const { d_texture->Unbind(); }
 
     std::shared_ptr<Texture> GetAtlas() const { return d_texture; }
 };

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -27,7 +27,7 @@ public:
     std::size_t Width() const { return d_texture->Width(); }
     std::size_t Height() const { return d_texture->Height(); }
 
-    void Bind() const { d_texture->Bind(); }
+    void Bind(int slot) const { d_texture->Bind(slot); }
     void Unbind() const { d_texture->Unbind(); }
 
     std::shared_ptr<Texture> GetAtlas() const { return d_texture; }

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -54,7 +54,7 @@ void Text(const std::string& text)
     ImGui::Text(text.c_str());
 }
 
-void Image(const Texture& image,
+void Image(std::uint32_t image,
            const Maths::vec2& size,
            const Maths::vec2& uv0,
            const Maths::vec2& uv1,
@@ -62,7 +62,7 @@ void Image(const Texture& image,
            const Maths::vec4& borderCol)
 {
     ImGui::Image(
-        (ImTextureID)(intptr_t)image.Id(),
+        (ImTextureID)(intptr_t)image,
         {size.x, size.y},
         {uv0.x, uv0.y},
         {uv1.x, uv1.y},
@@ -71,9 +71,9 @@ void Image(const Texture& image,
     );
 }
 
-void Image(const Texture& image, float size)
+void Image(std::uint32_t image, float size)
 {
-    Image(image, {image.AspectRatio() * size, size});
+    Image(image, {4.0f/3.0f * size, size});
 }
 
 void SetGuizmo()

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -54,7 +54,7 @@ void Text(const std::string& text)
     ImGui::Text(text.c_str());
 }
 
-void Image(std::uint32_t image,
+void Image(const std::shared_ptr<Texture>& image,
            const Maths::vec2& size,
            const Maths::vec2& uv0,
            const Maths::vec2& uv1,
@@ -62,7 +62,7 @@ void Image(std::uint32_t image,
            const Maths::vec4& borderCol)
 {
     ImGui::Image(
-        (ImTextureID)(intptr_t)image,
+        (ImTextureID)(intptr_t)image->Id(),
         {size.x, size.y},
         {uv0.x, uv0.y},
         {uv1.x, uv1.y},
@@ -71,9 +71,9 @@ void Image(std::uint32_t image,
     );
 }
 
-void Image(std::uint32_t image, float size)
+void Image(const std::shared_ptr<Texture>& image, float size)
 {
-    Image(image, {4.0f/3.0f * size, size});
+    Image(image, {image->AspectRatio() * size, size});
 }
 
 void SetGuizmo()

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -26,7 +26,7 @@ void TextModifiable(std::string& text);
 void Text(const std::string& text);
 
 // A wrapper for ImGui::Image that uses Sprocket types.
-void Image(std::uint32_t image,
+void Image(const std::shared_ptr<Texture>& image,
            const Maths::vec2& size,
            const Maths::vec2& uv0 = {0, 1},
            const Maths::vec2& uv1 = {1, 0},
@@ -36,7 +36,7 @@ void Image(std::uint32_t image,
 
 // A simplified version of the above where the texture maintains
 // aspect ratio. The size is the height in pixels.
-void Image(std::uint32_t image, float size);
+void Image(const std::shared_ptr<Texture>& image, float size);
 
 // Adds the Gizmo to the current panels draw list
 void SetGuizmo();

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -26,7 +26,7 @@ void TextModifiable(std::string& text);
 void Text(const std::string& text);
 
 // A wrapper for ImGui::Image that uses Sprocket types.
-void Image(const Texture& image,
+void Image(std::uint32_t image,
            const Maths::vec2& size,
            const Maths::vec2& uv0 = {0, 1},
            const Maths::vec2& uv1 = {1, 0},
@@ -36,7 +36,7 @@ void Image(const Texture& image,
 
 // A simplified version of the above where the texture maintains
 // aspect ratio. The size is the height in pixels.
-void Image(const Texture& image, float size);
+void Image(std::uint32_t image, float size);
 
 // Adds the Gizmo to the current panels draw list
 void SetGuizmo();

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -184,13 +184,13 @@ void UIEngine::EndFrame()
     for (const auto& panelHash : d_panelOrder) {
         const auto& panel = d_panels[panelHash];
         d_shader.LoadInt("texture_channels", 1);
-        white.Bind();
+        white.Bind(0);
         d_buffer.Draw(panel.quadVertices, panel.quadIndices);
-        d_font.Bind();
+        d_font.Bind(0);
         d_buffer.Draw(panel.textVertices, panel.textIndices);
         for (const auto& cmd : panel.extraCommands) {
             d_shader.LoadInt("texture_channels", cmd.texture->GetChannels());
-            cmd.texture->Bind();
+            cmd.texture->Bind(0);
             d_buffer.Draw(cmd.vertices, cmd.indices);
         }
     }

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -110,6 +110,8 @@ void UIEngine::StartFrame()
 void UIEngine::EndFrame()
 {
     assert(!d_currentPanel);
+    static unsigned char arr[4] = {0xff, 0xff, 0xff, 0xff};
+    static Texture white(1, 1, arr);
 
     bool foundHovered = false;
     bool foundClicked = false;
@@ -182,7 +184,7 @@ void UIEngine::EndFrame()
     for (const auto& panelHash : d_panelOrder) {
         const auto& panel = d_panels[panelHash];
         d_shader.LoadInt("texture_channels", 1);
-        Texture::White().Bind();
+        white.Bind();
         d_buffer.Draw(panel.quadVertices, panel.quadIndices);
         d_font.Bind();
         d_buffer.Draw(panel.textVertices, panel.textIndices);


### PR DESCRIPTION
In newer Open GL, there are "Direct State Access" functions that have a slightly cleaner API that older functions. So let's switch to those. While at it, I am started the process of removing the "Resources" objects (VAO, VBO...) in favour of just storing the IDs directly in the containing objects, as they are getting passed round by shared pointer anyway.
- Make `Mesh`, `Texture`, `FrameBuffer` and `DepthBuffer` non-copyable to ensure we reference count the GPU resources properly.
- Replace the internal resources used in these with `uint32_t`s.
- `Texture::Bind` now accepts an `int` as the texture slot, which must be specified.
- Removed `Texture::Unbind`.
- Removed a few of the `Texture` constructors with the aim of making the interface simpler.
- Added `Texture::Resize`. This should should be called on textures loaded from files, which are intended to be immutable. The asset manager may want to store `std::shared_ptr<const Texture>` instead to enforce this, however this has not been done here.
- `FrameBuffer` now stores `Texture` objects. The depth buffer within is now a texture (instead of a render buffer) as well, which is less efficient but allows us to easily render the depth map if we desire.
- Rename `texture_sampler` to `u_albedo_map` in the PBR shader.