### PR TITLE
Scene Pausing

### DIFF
--- a/Anvil/EditorLayer.cpp
+++ b/Anvil/EditorLayer.cpp
@@ -95,8 +95,8 @@ void EditorLayer::OnUpdate(double dt)
     //d_shadowMap.Draw(sun, target, *d_scene);
     //d_entityRenderer.EnableShadows(d_shadowMap);
     
+    d_activeScene->OnUpdate(dt, !d_paused);
     if (!d_paused) {
-        d_activeScene->OnUpdate(dt);
         d_particleManager.OnUpdate(dt);
 
         if (d_isViewportFocused && !d_playingGame) {

--- a/Game/WorldLayer.cpp
+++ b/Game/WorldLayer.cpp
@@ -147,26 +147,25 @@ void WorldLayer::OnUpdate(double dt)
 
     d_hoveredEntityUI.OnUpdate(dt);
     d_mouse.OnUpdate();
-    d_cycle.OnUpdate(dt);
-    auto& sun = d_scene->GetSun();
-    
     if (!d_paused) {
-
-        float factor = (-d_cycle.GetSunDir().y + 1.0f) / 2.0f;
-        float facSq = factor * factor;
-        auto skyColour = (1.0f - facSq) * NAVY_NIGHT + facSq * LIGHT_BLUE;
-        d_core.window->SetClearColour(skyColour);
-        if (d_cycle.IsDay()) {
-            sun.direction = d_cycle.GetSunDir();
-            sun.colour = {1.0, 0.945, 0.789};
-        }
-        else {
-            sun.direction = -d_cycle.GetSunDir();
-            sun.colour = {0.5, 0.57, 0.98};
-        }
-        sun.brightness = 2.0f * std::abs(glm::cos(d_cycle.GetAngle()));
-        sun.direction = glm::normalize(sun.direction);
+        d_cycle.OnUpdate(dt);
     }
+    
+    auto& sun = d_scene->GetSun();
+    float factor = (-d_cycle.GetSunDir().y + 1.0f) / 2.0f;
+    float facSq = factor * factor;
+    auto skyColour = (1.0f - facSq) * NAVY_NIGHT + facSq * LIGHT_BLUE;
+    d_core.window->SetClearColour(skyColour);
+    if (d_cycle.IsDay()) {
+        sun.direction = d_cycle.GetSunDir();
+        sun.colour = {1.0, 0.945, 0.789};
+    }
+    else {
+        sun.direction = -d_cycle.GetSunDir();
+        sun.colour = {0.5, 0.57, 0.98};
+    }
+    sun.brightness = 2.0f * std::abs(glm::cos(d_cycle.GetAngle()));
+    sun.direction = glm::normalize(sun.direction);
 
     d_scene->OnUpdate(dt, !d_paused);
 

--- a/Game/WorldLayer.cpp
+++ b/Game/WorldLayer.cpp
@@ -165,10 +165,10 @@ void WorldLayer::OnUpdate(double dt)
             sun.colour = {0.5, 0.57, 0.98};
         }
         sun.brightness = 2.0f * std::abs(glm::cos(d_cycle.GetAngle()));
-
         sun.direction = glm::normalize(sun.direction);
-        d_scene->OnUpdate(dt);
     }
+
+    d_scene->OnUpdate(dt, !d_paused);
 
     // Create the Shadow Map
     float lambda = 5.0f; // TODO: Calculate the floor intersection point

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -11,7 +11,7 @@ end
 function OnUpdate(entity, dt)
     TIME = TIME + dt
 
-    local rotateSpeed = 0.01
+    local rotateSpeed = 0.001
 
     local dx = 0
     local dy = 0

--- a/Resources/Shaders/Entity_PBR_Static.vert
+++ b/Resources/Shaders/Entity_PBR_Static.vert
@@ -1,11 +1,13 @@
 #version 450 core
 
-layout(location = 0) in vec3 position;
+layout(location = 0) in vec3 position; // vertex position in model space
 layout(location = 1) in vec2 texture_coords;
 layout(location = 2) in vec3 normal;
 layout(location = 3) in vec3 tangent;
 layout(location = 4) in vec3 bitangent;
 
+// Model Matrix
+// Variables needed to calculate the matrix that converts from model space to world space
 layout(location = 5) in vec3 model_position;
 layout(location = 6) in vec4 model_orientation;
 layout(location = 7) in vec3 model_scale;
