### PR TITLE
Remove Entity Sorting

### DIFF
--- a/Anvil/Camera.cpp
+++ b/Anvil/Camera.cpp
@@ -6,7 +6,7 @@ namespace Sprocket {
 
 Camera::Camera(Window* window, const glm::vec3& target)
     : d_window(window)
-    , d_position({d_distance, d_absMin, 0.0})
+    , d_position()
     , d_target(target)
     , d_yaw(0.0f)
     , d_distance(8.0f)

--- a/Sprocket/Graphics/Rendering/EntityRenderer.h
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.h
@@ -12,6 +12,7 @@ namespace Sprocket {
 
 class EntityRenderer
 {
+public:
     // PBR Texture Slots
     static constexpr int ALBEDO_SLOT = 0;
     static constexpr int NORMAL_SLOT = 1;
@@ -24,6 +25,7 @@ class EntityRenderer
     // Animation Data
     static constexpr int MAX_BONES = 50;
 
+private:
     AssetManager*    d_assetManager;
     ParticleManager* d_particleManager;
 

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -40,14 +40,6 @@ void Scene::OnStartup()
 
 void Scene::OnUpdate(double dt)
 {
-    d_sinceLastSort += dt;
-    if (d_sinceLastSort > 5.0) {
-        d_registry.sort<ModelComponent>([](const auto& lhs, const auto& rhs) {
-            return lhs.mesh < rhs.mesh || (lhs.mesh == rhs.mesh && lhs.material < rhs.material);
-        });
-        d_sinceLastSort -= 5.0f;
-    }
-
     for (auto system : d_systems) {
         system->OnUpdate(*this, dt);
     }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -50,8 +50,6 @@ private:
     Sun d_sun;
     Ambience d_ambience;
 
-    double d_sinceLastSort = 0.0f;
-
     template <typename T> void OnAddCB(entt::registry& r, entt::entity e);
     template <typename T> void OnUpdateCB(entt::registry& r, entt::entity e);
     template <typename T> void OnRemoveCB(entt::registry& r, entt::entity e);


### PR DESCRIPTION
Regularly sorting the elements to optimise the rendering was poor design, as sorting can be quite inefficient, and made the renderer more complex. Instead, we can just build up a map of draw commands each frame to achieve the same with a minimal performance hit. This allows us to remove the sorting feature. The main motivation for this was so that we do not need to implement sorting in our own ECS, which will greatly simplify the design.

- Change the renderer to build up a map of draw commands. This no longer relies on the entities being sorted. This also means all frames are done in the fewest draw commands, whereas before sorting would only occur once every 5 seconds, causing new entities to be separate draw calls until then.
- Remove the sorting in `Scene`.
- Fix the initial position of the camera in `Anvil`.
- Extract material uploading into a separate function to reduce duplication.