@@ -15,10 +17,12 @@ out Data
     vec3 world_position;
     vec2 texture_coords;
 
+    // Tangent space unit vectors in world space
     vec3 world_normal;
     vec3 world_tangent;
     vec3 world_bitangent;
 
+    // Tangent space unit vectors in model space
     vec3 normal;
     vec3 tangent;
     vec3 bitangent;

--- a/Runtime/Console.cpp
+++ b/Runtime/Console.cpp
@@ -25,6 +25,23 @@ Console::Console(Window* window)
 void Console::OnUpdate(double dt)
 {
     d_ui.OnUpdate(dt);
+}
+
+void Console::OnEvent(Event& event)
+{
+    auto e = event.As<KeyboardButtonPressedEvent>();
+    if (e && e->Key() == Keyboard::ENTER) {
+        d_consoleLines.push_front({d_commandLine, glm::vec4{1.0, 1.0, 1.0, 1.0}});
+        HandleCommand(d_commandLine);
+        d_commandLine = "";
+        e->Consume();
+    } else {
+        d_ui.OnEvent(event);
+    }
+}
+
+void Console::Draw()
+{
     d_ui.StartFrame();
 
     double W = 0.8 * d_window->Width() - 20;
@@ -45,23 +62,6 @@ void Console::OnUpdate(double dt)
     }
 
     d_ui.EndPanel();
-}
-
-void Console::OnEvent(Event& event)
-{
-    auto e = event.As<KeyboardButtonPressedEvent>();
-    if (e && e->Key() == Keyboard::ENTER) {
-        d_consoleLines.push_front({d_commandLine, glm::vec4{1.0, 1.0, 1.0, 1.0}});
-        HandleCommand(d_commandLine);
-        d_commandLine = "";
-        e->Consume();
-    } else {
-        d_ui.OnEvent(event);
-    }
-}
-
-void Console::Draw()
-{
     d_ui.EndFrame();
 }
 

--- a/Runtime/EditorLayer.cpp
+++ b/Runtime/EditorLayer.cpp
@@ -62,18 +62,23 @@ void EditorLayer::OnUpdate(double dt)
     if (d_consoleActive) {
         d_console.OnUpdate(dt);
     } else {
-        d_scene->OnUpdate(dt);
         d_particleManager.OnUpdate(dt);
     }
     
+    d_scene->OnUpdate(dt, !d_consoleActive);
     d_scene->Each<TransformComponent>([&](Entity& entity) {
         auto& transform = entity.Get<TransformComponent>();
         if (transform.position.y < -50) {
             entity.Kill();
         }
     });
+    
     d_skyboxRenderer.Draw(d_skybox, d_runtimeCamera);
     d_entityRenderer.Draw(d_runtimeCamera, *d_scene);
+
+    if (d_consoleActive) {
+        d_console.Draw();
+    }
 }
 
 }

--- a/Runtime/EditorLayer.cpp
+++ b/Runtime/EditorLayer.cpp
@@ -2,6 +2,11 @@
 
 namespace Sprocket {
 
+const auto LIGHT_BLUE  = Sprocket::FromHex(0x25CCF7);
+const auto CLEAR_BLUE  = Sprocket::FromHex(0x1B9CFC);
+const auto GARDEN      = Sprocket::FromHex(0x55E6C1);
+const auto SPACE_DARK  = Sprocket::FromHex(0x2C3A47);
+
 EditorLayer::EditorLayer(const CoreSystems& core) 
     : d_core(core)
     , d_entityRenderer(core.assetManager)
@@ -46,10 +51,8 @@ void EditorLayer::OnEvent(Event& event)
     if (d_consoleActive) {
         d_console.OnEvent(event);
         event.Consume();
-    } else {
-        d_scene->OnEvent(event);
     }
-
+    d_scene->OnEvent(event);
 }
 
 void EditorLayer::OnUpdate(double dt)
@@ -71,8 +74,6 @@ void EditorLayer::OnUpdate(double dt)
     });
     d_skyboxRenderer.Draw(d_skybox, d_runtimeCamera);
     d_entityRenderer.Draw(d_runtimeCamera, *d_scene);
-
-    if (d_consoleActive) { d_console.Draw(); }
 }
 
 }

--- a/Sprocket/Graphics/Mesh.cpp
+++ b/Sprocket/Graphics/Mesh.cpp
@@ -134,12 +134,7 @@ bool IsBone(const Skeleton& skeleton, const aiNode* node)
     return it != skeleton.boneMap.end();
 }
 
-void LoadAnimations(
-    Skeleton& skeleton,
-    Bone* bone,
-    const aiScene* scene,
-    const glm::mat4& transform
-)
+void LoadAnimations(Skeleton& skeleton, Bone* bone, const aiScene* scene, const glm::mat4& transform)
 {
     assert(bone);
     for (u32 i = 0; i != scene->mNumAnimations; ++i) {

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -17,8 +17,8 @@ public:
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
     
-    virtual void OnUpdate(Scene& scene, double dt) {};
-        // Called every tick of the game loop.
+    virtual void OnUpdate(Scene& scene, double dt, bool active) {};
+        // Called every tick of the game loop. If active is false, the scene is "paused".
 
     virtual void OnEvent(Scene& scene, Event& event) {};
         // Called with every event so systems can consume them.

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -38,7 +38,7 @@ void Scene::OnStartup()
     }
 }
 
-void Scene::OnUpdate(double dt)
+void Scene::OnUpdate(double dt, bool active)
 {
     d_sinceLastSort += dt;
     if (d_sinceLastSort > 5.0) {
@@ -49,7 +49,7 @@ void Scene::OnUpdate(double dt)
     }
 
     for (auto system : d_systems) {
-        system->OnUpdate(*this, dt);
+        system->OnUpdate(*this, dt, active);
     }
 }
 

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -66,7 +66,7 @@ public:
     void ClearSystems();
 
     void OnStartup();
-    void OnUpdate(double dt);
+    void OnUpdate(double dt, bool active);
     void OnEvent(Event& event);
 
     std::size_t Size() const;

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -5,8 +5,10 @@
 
 namespace Sprocket {
 
-void AnimationSystem::OnUpdate(Scene& scene, double dt)
+void AnimationSystem::OnUpdate(Scene& scene, double dt, bool active)
 {
+    if (!active) { return; }
+    
     scene.Each<AnimationComponent>([dt](Entity& entity) {
         auto& ac = entity.Get<AnimationComponent>();
         ac.time += (float)dt * ac.speed;

--- a/Sprocket/Scene/Systems/AnimationSystem.h
+++ b/Sprocket/Scene/Systems/AnimationSystem.h
@@ -6,7 +6,7 @@ namespace Sprocket {
 class AnimationSystem : public EntitySystem
 {
 public:
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -77,8 +77,10 @@ void GameGrid::OnStartup(Scene& scene)
     });
 }
 
-void GameGrid::OnUpdate(Sprocket::Scene&, double)
+void GameGrid::OnUpdate(Sprocket::Scene&, double dt, bool active)
 {
+    if (!active) { return; }
+    
     auto& camTr = d_camera.Get<TransformComponent>();
 
     d_mouse.OnUpdate();

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -37,7 +37,7 @@ public:
     GameGrid(Window* window);
 
     void OnStartup(Scene& scene) override;
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
     void OnEvent(Scene& scene, Event& event) override;
 
     Entity At(int x, int z) const;

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -9,8 +9,10 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 {
 }
 
-void ParticleSystem::OnUpdate(Scene& scene, double dt)
+void ParticleSystem::OnUpdate(Scene& scene, double dt, bool active)
 {
+    if (!active) { return; }
+    
     scene.Each<TransformComponent, ParticleComponent>([&](Entity& entity) {
         auto& tc = entity.Get<TransformComponent>();
         auto& pc = entity.Get<ParticleComponent>();

--- a/Sprocket/Scene/Systems/ParticleSystem.h
+++ b/Sprocket/Scene/Systems/ParticleSystem.h
@@ -12,7 +12,7 @@ class ParticleSystem : public EntitySystem
 public:
     ParticleSystem(ParticleManager* manager);
     
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -4,8 +4,10 @@
 
 namespace Sprocket {
 
-void PathFollower::OnUpdate(Sprocket::Scene& scene, double dt)
+void PathFollower::OnUpdate(Sprocket::Scene& scene, double dt, bool active)
 {
+    if (!active) { return; }
+    
     scene.Each<TransformComponent, PathComponent>([&](Entity& entity) {
         auto& transform = entity.Get<TransformComponent>();
         auto& path = entity.Get<PathComponent>();

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class PathFollower : public EntitySystem
 {
 public:
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
         // Called once per entity per frame and before the system updates.
 };
 

--- a/Sprocket/Scene/Systems/PhysicsEngine.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine.cpp
@@ -232,8 +232,10 @@ void PhysicsEngine::OnStartup(Scene& scene)
     });
 }
 
-void PhysicsEngine::OnUpdate(Scene& scene, double dt)
+void PhysicsEngine::OnUpdate(Scene& scene, double dt, bool active)
 {
+    if (!active) { return; }
+    
     // Pre Update
     // Do this even if not running so that the physics engine stays up
     // to date with the scene.

--- a/Sprocket/Scene/Systems/PhysicsEngine.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine.h
@@ -31,7 +31,7 @@ public:
     ~PhysicsEngine() {}
 
     void OnStartup(Scene& scene) override;
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
 
     void Running(bool isRunning);
     bool Running() const { return d_running; }

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -36,9 +36,12 @@ void ScriptRunner::OnStartup(Scene& scene)
     });
 }
 
-void ScriptRunner::OnUpdate(Scene& scene, double dt)
+void ScriptRunner::OnUpdate(Scene& scene, double dt, bool active)
 {
+    // Always update the mouse even if inactive so that mouse offsets stay correct.
     d_mouse.OnUpdate();
+
+    if (!active) { return; }
 
     scene.Each<ScriptComponent>([&](Entity& entity) {
         auto& luaEngine = d_engines[entity.Id()];

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -19,7 +19,7 @@ public:
     ScriptRunner();
 
     void OnStartup(Scene& scene) override;
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
     void OnEvent(Scene& scene, Event& event) override;
 };
 

--- a/Sprocket/Scene/Systems/Selector.cpp
+++ b/Sprocket/Scene/Systems/Selector.cpp
@@ -23,14 +23,15 @@ void Selector::OnStartup(Scene& manager)
     });
 }
 
-void Selector::OnUpdate(Scene& manager, double dt)
+void Selector::OnUpdate(Scene& manager, double dt, bool active)
 {
+    d_mouse.OnUpdate();
+    if (!active) { return; }
+
     if (!d_enabled) {
         ClearHovered();
         ClearSelected();
     }
-
-    d_mouse.OnUpdate();
 }
 
 void Selector::OnEvent(Scene& scene, Event& event)

--- a/Sprocket/Scene/Systems/Selector.h
+++ b/Sprocket/Scene/Systems/Selector.h
@@ -40,7 +40,7 @@ public:
     ~Selector() {}
 
     void OnStartup(Scene& scene) override;
-    void OnUpdate(Scene& scene, double dt) override;
+    void OnUpdate(Scene& scene, double dt, bool active) override;
     void OnEvent(Scene& scene, Event& event) override;
 
     void Enable(bool newEnabled);

--- a/Sprocket/Utility/Printer.h
+++ b/Sprocket/Utility/Printer.h
@@ -1,3 +1,4 @@
+#include pragma once
 #include <string>
 #include <optional>
 

--- a/Sprocket/Utility/Printer.h
+++ b/Sprocket/Utility/Printer.h
@@ -1,4 +1,4 @@
-#include pragma once
+#pragma once
 #include <string>
 #include <optional>
 


### PR DESCRIPTION
Previously, we would "pause" a scene by just not calling the update function. This creates some issues, in particular if a scene system makes use of the mouse. If a scene does not get updated, then when we unpause, the mouse offset could be huge, which was causing the camera to jump when closing the console in `Runtime`. 

To fix this, we do a similar thing to what we did with events. Previously, objects would "consume" events just by not passing them on, but this also caused issues with mouse and keyboard events for disabled/paused/inactive objects. We changed events to have an `consumed` flag. Then objects would still be made aware of consumed events.

Now, Scene::OnUpdate and all system update functions receive an `active` flag, which is true if the scene is running and false if it is paused. It is up to the systems themselves to decide what to do when paused. Now, they can continue to update their internal mouse proxies without needing to update the whole system.

This change also adds some comments here and there and some code cleaning, as well as making it possible to change the time of day in `Game` from the escape menu and have it be visible without closing the menu.