### PR TITLE
Sprocket 2D Preparation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,6 +92,7 @@
         "matrixfunctions": "cpp",
         "polynomials": "cpp",
         "adolcforward": "cpp",
-        "clocale": "cpp"
+        "clocale": "cpp",
+        "ranges": "cpp"
     }
 }

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -48,7 +48,7 @@ Anvil::Anvil(Window* window)
     d_scene->Load(d_sceneFile);
 
     d_runtimeCamera = d_scene->Entities().Find([](ecs::Entity entity) {
-        return entity.Has<CameraComponent>();
+        return entity.Has<Camera3DComponent>();
     });
 
     d_activeScene = d_scene;
@@ -104,8 +104,8 @@ void Anvil::OnUpdate(double dt)
     }
     
     std::vector<ecs::Entity> toDelete;
-    for (auto entity : d_activeScene->Entities().View<TransformComponent>()) {
-        auto& transform = entity.Get<TransformComponent>();
+    for (auto entity : d_activeScene->Entities().View<Transform3DComponent>()) {
+        auto& transform = entity.Get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);
         }
@@ -203,7 +203,7 @@ void Anvil::OnRender()
                 Loader::Copy(&d_scene->Entities(), &d_activeScene->Entities());
 
                 d_playingGame = true;
-                d_runtimeCamera = d_activeScene->Entities().Find<CameraComponent>();
+                d_runtimeCamera = d_activeScene->Entities().Find<Camera3DComponent>();
                 d_window->SetCursorVisibility(false);
             }
             ImGui::EndMenu();

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -195,7 +195,7 @@ void Anvil::OnRender()
         if (ImGui::BeginMenu("Scene")) {
             if (ImGui::MenuItem("Run")) {
                 d_activeScene = std::make_shared<Scene>(); 
-                d_activeScene->Add<PhysicsEngine>();
+                d_activeScene->Add<PhysicsEngine3D>();
                 d_activeScene->Add<CameraSystem>(d_window->AspectRatio());
                 d_activeScene->Add<ScriptRunner>(d_window);
                 d_activeScene->Add<ParticleSystem>(&d_particleManager);

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -17,7 +17,7 @@ class Anvil
     Camera d_editorCamera;
 
     // Rendering
-    EntityRenderer d_entityRenderer;
+    Scene3DRenderer d_entityRenderer;
     SkyboxRenderer d_skyboxRenderer;
     ColliderRenderer d_colliderRenderer;
 

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -14,7 +14,7 @@ namespace {
 
 void ShowGuizmo(
     Anvil& editor,
-    TransformComponent& c,
+    Transform3DComponent& c,
     ImGuizmo::OPERATION mode,
     ImGuizmo::MODE coords,
     glm::vec3* snap = nullptr)
@@ -73,18 +73,32 @@ void Inspector::Show(Anvil& editor)
         
     }
 
-    if (entity.Has<TransformComponent>()) {
-        auto& c = entity.Get<TransformComponent>();
-        if (ImGui::CollapsingHeader("Transform")) {
+    if (entity.Has<Transform2DComponent>()) {
+        auto& c = entity.Get<Transform2DComponent>();
+        if (ImGui::CollapsingHeader("Transform 2D")) {
+            ImGui::PushID(count++);
+            ImGui::DragFloat2("Position", &c.position.x, 0.1f);
+            ImGui::DragFloat("Rotation", &c.rotation, 0.01f);
+            ImGui::DragFloat2("Scale", &c.scale.x, 0.1f);
+            
+            if (ImGui::Button("Delete")) { entity.Remove<Transform2DComponent>(); }
+            ImGui::PopID();
+        }
+        
+    }
+
+    if (entity.Has<Transform3DComponent>()) {
+        auto& c = entity.Get<Transform3DComponent>();
+        if (ImGui::CollapsingHeader("Transform 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
             ImGuiXtra::Euler("Orientation", &c.orientation);
             ImGui::DragFloat3("Scale", &c.scale.x, 0.1f);
-            ImGuiXtra::GuizmoSettings(d_mode, d_coords, d_useSnap, d_snap);
-            if (ImGui::Button("Delete")) { entity.Remove<TransformComponent>(); }
+            
+            if (ImGui::Button("Delete")) { entity.Remove<Transform3DComponent>(); }
             ImGui::PopID();
         }
-        ShowGuizmo(editor, c, d_mode, d_coords, d_useSnap ? &d_snap : nullptr);
+        
     }
 
     if (entity.Has<ModelComponent>()) {
@@ -179,15 +193,15 @@ void Inspector::Show(Anvil& editor)
         
     }
 
-    if (entity.Has<CameraComponent>()) {
-        auto& c = entity.Get<CameraComponent>();
-        if (ImGui::CollapsingHeader("Camera")) {
+    if (entity.Has<Camera3DComponent>()) {
+        auto& c = entity.Get<Camera3DComponent>();
+        if (ImGui::CollapsingHeader("Camera 3D")) {
             ImGui::PushID(count++);
             ;
             ImGui::DragFloat("FOV", &c.fov, 0.01f);
             ImGui::DragFloat("Pitch", &c.pitch, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<CameraComponent>(); }
+            if (ImGui::Button("Delete")) { entity.Remove<Camera3DComponent>(); }
             ImGui::PopID();
         }
         
@@ -291,15 +305,15 @@ void Inspector::Show(Anvil& editor)
         
     }
 
-    if (entity.Has<AnimationComponent>()) {
-        auto& c = entity.Get<AnimationComponent>();
-        if (ImGui::CollapsingHeader("Animation")) {
+    if (entity.Has<MeshAnimationComponent>()) {
+        auto& c = entity.Get<MeshAnimationComponent>();
+        if (ImGui::CollapsingHeader("Mesh Animation")) {
             ImGui::PushID(count++);
             ImGuiXtra::TextModifiable(c.name);
             ImGui::DragFloat("Time", &c.time, 0.01f);
             ImGui::DragFloat("Speed", &c.speed, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<AnimationComponent>(); }
+            if (ImGui::Button("Delete")) { entity.Remove<MeshAnimationComponent>(); }
             ImGui::PopID();
         }
         
@@ -320,9 +334,13 @@ void Inspector::Show(Anvil& editor)
             NameComponent c;
             entity.Add<NameComponent>(c);
         }
-        if (!entity.Has<TransformComponent>() && ImGui::Selectable("Transform")) {
-            TransformComponent c;
-            entity.Add<TransformComponent>(c);
+        if (!entity.Has<Transform2DComponent>() && ImGui::Selectable("Transform 2D")) {
+            Transform2DComponent c;
+            entity.Add<Transform2DComponent>(c);
+        }
+        if (!entity.Has<Transform3DComponent>() && ImGui::Selectable("Transform 3D")) {
+            Transform3DComponent c;
+            entity.Add<Transform3DComponent>(c);
         }
         if (!entity.Has<ModelComponent>() && ImGui::Selectable("Model")) {
             ModelComponent c;
@@ -348,9 +366,9 @@ void Inspector::Show(Anvil& editor)
             ScriptComponent c;
             entity.Add<ScriptComponent>(c);
         }
-        if (!entity.Has<CameraComponent>() && ImGui::Selectable("Camera")) {
-            CameraComponent c;
-            entity.Add<CameraComponent>(c);
+        if (!entity.Has<Camera3DComponent>() && ImGui::Selectable("Camera 3D")) {
+            Camera3DComponent c;
+            entity.Add<Camera3DComponent>(c);
         }
         if (!entity.Has<SelectComponent>() && ImGui::Selectable("Select")) {
             SelectComponent c;
@@ -380,9 +398,9 @@ void Inspector::Show(Anvil& editor)
             ParticleComponent c;
             entity.Add<ParticleComponent>(c);
         }
-        if (!entity.Has<AnimationComponent>() && ImGui::Selectable("Animation")) {
-            AnimationComponent c;
-            entity.Add<AnimationComponent>(c);
+        if (!entity.Has<MeshAnimationComponent>() && ImGui::Selectable("Mesh Animation")) {
+            MeshAnimationComponent c;
+            entity.Add<MeshAnimationComponent>(c);
         }
         ImGui::EndMenu();
     }

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -13,7 +13,7 @@ namespace {
 
 void ShowGuizmo(
     Anvil& editor,
-    TransformComponent& c,
+    Transform3DComponent& c,
     ImGuizmo::OPERATION mode,
     ImGuizmo::MODE coords,
     glm::vec3* snap = nullptr)
@@ -38,7 +38,7 @@ void ShowGuizmo(
 
 void Inspector::Show(Anvil& editor)
 {
-    ECS::Entity entity = editor.Selected();
+    ecs::Entity entity = editor.Selected();
 
     if (!editor.Selected().Valid()) {
         if (ImGui::Button("New Entity")) {
@@ -80,7 +80,7 @@ void Inspector::Show(Anvil& editor)
     }
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
-        ECS::Entity copy = Loader::Copy(&editor.GetScene()->Entities(), entity);
+        ecs::Entity copy = Loader::Copy(&editor.GetScene()->Entities(), entity);
         editor.SetSelected(copy);
     }
     if (ImGui::Button("Delete Entity")) {

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -158,7 +158,7 @@ void WorldLayer::OnEvent(Sprocket::Event& event)
     }
 
     if (auto e = event.As<MouseButtonPressedEvent>()) {
-        auto& tr = d_camera.Get<TransformComponent>();
+        auto& tr = d_camera.Get<Transform3DComponent>();
         if (e->Mods() & KeyModifier::CTRL) {
             glm::vec3 cameraPos = tr.position;
             glm::vec3 direction = Maths::GetMouseRay(
@@ -177,7 +177,7 @@ void WorldLayer::OnEvent(Sprocket::Event& event)
 
             if (e->Button() == Mouse::LEFT) {
                 std::queue<glm::vec3>().swap(path.markers);
-                auto pos = d_worker.Get<TransformComponent>().position;
+                auto pos = d_worker.Get<Transform3DComponent>().position;
                 if (glm::distance(pos, mousePos) > 1.0f) {
                     path.markers = GenerateAStarPath(
                         pos,
@@ -243,7 +243,8 @@ void WorldLayer::OnRender()
 
     // Create the Shadow Map
     float lambda = 5.0f; // TODO: Calculate the floor intersection point
-    glm::vec3 target = d_camera.Get<TransformComponent>().position + lambda * Maths::Forwards(d_camera.Get<TransformComponent>().orientation);
+    auto& tc = d_camera.Get<Transform3DComponent>();
+    glm::vec3 target = tc.position + lambda * Maths::Forwards(tc.orientation);
     d_shadowMap.Draw(
         d_scene.Entities().Find<SunComponent>().Get<SunComponent>().direction,
         target,
@@ -449,7 +450,7 @@ void WorldLayer::AddTree(const glm::ivec2& pos)
     auto& name = newEntity.Add<NameComponent>();
     name.name = "Tree";
 
-    auto& tr = newEntity.Add<TransformComponent>();
+    auto& tr = newEntity.Add<Transform3DComponent>();
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), Random(0.0f, 360.0f), {0, 1, 0});
     float r = Random(1.0f, 1.3f);
     tr.scale = {r, r, r};
@@ -474,7 +475,7 @@ void WorldLayer::AddRockBase(
     auto& n = newEntity.Add<NameComponent>();
     n.name = name;
 
-    auto& tr = newEntity.Add<TransformComponent>();
+    auto& tr = newEntity.Add<Transform3DComponent>();
     tr.position.y -= Random(0.0f, 0.5f);
     float randomRotation = glm::half_pi<float>() * Random(0, 3);
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), randomRotation, {0.0, 1.0, 0.0});

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -23,7 +23,7 @@ class WorldLayer
     Sprocket::ecs::Entity d_worker;
     
     // RENDERING
-    Sprocket::EntityRenderer  d_entityRenderer;
+    Sprocket::Scene3DRenderer  d_entityRenderer;
     Sprocket::PostProcessor   d_postProcessor;
 
     // Additional world setup

--- a/Resources/Anvil.yaml
+++ b/Resources/Anvil.yaml
@@ -14,20 +14,20 @@ Entities:
       shadows: false
   - NameComponent:
       name: Running Character
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.34701, 0.2741509, -6.543652]
       orientation: [1, 1.159412e-09, 0, 0]
       scale: [0.2210628, 0.2210639, 0.2210466]
     ModelComponent:
       mesh: D:\dev\Sprocket\Resources\Models\RunningCharacter\RunningCharacter.fbx
       material: D:\dev\Sprocket\Resources\Materials\RunningCharacter.yaml
-    AnimationComponent:
+    MeshAnimationComponent:
       name: Armature|ArmatureAction
       time: 5
       speed: 1
   - NameComponent:
       name: Bridge Thin 3
-    TransformComponent:
+    Transform3DComponent:
       position: [0, 0, 10]
       orientation: [1, 0, 0, 0]
       scale: [5, 0.948213, 0.2955239]
@@ -51,7 +51,7 @@ Entities:
       {}
   - NameComponent:
       name: Bridge Thin 2
-    TransformComponent:
+    Transform3DComponent:
       position: [0, 0, 9]
       orientation: [1, 0, 0, 0]
       scale: [5, 0.948213, 0.2955239]
@@ -75,7 +75,7 @@ Entities:
       {}
   - NameComponent:
       name: Player
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.72964, 1.646085, -0.107402]
       orientation: [0.7213101, 0, -0.6926123, 0]
       scale: [0.2999891, 0.3, 0.2999891]
@@ -98,14 +98,14 @@ Entities:
     ScriptComponent:
       script: Resources/Scripts/PlayerController.lua
       active: true
-    CameraComponent:
+    Camera3DComponent:
       fov: 70
       pitch: 0
     SelectComponent:
       {}
   - NameComponent:
       name: Bridge Thin 1
-    TransformComponent:
+    Transform3DComponent:
       position: [0, 0, 8]
       orientation: [1, 0, 0, 0]
       scale: [5, 0.948213, 0.2955239]
@@ -129,7 +129,7 @@ Entities:
       {}
   - NameComponent:
       name: Bridge Wide
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.1458986, 0.02311094, -8.724297]
       orientation: [0.7933534, 0, 0.6087613, 0]
       scale: [1.494947, 0.6160595, 6.666203]
@@ -153,7 +153,7 @@ Entities:
       {}
   - NameComponent:
       name: Platform (Angled)
-    TransformComponent:
+    Transform3DComponent:
       position: [0.001507398, 2.274611, 21.75628]
       orientation: [0.6945286, -0.1323189, 0.6947241, -0.1322128]
       scale: [0.9999771, 0.9998871, 1]
@@ -177,7 +177,7 @@ Entities:
       {}
   - NameComponent:
       name: Platform (Blue)
-    TransformComponent:
+    Transform3DComponent:
       position: [-10, 0, 0]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -201,7 +201,7 @@ Entities:
       {}
   - NameComponent:
       name: Island
-    TransformComponent:
+    Transform3DComponent:
       position: [0, -7, -30]
       orientation: [1, 0, 0, 0]
       scale: [0.5, 0.5, 0.5]
@@ -212,7 +212,7 @@ Entities:
       {}
   - NameComponent:
       name: Platform (Red)
-    TransformComponent:
+    Transform3DComponent:
       position: [10, 0, 0]
       orientation: [1, 0, 0, 0]
       scale: [1, 0.9999998, 0.9999998]
@@ -236,7 +236,7 @@ Entities:
       {}
   - NameComponent:
       name: Red Light
-    TransformComponent:
+    Transform3DComponent:
       position: [14, 5, 0]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -245,7 +245,7 @@ Entities:
       brightness: 2
   - NameComponent:
       name: Blue Light
-    TransformComponent:
+    Transform3DComponent:
       position: [-14, 5, 0]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -254,7 +254,7 @@ Entities:
       brightness: 2
   - NameComponent:
       name: Green Light
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.224496, 2.567594, -9.963178]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -263,7 +263,7 @@ Entities:
       brightness: 43.9
   - NameComponent:
       name: White Light
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.66809, 20.76288, -13.71229]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -272,7 +272,7 @@ Entities:
       brightness: 260.9
   - NameComponent:
       name: Pit Wall 4
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.48153, -0.7553417, 11.35812]
       orientation: [1, 0, 0, 0]
       scale: [5, 0.948213, 0.2955239]
@@ -296,7 +296,7 @@ Entities:
       {}
   - NameComponent:
       name: Pit Wall 3
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.48153, -0.7553417, 1.987747]
       orientation: [1, 0, 0, 0]
       scale: [5, 0.948213, 0.2955239]
@@ -320,7 +320,7 @@ Entities:
       {}
   - NameComponent:
       name: Pit Wall 2
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.76336, -0.7553418, 6.675583]
       orientation: [0.7069848, -1.843149e-11, 0.7072288, -1.843147e-11]
       scale: [4.99997, 0.948213, 0.2955132]
@@ -344,7 +344,7 @@ Entities:
       {}
   - NameComponent:
       name: Pit Wall 1
-    TransformComponent:
+    Transform3DComponent:
       position: [-27.19478, -0.7553418, 6.675583]
       orientation: [0.7069848, -1.843149e-11, 0.7072288, -1.843147e-11]
       scale: [4.99997, 0.948213, 0.2955132]
@@ -368,7 +368,7 @@ Entities:
       {}
   - NameComponent:
       name: Pit Floor
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.48153, -1.756183, 6.635912]
       orientation: [1, 0, 0, 0]
       scale: [4.8, 0.3, 4.8]
@@ -392,7 +392,7 @@ Entities:
       {}
   - NameComponent:
       name: Pit Crate
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.92559, -1.5, 10.18482]
       orientation: [0.9999999, 0, -0.0002423458, 0]
       scale: [1.107292, 1.107288, 1.107292]
@@ -416,7 +416,7 @@ Entities:
       {}
   - NameComponent:
       name: Sphere (Particles)
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.352023, 2.686497, 12.41776]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -446,7 +446,7 @@ Entities:
       life: 60.5
   - NameComponent:
       name: Sphere (No Particles)
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.44487, 2.686496, 12.44196]
       orientation: [1, 0, 0, 0]
       scale: [1, 1, 1]
@@ -469,7 +469,7 @@ Entities:
       {}
   - NameComponent:
       name: Tree Small
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.01267, 0.3019291, -13.35674]
       orientation: [0.9726272, 0, 0.2323713, 0]
       scale: [3.049998, 3.05, 3.049998]
@@ -491,7 +491,7 @@ Entities:
       applyScale: true
   - NameComponent:
       name: Tree Large
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.764427, 0.301929, -26.94802]
       orientation: [0.9677961, 0, 0.2517355, 0]
       scale: [4.208998, 4.209, 4.208998]
@@ -500,7 +500,7 @@ Entities:
       material: Resources/Materials/tree.yaml
   - NameComponent:
       name: Pistol
-    TransformComponent:
+    Transform3DComponent:
       position: [7.777368, 2.526275, -10.93738]
       orientation: [0.6755896, -0.7372779, 0, 0]
       scale: [0.02989681, 0.02989674, 0.02989682]
@@ -527,7 +527,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.08163, 1.329976, -4.062364]
       orientation: [0.9973543, 0, -0.07269317, 0]
       scale: [1.107289, 1.107288, 1.107289]
@@ -551,7 +551,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Upper
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.50688, 2.658418, -6.193301]
       orientation: [0.9678881, 0, -0.2513813, 0]
       scale: [1.107289, 1.107288, 1.107289]
@@ -575,7 +575,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.520597, 3.294004, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -599,7 +599,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.520597, 4.494779, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -623,7 +623,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.648428, 5.646762, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -647,7 +647,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.850865, 5.689884, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -671,7 +671,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.850865, 4.496203, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -695,7 +695,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.850865, 3.253146, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -719,7 +719,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.13275, 3.253146, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -743,7 +743,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.13275, 4.474674, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]
@@ -767,7 +767,7 @@ Entities:
       {}
   - NameComponent:
       name: Crate Lower
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.982604, 5.576144, -4.062364]
       orientation: [1, 0, 0, 0]
       scale: [0.5204259, 0.5204254, 0.5204259]

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -7,7 +7,7 @@ Entities:
       brightness: 0.01
   - NameComponent:
       name: Sun
-    TransformComponent:
+    Transform3DComponent:
       position: [0, 0, 0]
       orientation: [0, 0, 0, 1]
       scale: [1, 1, 1]
@@ -18,7 +18,7 @@ Entities:
       shadows: true
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.4787534, 12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -32,7 +32,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, 0, -1.5]
       orientation: [-0.5364246, 0, 0.8439482, 0]
       scale: [1.040643, 1.040643, 1.040643]
@@ -46,7 +46,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, 0, 14.5]
       orientation: [0.7897523, 0, 0.6134259, 0]
       scale: [1.229655, 1.229655, 1.229655]
@@ -60,7 +60,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, 0, 11.5]
       orientation: [0.9227979, 0, 0.3852844, 0]
       scale: [1.114468, 1.114468, 1.114468]
@@ -74,7 +74,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, 0, 20.5]
       orientation: [-0.4916484, 0, 0.8707938, 0]
       scale: [1.131623, 1.131623, 1.131623]
@@ -88,7 +88,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, 0, 14.5]
       orientation: [0.0295611, 0, 0.999563, 0]
       scale: [1.010334, 1.010334, 1.010334]
@@ -102,7 +102,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, 0, 21.5]
       orientation: [-0.7369825, 0, 0.6759118, 0]
       scale: [1.285067, 1.285067, 1.285067]
@@ -116,7 +116,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1585497, 15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -130,7 +130,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.06259138, 11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -144,7 +144,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.3474143, 11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -158,7 +158,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.4109516, 11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -172,7 +172,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.4117289, 11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -186,7 +186,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.4970343, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -200,7 +200,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.04856589, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -214,7 +214,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.07455699, 19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -228,7 +228,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.02308569, 21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -242,7 +242,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.4362144, 15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -256,7 +256,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1384615, 18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -270,7 +270,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1582752, 19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -284,7 +284,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.01591642, 19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -298,7 +298,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.3393676, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -312,7 +312,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.3406798, 21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -326,7 +326,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.4669966, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -340,7 +340,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1059622, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -354,7 +354,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.4245647, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -368,7 +368,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.180647, 19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -382,7 +382,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.01785584, 20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -396,7 +396,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.2518314, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -410,7 +410,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.4797462, 20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -424,7 +424,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.4392153, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -438,7 +438,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.3961037, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -452,7 +452,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.3198817, 20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -466,7 +466,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.4578678, 20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -480,7 +480,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.05623226, 19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -494,7 +494,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.2108806, 18.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -508,7 +508,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.002391742, 17.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -522,7 +522,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.07094317, 16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -536,7 +536,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.1485147, 16.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -550,7 +550,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.4001402, 18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -564,7 +564,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.3990529, 18.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -578,7 +578,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.2426878, 18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -592,7 +592,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.05493088, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -606,7 +606,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4785835, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -620,7 +620,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4905548, 18.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -634,7 +634,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4852964, 17.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -648,7 +648,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.3629195, 16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -662,7 +662,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.07880654, 16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -676,7 +676,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.4964406, 16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -690,7 +690,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.2734407, 16.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -704,7 +704,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.09419098, 16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -718,7 +718,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.1392491, 15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -732,7 +732,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.2736103, 14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -746,7 +746,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.0487702, 13.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -760,7 +760,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.1540835, 12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -774,7 +774,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.3161796, 12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -788,7 +788,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.110517, 12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -802,7 +802,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.4566879, 12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -816,7 +816,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4844339, 12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -830,7 +830,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.06349341, 12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -844,7 +844,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.4175043, 14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -858,7 +858,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.452896, 14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -872,7 +872,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.0677385, 14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -886,7 +886,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.3990529, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -900,7 +900,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.4073618, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -914,7 +914,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4838475, 15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -928,7 +928,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4073618, 14.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -942,7 +942,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, 0, -0.5]
       orientation: [-0.8686448, 0, 0.4954354, 0]
       scale: [1.038096, 1.038096, 1.038096]
@@ -956,7 +956,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.4844339, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -970,7 +970,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Worker
-    TransformComponent:
+    Transform3DComponent:
       position: [7.640841, 0.5, -3.894935]
       orientation: [1, 0, 0, 0]
       scale: [0.5, 0.5, 0.5]
@@ -983,7 +983,7 @@ Entities:
       speed: 3
   - NameComponent:
       name: Camera
-    TransformComponent:
+    Transform3DComponent:
       position: [2.77499, 7.343201, 12.0269]
       orientation: [0.8874592, -0.3455494, 0.2841952, 0.1106569]
       scale: [1, 1, 1]
@@ -995,7 +995,7 @@ Entities:
       pitch: 0
   - NameComponent:
       name: Terrain
-    TransformComponent:
+    Transform3DComponent:
       position: [0, 0, 0]
       orientation: [1, 0, 0, 0]
       scale: [25, 25, 25]
@@ -1006,7 +1006,7 @@ Entities:
       {}
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4073618, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1020,7 +1020,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.0677385, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1034,7 +1034,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.452896, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1048,7 +1048,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4175043, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1062,7 +1062,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.06349341, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1076,7 +1076,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4844339, -19.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1090,7 +1090,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4566879, -18.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1104,7 +1104,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.110517, -17.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1118,7 +1118,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3161796, -16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1132,7 +1132,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.1540835, -15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1146,7 +1146,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.0487702, -14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1160,7 +1160,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.2736103, -13.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1174,7 +1174,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.1392491, -12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1188,7 +1188,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.09419098, -11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1202,7 +1202,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.2734407, -10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1216,7 +1216,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4964406, -9.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1230,7 +1230,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4787534, -8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1244,7 +1244,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4982307, -7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1258,7 +1258,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4824443, -6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1272,7 +1272,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4838475, -5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1286,7 +1286,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.07880654, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1300,7 +1300,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3629195, -3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1314,7 +1314,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4852964, -2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1328,7 +1328,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4905548, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1342,7 +1342,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4785835, -0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1356,7 +1356,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.05493088, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1370,7 +1370,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.2426878, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1384,7 +1384,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3990529, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1398,7 +1398,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4001402, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1412,7 +1412,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.1485147, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1426,7 +1426,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.07094317, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1440,7 +1440,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.002391742, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1454,7 +1454,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.2108806, 7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1468,7 +1468,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.05623226, 8.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1482,7 +1482,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4578678, 9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1496,7 +1496,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3198817, 10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1510,7 +1510,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3961037, 11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1524,7 +1524,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4392153, 12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1538,7 +1538,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4797462, 13.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1552,7 +1552,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.2518314, 14.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1566,7 +1566,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3278703, 15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1580,7 +1580,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3989643, 16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1594,7 +1594,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.01785584, 17.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1608,7 +1608,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.180647, 18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1622,7 +1622,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4245647, 19.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1636,7 +1636,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.1059622, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1650,7 +1650,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.4669966, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1664,7 +1664,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3406798, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1678,7 +1678,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.3393676, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1692,7 +1692,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-24.5, -0.1993693, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1706,7 +1706,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3788701, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1720,7 +1720,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3703236, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1734,7 +1734,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3715662, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1748,7 +1748,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2373793, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1762,7 +1762,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1961135, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1776,7 +1776,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2110438, -19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1790,7 +1790,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3277389, -18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1804,7 +1804,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.08693258, -17.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1818,7 +1818,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.08559334, -16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1832,7 +1832,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1509566, -15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1846,7 +1846,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3530231, -14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1860,7 +1860,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3986399, -13.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1874,7 +1874,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.01591642, -12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1888,7 +1888,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1582752, -11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1902,7 +1902,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1384615, -10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1916,7 +1916,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.4362144, -9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1930,7 +1930,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.02308569, -8.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1944,7 +1944,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.07455699, -7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1958,7 +1958,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.04856589, -6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1972,7 +1972,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.4970343, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -1986,7 +1986,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.4117289, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2000,7 +2000,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.4109516, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2014,7 +2014,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3474143, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2028,7 +2028,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.06259138, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2042,7 +2042,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1585497, -0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2056,7 +2056,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.381875, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2070,7 +2070,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.475111, 1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2084,7 +2084,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2452945, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2098,7 +2098,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.01722304, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2112,7 +2112,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3318028, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2126,7 +2126,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2193722, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2140,7 +2140,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.06294832, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2154,7 +2154,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1907792, 7.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2168,7 +2168,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.1051045, 8.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2182,7 +2182,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3827584, 9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2196,7 +2196,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.02560821, 10.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2210,7 +2210,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3976, 11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2224,7 +2224,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.01822063, 12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2238,7 +2238,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.0934363, 13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2252,7 +2252,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2043656, 16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2266,7 +2266,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2448822, 17.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2280,7 +2280,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2289946, 18.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2294,7 +2294,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2227931, 19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2308,7 +2308,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.2437845, 20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2322,7 +2322,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3231565, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2336,7 +2336,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3969875, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2350,7 +2350,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.3546824, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2364,7 +2364,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-23.5, -0.4604374, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2378,7 +2378,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3773433, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2392,7 +2392,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4037655, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2406,7 +2406,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.1380125, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2420,7 +2420,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3528871, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2434,7 +2434,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3398513, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2448,7 +2448,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.001409216, -19.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2462,7 +2462,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.327549, -18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2476,7 +2476,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3553519, -17.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2490,7 +2490,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.08130587, -16.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2504,7 +2504,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3219805, -15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2518,7 +2518,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.05949884, -14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2532,7 +2532,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2280164, -13.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2546,7 +2546,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.249182, -12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2560,7 +2560,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3869586, -11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2574,7 +2574,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.479872, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2588,7 +2588,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2868773, -4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2602,7 +2602,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.1701929, -3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2616,7 +2616,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4383787, -2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2630,7 +2630,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2926339, -1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2644,7 +2644,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4040878, -0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2658,7 +2658,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.111906, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2672,7 +2672,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.008886948, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2686,7 +2686,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3756335, 2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2700,7 +2700,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.410623, 3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2714,7 +2714,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.1275476, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2728,7 +2728,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4104204, 5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2742,7 +2742,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2529785, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2756,7 +2756,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.470037, 7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2770,7 +2770,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3495384, 8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2784,7 +2784,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2063333, 9.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2798,7 +2798,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4454516, 10.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2812,7 +2812,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2115826, 11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2826,7 +2826,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.4796457, 17.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2840,7 +2840,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2904783, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2854,7 +2854,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.2736078, 19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2868,7 +2868,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.07902879, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2882,7 +2882,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.06931222, 21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2896,7 +2896,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.3808656, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2910,7 +2910,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.074647, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2924,7 +2924,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-22.5, -0.115078, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2938,7 +2938,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1287541, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2952,7 +2952,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4048673, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2966,7 +2966,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4203586, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2980,7 +2980,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4942608, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -2994,7 +2994,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1271411, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3008,7 +3008,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1662241, -19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3022,7 +3022,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4071424, -18.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3036,7 +3036,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1499159, -17.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3050,7 +3050,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1217625, -16.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3064,7 +3064,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.006769563, -15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3078,7 +3078,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4646318, -1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3092,7 +3092,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1086189, -0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3106,7 +3106,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1749919, 0.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3120,7 +3120,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4536824, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3134,7 +3134,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.09829763, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3148,7 +3148,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4242339, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3162,7 +3162,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1255419, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3176,7 +3176,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4775088, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3190,7 +3190,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.3080224, 8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3204,7 +3204,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.3894489, 9.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3218,7 +3218,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.2366444, 20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3232,7 +3232,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4937298, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3246,7 +3246,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.1758298, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3260,7 +3260,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.03379769, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3274,7 +3274,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-21.5, -0.4154143, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3288,7 +3288,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.3967988, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3302,7 +3302,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.292632, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3316,7 +3316,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.2972518, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3330,7 +3330,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.2748618, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3344,7 +3344,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.3663993, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3358,7 +3358,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.4585968, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3372,7 +3372,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-20.5, -0.3476164, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3386,7 +3386,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.1429195, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3400,7 +3400,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.3399099, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3414,7 +3414,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.3786001, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3428,7 +3428,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.1961602, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3442,7 +3442,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, 0, -6.5]
       orientation: [-0.7153419, 0, 0.6987746, 0]
       scale: [1.168467, 1.168467, 1.168467]
@@ -3456,7 +3456,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.1902229, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3470,7 +3470,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.104034, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3484,7 +3484,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, 0, 3.5]
       orientation: [-0.2114594, 0, 0.9773868, 0]
       scale: [1.158211, 1.158211, 1.158211]
@@ -3498,7 +3498,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.03792715, 9.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3512,7 +3512,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.2021043, 10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3526,7 +3526,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, 0, 11.5]
       orientation: [0.985671, 0, 0.168679, 0]
       scale: [1.105829, 1.105829, 1.105829]
@@ -3540,7 +3540,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.2653988, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3554,7 +3554,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.2964119, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3568,7 +3568,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.3895836, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3582,7 +3582,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-19.5, -0.1781726, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3596,7 +3596,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.4670053, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3610,7 +3610,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.4824832, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3624,7 +3624,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.0649531, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3638,7 +3638,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.07721921, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3652,7 +3652,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.2844118, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3666,7 +3666,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.1974541, -7.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3680,7 +3680,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.2346953, -6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3694,7 +3694,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.193648, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3708,7 +3708,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, 0, -0.5]
       orientation: [0.999301, 0, 0.03738274, 0]
       scale: [1.218086, 1.218086, 1.218086]
@@ -3722,7 +3722,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.1685613, 2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3736,7 +3736,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.1942849, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3750,7 +3750,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.08109115, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3764,7 +3764,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.4637464, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3778,7 +3778,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.3971423, 6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3792,7 +3792,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.2180588, 7.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3806,7 +3806,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.1556075, 8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3820,7 +3820,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.4313391, 9.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3834,7 +3834,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.2642666, 13.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3848,7 +3848,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.31018, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3862,7 +3862,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.08282436, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3876,7 +3876,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.05977359, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3890,7 +3890,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-18.5, -0.300991, 24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3904,7 +3904,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.2359784, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3918,7 +3918,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.1314856, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3932,7 +3932,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.1701099, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3946,7 +3946,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.3270395, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3960,7 +3960,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.264921, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3974,7 +3974,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.3446073, -3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -3988,7 +3988,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.3580503, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4002,7 +4002,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.3740758, -1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4016,7 +4016,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.4941897, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4030,7 +4030,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.2252708, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4044,7 +4044,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.3602467, 1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4058,7 +4058,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.04191069, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4072,7 +4072,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.4562888, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4086,7 +4086,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.1144885, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4100,7 +4100,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.2527493, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4114,7 +4114,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.4566687, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4128,7 +4128,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.2791344, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4142,7 +4142,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.07618901, 10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4156,7 +4156,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.251595, 11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4170,7 +4170,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, 0, 15.5]
       orientation: [-0.8539785, 0, 0.5203084, 0]
       scale: [1.138742, 1.138742, 1.138742]
@@ -4184,7 +4184,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.2691712, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4198,7 +4198,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.273296, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4212,7 +4212,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-17.5, -0.4980673, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4226,7 +4226,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.2237922, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4240,7 +4240,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.03908776, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4254,7 +4254,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4272255, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4268,7 +4268,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.2213391, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4282,7 +4282,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.3021157, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4296,7 +4296,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, 0, -6.5]
       orientation: [0.9443907, 0, 0.3288254, 0]
       scale: [1.149563, 1.149563, 1.149563]
@@ -4310,7 +4310,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.480949, -5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4324,7 +4324,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4899628, -4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4338,7 +4338,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.002317113, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4352,7 +4352,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.01715866, -2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4366,7 +4366,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.3874552, -1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4380,7 +4380,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.488501, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4394,7 +4394,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4086516, 0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4408,7 +4408,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.1815932, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4422,7 +4422,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4343474, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4436,7 +4436,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.3397599, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4450,7 +4450,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.04221793, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4464,7 +4464,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, 0, 9.5]
       orientation: [0.4645019, 0, 0.8855721, 0]
       scale: [1.119935, 1.119935, 1.119935]
@@ -4478,7 +4478,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4279376, 21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4492,7 +4492,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.1299352, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4506,7 +4506,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.02252977, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4520,7 +4520,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-16.5, -0.4000342, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4534,7 +4534,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.3300597, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4548,7 +4548,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.2157069, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4562,7 +4562,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.3749705, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4576,7 +4576,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.4553238, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4590,7 +4590,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.06649802, -20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4604,7 +4604,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, 0, -15.5]
       orientation: [0.8412046, 0, 0.540717, 0]
       scale: [1.294708, 1.294708, 1.294708]
@@ -4618,7 +4618,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.1319015, -8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4632,7 +4632,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.04767759, -7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4646,7 +4646,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.07276949, -6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4660,7 +4660,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.1413366, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4674,7 +4674,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.06803428, -4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4688,7 +4688,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.4010557, -3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4702,7 +4702,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.4346461, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4716,7 +4716,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.03877851, -1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4730,7 +4730,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.2898523, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4744,7 +4744,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.3136922, 0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4758,7 +4758,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.2749301, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4772,7 +4772,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.004046956, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4786,7 +4786,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.0724774, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4800,7 +4800,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.3401435, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4814,7 +4814,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-15.5, -0.4265155, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4828,7 +4828,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.2669666, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4842,7 +4842,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.3110276, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4856,7 +4856,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.2193334, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4870,7 +4870,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.1754762, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4884,7 +4884,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.0997756, -20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4898,7 +4898,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, 0, -17.5]
       orientation: [-0.04161245, 0, 0.9991338, 0]
       scale: [1.0414, 1.0414, 1.0414]
@@ -4912,7 +4912,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.200904, -16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4926,7 +4926,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.1911665, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4940,7 +4940,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.03798334, -4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4954,7 +4954,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.3812107, -3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4968,7 +4968,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.1199581, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4982,7 +4982,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.02023556, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -4996,7 +4996,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.06165947, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5010,7 +5010,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.126478, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5024,7 +5024,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-14.5, -0.0919539, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5038,7 +5038,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.2523855, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5052,7 +5052,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1199763, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5066,7 +5066,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4113025, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5080,7 +5080,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.2086335, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5094,7 +5094,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4908616, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5108,7 +5108,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.02482721, -12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5122,7 +5122,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4117277, -11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5136,7 +5136,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4513581, -10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5150,7 +5150,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1509137, -9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5164,7 +5164,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4723936, -8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5178,7 +5178,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.02397214, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5192,7 +5192,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.245432, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5206,7 +5206,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.1239238, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5220,7 +5220,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.2446263, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5234,7 +5234,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.2720281, 6.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5248,7 +5248,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.3986399, 18.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5262,7 +5262,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-13.5, -0.4438631, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5276,7 +5276,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.4500269, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5290,7 +5290,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.1719198, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5304,7 +5304,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.1846234, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5318,7 +5318,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.01663428, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5332,7 +5332,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.05560138, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5346,7 +5346,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.08143606, -15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5360,7 +5360,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.390126, -14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5374,7 +5374,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.438682, -13.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5388,7 +5388,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.1948694, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5402,7 +5402,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.1051509, -11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5416,7 +5416,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.1208456, -10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5430,7 +5430,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, 0, -7.5]
       orientation: [0.6547996, 0, 0.7558026, 0]
       scale: [1.121174, 1.121174, 1.121174]
@@ -5444,7 +5444,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.246221, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5458,7 +5458,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.04822727, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5472,7 +5472,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.11171, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5486,7 +5486,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.06598665, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5500,7 +5500,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.2451507, 6.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5514,7 +5514,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.3530231, 17.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5528,7 +5528,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-12.5, -0.4774717, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5542,7 +5542,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.4780673, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5556,7 +5556,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.3259843, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5570,7 +5570,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.2876043, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5584,7 +5584,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.3787518, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5598,7 +5598,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.02988977, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5612,7 +5612,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, 0, -13.5]
       orientation: [0.2020314, 0, 0.9793791, 0]
       scale: [1.070434, 1.070434, 1.070434]
@@ -5626,7 +5626,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.2764406, -12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5640,7 +5640,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.1765793, -11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5654,7 +5654,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.02657628, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5668,7 +5668,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.410597, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5682,7 +5682,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.1612554, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5696,7 +5696,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.007701721, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5710,7 +5710,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.2024907, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5724,7 +5724,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1509566, 16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5738,7 +5738,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-11.5, -0.4542168, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5752,7 +5752,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.08449502, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5766,7 +5766,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.4045686, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5780,7 +5780,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.3245578, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5794,7 +5794,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.1291479, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5808,7 +5808,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.3658612, -8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5822,7 +5822,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, 0, -7.5]
       orientation: [0.917946, 0, 0.3967054, 0]
       scale: [1.194324, 1.194324, 1.194324]
@@ -5836,7 +5836,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.2466634, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5850,7 +5850,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.2254619, 5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5864,7 +5864,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.1892502, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5878,7 +5878,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.08693258, 15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5892,7 +5892,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-10.5, -0.359235, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5906,7 +5906,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.1481604, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5920,7 +5920,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.1439025, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5934,7 +5934,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.3723464, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5948,7 +5948,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.3117178, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5962,7 +5962,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, 0, -2.5]
       orientation: [0.8289214, 0, 0.5593651, 0]
       scale: [1.243562, 1.243562, 1.243562]
@@ -5976,7 +5976,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.3433877, 1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -5990,7 +5990,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.156254, 5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6004,7 +6004,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.09175558, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6018,7 +6018,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.08559334, 16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6032,7 +6032,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-9.5, -0.1842423, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6046,7 +6046,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.1719649, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6060,7 +6060,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.3128093, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6074,7 +6074,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.4078845, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6088,7 +6088,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.3901137, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6102,7 +6102,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, 0, -6.5]
       orientation: [-0.5071069, 0, 0.8618832, 0]
       scale: [1.024338, 1.024338, 1.024338]
@@ -6116,7 +6116,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.1897094, -0.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6130,7 +6130,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.464693, 0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6144,7 +6144,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.2292484, 1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6158,7 +6158,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.3161796, 2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6172,7 +6172,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.151807, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6186,7 +6186,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.2433958, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6200,7 +6200,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.3989643, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6214,7 +6214,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.2179293, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6228,7 +6228,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.3277389, 14.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6242,7 +6242,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-8.5, -0.2233919, 24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6256,7 +6256,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.3778949, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6270,7 +6270,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.1531747, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6284,7 +6284,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.05403096, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6298,7 +6298,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.2542543, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6312,7 +6312,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.1967949, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6326,7 +6326,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, 0, -3.5]
       orientation: [-0.03383341, 0, 0.9994275, 0]
       scale: [1.261056, 1.261056, 1.261056]
@@ -6340,7 +6340,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.4088139, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6354,7 +6354,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.1804304, 0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6368,7 +6368,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.06349341, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6382,7 +6382,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.4585589, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6396,7 +6396,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.3221591, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6410,7 +6410,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.3278703, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6424,7 +6424,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.1893047, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6438,7 +6438,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.2110438, 13.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6452,7 +6452,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-7.5, -0.4057902, 24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6466,7 +6466,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.09993643, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6480,7 +6480,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.2664128, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6494,7 +6494,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4744625, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6508,7 +6508,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.1753636, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6522,7 +6522,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.495055, -20.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6536,7 +6536,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4695008, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6550,7 +6550,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.120038, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6564,7 +6564,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4844339, 0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6578,7 +6578,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4073618, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6592,7 +6592,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.4175043, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6606,7 +6606,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.1943076, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6620,7 +6620,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.3112375, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6634,7 +6634,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.3898447, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6648,7 +6648,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.2935224, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6662,7 +6662,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.1961135, 12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6676,7 +6676,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-6.5, -0.1038711, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6690,7 +6690,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.270069, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6704,7 +6704,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.1506232, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6718,7 +6718,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.009225422, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6732,7 +6732,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.2354617, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6746,7 +6746,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4500916, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6760,7 +6760,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, 0, -5.5]
       orientation: [0.749096, 0, 0.6624615, 0]
       scale: [1.058349, 1.058349, 1.058349]
@@ -6774,7 +6774,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4221544, -4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6788,7 +6788,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4429991, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6802,7 +6802,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.09738214, -2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6816,7 +6816,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.2206117, -1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6830,7 +6830,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.1129609, -0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6844,7 +6844,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.452896, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6858,7 +6858,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.0677385, 1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6872,7 +6872,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.1197512, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6886,7 +6886,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.1138321, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6900,7 +6900,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.3998266, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6914,7 +6914,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.2178493, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6928,7 +6928,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.2373793, 12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6942,7 +6942,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.3715662, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6956,7 +6956,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.04491158, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6970,7 +6970,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.4616898, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6984,7 +6984,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.3222753, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -6998,7 +6998,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.2151037, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7012,7 +7012,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.3165318, -20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7026,7 +7026,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.09240816, -1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7040,7 +7040,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.110517, -0.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7054,7 +7054,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.4566879, 0.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7068,7 +7068,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.3633272, 1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7082,7 +7082,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.1540835, 2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7096,7 +7096,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.2736103, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7110,7 +7110,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.219435, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7124,7 +7124,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.3788701, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7138,7 +7138,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.05555961, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7152,7 +7152,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.3536608, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7166,7 +7166,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.1290323, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7180,7 +7180,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.08116426, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7194,7 +7194,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.2043599, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7208,7 +7208,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.06686819, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7222,7 +7222,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, 0, -3.5]
       orientation: [-0.2937282, 0, 0.955889, 0]
       scale: [1.134867, 1.134867, 1.134867]
@@ -7236,7 +7236,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.1311059, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7250,7 +7250,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.02102706, 0.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7264,7 +7264,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.3014216, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7278,7 +7278,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.3986821, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7292,7 +7292,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1993693, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7306,7 +7306,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.0837779, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7320,7 +7320,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1108734, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7334,7 +7334,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.4156072, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7348,7 +7348,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.05870883, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7362,7 +7362,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1624818, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7376,7 +7376,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1483379, -20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7390,7 +7390,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.3278899, -4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7404,7 +7404,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.1593892, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7418,7 +7418,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.210095, -2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7432,7 +7432,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, 0, -0.5]
       orientation: [0.2359899, 0, 0.9717555, 0]
       scale: [1.234573, 1.234573, 1.234573]
@@ -7446,7 +7446,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.2539291, 1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7460,7 +7460,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.05659627, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7474,7 +7474,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.04275789, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7488,7 +7488,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.4967674, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7502,7 +7502,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.1312411, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7516,7 +7516,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.09078649, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7530,7 +7530,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.4005073, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7544,7 +7544,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, 0, -5.5]
       orientation: [-0.7352417, 0, 0.6778049, 0]
       scale: [1.008766, 1.008766, 1.008766]
@@ -7558,7 +7558,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.1329603, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7572,7 +7572,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.4644271, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7586,7 +7586,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-1.5, -0.1220691, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7600,7 +7600,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.3651654, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7614,7 +7614,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.05036924, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7628,7 +7628,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.2443045, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7642,7 +7642,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.172164, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7656,7 +7656,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.2892625, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7670,7 +7670,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.1408137, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7684,7 +7684,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-0.5, -0.1186418, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7698,7 +7698,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.4843202, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7712,7 +7712,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.2294244, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7726,7 +7726,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.1068864, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7740,7 +7740,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.4815443, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7754,7 +7754,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, 0, -6.5]
       orientation: [-0.3266748, 0, 0.9451368, 0]
       scale: [1.164042, 1.164042, 1.164042]
@@ -7768,7 +7768,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.1132757, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7782,7 +7782,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.2605679, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7796,7 +7796,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, 0, 3.5]
       orientation: [0.8272474, 0, 0.5618377, 0]
       scale: [1.069478, 1.069478, 1.069478]
@@ -7810,7 +7810,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.2007857, 9.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7824,7 +7824,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.2444489, 10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7838,7 +7838,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, 0, 11.5]
       orientation: [0.2690491, 0, 0.9631265, 0]
       scale: [1.187218, 1.187218, 1.187218]
@@ -7852,7 +7852,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.08507614, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7866,7 +7866,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.3395678, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7880,7 +7880,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.1495259, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7894,7 +7894,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [0.5, -0.1977576, 24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7908,7 +7908,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.3182343, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7922,7 +7922,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.1837183, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7936,7 +7936,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.07578708, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7950,7 +7950,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.493991, -7.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7964,7 +7964,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.3846216, -6.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7978,7 +7978,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.01886943, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -7992,7 +7992,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, 0, -0.5]
       orientation: [-0.9342938, 0, 0.356504, 0]
       scale: [1.26555, 1.26555, 1.26555]
@@ -8006,7 +8006,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.4796108, 2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8020,7 +8020,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.4566434, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8034,7 +8034,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.009033135, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8048,7 +8048,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.3980919, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8062,7 +8062,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.2914232, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8076,7 +8076,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.04935614, 7.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8090,7 +8090,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.3834271, 8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8104,7 +8104,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.1309356, 9.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8118,7 +8118,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.1638989, 13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8132,7 +8132,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.1676784, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8146,7 +8146,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.06453308, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8160,7 +8160,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.339864, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8174,7 +8174,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [1.5, -0.1459804, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8188,7 +8188,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.06827657, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8202,7 +8202,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.4235548, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8216,7 +8216,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.07880654, -3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8230,7 +8230,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.3629195, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8244,7 +8244,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.4905548, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8258,7 +8258,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.4785835, -0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8272,7 +8272,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.247087, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8286,7 +8286,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.006269402, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8300,7 +8300,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.3895259, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8314,7 +8314,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.1432933, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8328,7 +8328,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.3575186, 6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8342,7 +8342,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.04934952, 7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8356,7 +8356,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.4518603, 10.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8370,7 +8370,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.1923776, 11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8384,7 +8384,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, 0, 15.5]
       orientation: [-0.9418585, 0, 0.3360099, 0]
       scale: [1.106605, 1.106605, 1.106605]
@@ -8398,7 +8398,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.1670815, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8412,7 +8412,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.3599855, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8426,7 +8426,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [2.5, -0.3493729, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8440,7 +8440,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.03272253, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8454,7 +8454,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.09890492, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8468,7 +8468,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, 0, -6.5]
       orientation: [-0.04352629, 0, 0.9990523, 0]
       scale: [1.009162, 1.009162, 1.009162]
@@ -8482,7 +8482,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.2119892, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8496,7 +8496,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.2426878, -4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8510,7 +8510,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4838475, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8524,7 +8524,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4787534, -2.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8538,7 +8538,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4964406, -1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8552,7 +8552,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.09419098, -0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8566,7 +8566,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.3049333, 3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8580,7 +8580,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4671253, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8594,7 +8594,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, 0, 9.5]
       orientation: [-0.3612983, 0, 0.9324503, 0]
       scale: [1.141757, 1.141757, 1.141757]
@@ -8608,7 +8608,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4297211, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8622,7 +8622,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.3054581, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8636,7 +8636,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.4027447, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8650,7 +8650,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [3.5, -0.2442009, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8664,7 +8664,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.2883607, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8678,7 +8678,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.2572598, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8692,7 +8692,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, 0, -15.5]
       orientation: [0.8393729, 0, 0.543556, 0]
       scale: [1.073506, 1.073506, 1.073506]
@@ -8706,7 +8706,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.4001402, -8.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8720,7 +8720,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.1485147, -7.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8734,7 +8734,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.07094317, -6.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8748,7 +8748,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.002391742, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8762,7 +8762,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.2108806, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8776,7 +8776,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.4824443, -3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8790,7 +8790,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.4982307, -2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8804,7 +8804,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.2734407, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8818,7 +8818,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.1392491, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8832,7 +8832,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.4893403, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8846,7 +8846,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.1162002, 5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8860,7 +8860,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.3563472, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8874,7 +8874,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.3734521, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8888,7 +8888,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [4.5, -0.2502358, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8902,7 +8902,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.1612665, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8916,7 +8916,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.2355442, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8930,7 +8930,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.1591161, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8944,7 +8944,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, 0, -17.5]
       orientation: [0.9825109, 0, 0.186205, 0]
       scale: [1.285742, 1.285742, 1.285742]
@@ -8958,7 +8958,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.340986, -16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8972,7 +8972,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.2673605, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -8986,7 +8986,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.02121557, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9000,7 +9000,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.4359026, -3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9014,7 +9014,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.03572273, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9028,7 +9028,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.4673013, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9042,7 +9042,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.2608249, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9056,7 +9056,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.333557, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9070,7 +9070,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [5.5, -0.04836502, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9084,7 +9084,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.1448447, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9098,7 +9098,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.4090743, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9112,7 +9112,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.03276223, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9126,7 +9126,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.4087735, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9140,7 +9140,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.1159443, -11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9154,7 +9154,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.3612198, -10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9168,7 +9168,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.3523619, -9.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9182,7 +9182,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.07493272, -8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9196,7 +9196,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.0975537, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9210,7 +9210,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.3298026, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9224,7 +9224,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.2111092, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9238,7 +9238,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.2592975, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9252,7 +9252,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.4680275, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9266,7 +9266,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.4864873, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9280,7 +9280,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [6.5, -0.0711086, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9294,7 +9294,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.3244957, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9308,7 +9308,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.3215905, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9322,7 +9322,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.4001653, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9336,7 +9336,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.2363661, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9350,7 +9350,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.2268988, -15.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9364,7 +9364,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.2184665, -14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9378,7 +9378,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.2161957, -13.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9392,7 +9392,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.1221598, -12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9406,7 +9406,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.4126569, -11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9420,7 +9420,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.2529597, -10.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9434,7 +9434,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, 0, -7.5]
       orientation: [0.9658148, 0, 0.2592332, 0]
       scale: [1.272083, 1.272083, 1.272083]
@@ -9448,7 +9448,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.0665855, 2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9462,7 +9462,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.03825199, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9476,7 +9476,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.08669431, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9490,7 +9490,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.356952, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9504,7 +9504,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.1954689, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9518,7 +9518,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.3086025, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9532,7 +9532,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, -0.4156899, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9546,7 +9546,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.09454209, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9560,7 +9560,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.4016822, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9574,7 +9574,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.1984909, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9588,7 +9588,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.03023559, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9602,7 +9602,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, 0, -13.5]
       orientation: [0.6430613, 0, 0.7658147, 0]
       scale: [1.119777, 1.119777, 1.119777]
@@ -9616,7 +9616,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.4290496, -12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9630,7 +9630,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.2634379, -11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9644,7 +9644,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.4544683, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9658,7 +9658,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.2083997, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9672,7 +9672,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.3086396, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9686,7 +9686,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.3284299, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9700,7 +9700,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.09040935, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9714,7 +9714,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.3139867, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9728,7 +9728,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, -0.2575119, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9742,7 +9742,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.145992, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9756,7 +9756,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.4123158, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9770,7 +9770,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.2158256, -22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9784,7 +9784,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.1796622, -8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9798,7 +9798,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, 0, -7.5]
       orientation: [0.9988166, 0, 0.04863504, 0]
       scale: [1.244835, 1.244835, 1.244835]
@@ -9812,7 +9812,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.4920319, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9826,7 +9826,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.1466941, 5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9840,7 +9840,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.0835842, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9854,7 +9854,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.08605891, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9868,7 +9868,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.05310817, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9882,7 +9882,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.2463948, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9896,7 +9896,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.1862049, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9910,7 +9910,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.09766238, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9924,7 +9924,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.0990592, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9938,7 +9938,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.4321537, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9952,7 +9952,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.2448438, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9966,7 +9966,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.1020986, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9980,7 +9980,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.1697467, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -9994,7 +9994,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.3081361, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10008,7 +10008,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.4758152, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10022,7 +10022,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.4390253, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10036,7 +10036,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.460166, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10050,7 +10050,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.1962345, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10064,7 +10064,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.0263385, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10078,7 +10078,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.4732886, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10092,7 +10092,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.3689291, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10106,7 +10106,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.08334913, 24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10120,7 +10120,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.1345597, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10134,7 +10134,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.4859387, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10148,7 +10148,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.2114178, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10162,7 +10162,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.2819825, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10176,7 +10176,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.2739354, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10190,7 +10190,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.2991844, -24.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10204,7 +10204,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.4713685, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10218,7 +10218,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.06561092, 22.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10232,7 +10232,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.2088721, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10246,7 +10246,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.2833887, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10260,7 +10260,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.4915262, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10274,7 +10274,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.2771901, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10288,7 +10288,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.1507275, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10302,7 +10302,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, 0, -17.5]
       orientation: [0.5608097, 0, 0.8279448, 0]
       scale: [1.21033, 1.21033, 1.21033]
@@ -10316,7 +10316,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.06032446, -16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10330,7 +10330,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.3331694, -5.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10344,7 +10344,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.3688954, -4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10358,7 +10358,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.2695632, -3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10372,7 +10372,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.1213618, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10386,7 +10386,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.3490528, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10400,7 +10400,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.4114296, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10414,7 +10414,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.333264, 23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10428,7 +10428,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, -0.09273799, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10442,7 +10442,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.08906623, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10456,7 +10456,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.1563385, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10470,7 +10470,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.0640072, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10484,7 +10484,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.4408627, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10498,7 +10498,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.4995402, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10512,7 +10512,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.3371065, -11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10526,7 +10526,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.08556053, -10.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10540,7 +10540,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.3696488, -9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10554,7 +10554,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.01630041, -8.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10568,7 +10568,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.03127162, 2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10582,7 +10582,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.2805999, 3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10596,7 +10596,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.06578078, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10610,7 +10610,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.4409333, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10624,7 +10624,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.04497645, 6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10638,7 +10638,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.3345877, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10652,7 +10652,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, -0.004157223, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10666,7 +10666,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.09521663, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10680,7 +10680,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.2282552, -23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10694,7 +10694,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.1844583, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10708,7 +10708,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.3171517, -21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10722,7 +10722,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.230363, -15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10736,7 +10736,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.2648815, -14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10750,7 +10750,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.490819, -13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10764,7 +10764,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.2489347, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10778,7 +10778,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.07820248, -11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10792,7 +10792,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.167899, -10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10806,7 +10806,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, 0, -7.5]
       orientation: [-0.898749, 0, 0.4384635, 0]
       scale: [1.075847, 1.075847, 1.075847]
@@ -10820,7 +10820,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.3223823, 2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10834,7 +10834,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.1168377, 3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10848,7 +10848,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.1881361, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10862,7 +10862,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.08658151, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10876,7 +10876,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.09546185, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10890,7 +10890,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.2979905, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10904,7 +10904,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, -0.2141265, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10918,7 +10918,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.3634466, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10932,7 +10932,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.241011, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10946,7 +10946,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.4387865, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10960,7 +10960,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.06030581, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -10974,7 +10974,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, 0, -13.5]
       orientation: [-0.6058321, 0, 0.7955925, 0]
       scale: [1.176852, 1.176852, 1.176852]
@@ -10988,7 +10988,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.1173828, -12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11002,7 +11002,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.1130938, -11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11016,7 +11016,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.2389979, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11030,7 +11030,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.1923096, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11044,7 +11044,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.009105882, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11058,7 +11058,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.2914932, 7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11072,7 +11072,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.3736656, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11086,7 +11086,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.1259031, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11100,7 +11100,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, -0.3273618, 24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11114,7 +11114,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.1452203, -24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11128,7 +11128,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.03903347, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11142,7 +11142,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.3085454, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11156,7 +11156,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.2363846, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11170,7 +11170,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.1326405, -8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11184,7 +11184,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, 0, -7.5]
       orientation: [-0.9999387, 0, 0.01107375, 0]
       scale: [1.247313, 1.247313, 1.247313]
@@ -11198,7 +11198,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.2660488, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11212,7 +11212,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.4913317, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11226,7 +11226,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.449718, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11240,7 +11240,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.3651244, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11254,7 +11254,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [19.5, -0.3864505, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11268,7 +11268,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.1719385, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11282,7 +11282,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.1018799, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11296,7 +11296,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.2920347, -22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11310,7 +11310,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.4535543, -21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11324,7 +11324,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.05388451, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11338,7 +11338,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.1874063, 23.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11352,7 +11352,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [20.5, -0.4531541, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11366,7 +11366,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.4240444, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11380,7 +11380,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.4398269, -23.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11394,7 +11394,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.1633496, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11408,7 +11408,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.4088803, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11422,7 +11422,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.1633683, -20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11436,7 +11436,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.130364, -19.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11450,7 +11450,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.3296053, -18.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11464,7 +11464,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2971781, -17.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11478,7 +11478,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2933825, -16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11492,7 +11492,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.0112563, -1.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11506,7 +11506,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.0244916, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11520,7 +11520,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2126297, 0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11534,7 +11534,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.3849828, 1.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11548,7 +11548,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.1563594, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11562,7 +11562,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2458761, 3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11576,7 +11576,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.08074237, 4.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11590,7 +11590,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.244092, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11604,7 +11604,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.0893831, 6.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11618,7 +11618,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2145633, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11632,7 +11632,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.2114428, 21.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11646,7 +11646,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.1973639, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11660,7 +11660,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.04711467, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11674,7 +11674,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [21.5, -0.3882269, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11688,7 +11688,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2992618, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11702,7 +11702,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.4873772, -23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11716,7 +11716,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2354621, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11730,7 +11730,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3742526, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11744,7 +11744,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3479747, -20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11758,7 +11758,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.317251, -19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11772,7 +11772,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3499439, -18.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11786,7 +11786,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.03609013, -17.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11800,7 +11800,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3192654, -16.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11814,7 +11814,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3166817, -15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11828,7 +11828,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.01680192, -14.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11842,7 +11842,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2644603, -13.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11856,7 +11856,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.03440305, -12.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11870,7 +11870,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1480838, -5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11884,7 +11884,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1597999, -4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11898,7 +11898,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1626639, -3.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11912,7 +11912,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2654321, -2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11926,7 +11926,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.31556, -1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11940,7 +11940,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3272229, -0.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11954,7 +11954,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.4972527, 0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11968,7 +11968,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2038096, 1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11982,7 +11982,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.2580239, 2.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -11996,7 +11996,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.4099906, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12010,7 +12010,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.362227, 4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12024,7 +12024,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3591795, 5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12038,7 +12038,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1227874, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12052,7 +12052,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.4843247, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12066,7 +12066,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1661696, 8.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12080,7 +12080,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.265667, 16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12094,7 +12094,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3743046, 17.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12108,7 +12108,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.1625728, 18.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12122,7 +12122,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3414832, 19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12136,7 +12136,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.0528146, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12150,7 +12150,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3406357, 21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12164,7 +12164,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3054793, 22.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12178,7 +12178,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.03942119, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12192,7 +12192,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [22.5, -0.3894011, 24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12206,7 +12206,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2294681, -24.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12220,7 +12220,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2117265, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12234,7 +12234,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3490734, -22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12248,7 +12248,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.04541164, -21.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12262,7 +12262,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.03394242, -20.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12276,7 +12276,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1332358, -19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12290,7 +12290,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.03457003, -18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12304,7 +12304,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.07682836, -17.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12318,7 +12318,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2635214, -16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12332,7 +12332,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1405026, -15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12346,7 +12346,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1310244, -14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12360,7 +12360,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2200426, -13.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12374,7 +12374,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2416876, -12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12388,7 +12388,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2635714, -11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12402,7 +12402,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.06540273, -10.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12416,7 +12416,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2287122, -9.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12430,7 +12430,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.04722038, -8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12444,7 +12444,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4376858, -7.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12458,7 +12458,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.06019084, -6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12472,7 +12472,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2590261, -5.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12486,7 +12486,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4849186, -4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12500,7 +12500,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4718113, -3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12514,7 +12514,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3781408, -2.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12528,7 +12528,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3188545, -1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12542,7 +12542,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1340882, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12556,7 +12556,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.478847, 0.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12570,7 +12570,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.362453, 1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12584,7 +12584,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1203535, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12598,7 +12598,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2078813, 3.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12612,7 +12612,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3380612, 4.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12626,7 +12626,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2373592, 5.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12640,7 +12640,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1445323, 6.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12654,7 +12654,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.02772071, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12668,7 +12668,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3359041, 8.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12682,7 +12682,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3068721, 9.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12696,7 +12696,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3475702, 10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12710,7 +12710,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.2453096, 11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12724,7 +12724,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.03399638, 14.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12738,7 +12738,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4522374, 15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12752,7 +12752,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1273951, 16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12766,7 +12766,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4676071, 17.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12780,7 +12780,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.11202, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12794,7 +12794,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4591383, 19.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12808,7 +12808,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3339164, 20.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12822,7 +12822,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1519126, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12836,7 +12836,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.4221961, 22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12850,7 +12850,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.3950509, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12864,7 +12864,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [23.5, -0.1722312, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12878,7 +12878,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1131137, -24.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12892,7 +12892,7 @@ Entities:
       z: -25
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3902598, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12906,7 +12906,7 @@ Entities:
       z: -24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2244759, -22.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12920,7 +12920,7 @@ Entities:
       z: -23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.337666, -21.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12934,7 +12934,7 @@ Entities:
       z: -22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2550544, -20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12948,7 +12948,7 @@ Entities:
       z: -21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.003357659, -19.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12962,7 +12962,7 @@ Entities:
       z: -20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.115316, -18.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12976,7 +12976,7 @@ Entities:
       z: -19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3010852, -17.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -12990,7 +12990,7 @@ Entities:
       z: -18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3559404, -16.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13004,7 +13004,7 @@ Entities:
       z: -17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1933856, -15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13018,7 +13018,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.4922263, -14.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13032,7 +13032,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.4579956, -13.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13046,7 +13046,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3276066, -12.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13060,7 +13060,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.0005755287, -11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13074,7 +13074,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1363335, -10.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13088,7 +13088,7 @@ Entities:
       z: -11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2312246, -9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13102,7 +13102,7 @@ Entities:
       z: -10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2345078, -8.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13116,7 +13116,7 @@ Entities:
       z: -9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2121745, -7.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13130,7 +13130,7 @@ Entities:
       z: -8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.001500603, -6.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13144,7 +13144,7 @@ Entities:
       z: -7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2304582, -5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13158,7 +13158,7 @@ Entities:
       z: -6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.223212, -4.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13172,7 +13172,7 @@ Entities:
       z: -5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3850799, -3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13186,7 +13186,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.4854721, -2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13200,7 +13200,7 @@ Entities:
       z: -3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1612359, -1.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13214,7 +13214,7 @@ Entities:
       z: -2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1523318, -0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13228,7 +13228,7 @@ Entities:
       z: -1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3923697, 0.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13242,7 +13242,7 @@ Entities:
       z: 0
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1075545, 1.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13256,7 +13256,7 @@ Entities:
       z: 1
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2356786, 2.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13270,7 +13270,7 @@ Entities:
       z: 2
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1237925, 3.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13284,7 +13284,7 @@ Entities:
       z: 3
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.01788137, 4.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13298,7 +13298,7 @@ Entities:
       z: 4
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.4032255, 5.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13312,7 +13312,7 @@ Entities:
       z: 5
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.08793721, 6.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13326,7 +13326,7 @@ Entities:
       z: 6
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2431855, 7.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13340,7 +13340,7 @@ Entities:
       z: 7
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.360879, 8.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13354,7 +13354,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.203751, 9.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13368,7 +13368,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.236743, 10.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13382,7 +13382,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1078146, 11.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13396,7 +13396,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.0763606, 12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13410,7 +13410,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.270126, 13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13424,7 +13424,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1705623, 14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13438,7 +13438,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3615121, 15.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13452,7 +13452,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3036946, 16.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13466,7 +13466,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.141847, 17.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13480,7 +13480,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.09587263, 18.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13494,7 +13494,7 @@ Entities:
       z: 18
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.2714311, 19.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13508,7 +13508,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3692134, 20.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13522,7 +13522,7 @@ Entities:
       z: 20
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.3779624, 21.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13536,7 +13536,7 @@ Entities:
       z: 21
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1214248, 22.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13550,7 +13550,7 @@ Entities:
       z: 22
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.1659886, 23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13564,7 +13564,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [24.5, -0.4587122, 24.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13578,7 +13578,7 @@ Entities:
       z: 24
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.4073618, 13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13592,7 +13592,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.0677385, 14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13606,7 +13606,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.452896, 14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13620,7 +13620,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.4175043, 12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13634,7 +13634,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, -0.06349341, 15.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13648,7 +13648,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.4844339, 15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13662,7 +13662,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.4566879, 15.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13676,7 +13676,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, -0.3530231, 15.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13690,7 +13690,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, -0.3986399, 15.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13704,7 +13704,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, 0, 14.5]
       orientation: [-0.99975, 0, 0.02236243, 0]
       scale: [1.287252, 1.287252, 1.287252]
@@ -13718,7 +13718,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, 0, 13.5]
       orientation: [-0.9999382, 0, 0.0111169, 0]
       scale: [1.289467, 1.289467, 1.289467]
@@ -13732,7 +13732,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, 0, 13.5]
       orientation: [-0.9948544, 0, 0.1013153, 0]
       scale: [1.047284, 1.047284, 1.047284]
@@ -13746,7 +13746,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.1509566, 14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13760,7 +13760,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, 0, 14.5]
       orientation: [-0.9982396, 0, 0.05931081, 0]
       scale: [1.28715, 1.28715, 1.28715]
@@ -13774,7 +13774,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, 0, 15.5]
       orientation: [0.9410278, 0, 0.3383293, 0]
       scale: [1.145613, 1.145613, 1.145613]
@@ -13788,7 +13788,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, 0, 14.5]
       orientation: [-0.805505, 0, 0.592589, 0]
       scale: [1.240084, 1.240084, 1.240084]
@@ -13802,7 +13802,7 @@ Entities:
       z: 14
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, 0, 16.5]
       orientation: [0.5953096, 0, 0.8034964, 0]
       scale: [1.042566, 1.042566, 1.042566]
@@ -13816,7 +13816,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, 0, 16.5]
       orientation: [0.9998871, 0, 0.01502719, 0]
       scale: [1.126528, 1.126528, 1.126528]
@@ -13830,7 +13830,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 16.5]
       orientation: [0.9382299, 0, 0.3460124, 0]
       scale: [1.274721, 1.274721, 1.274721]
@@ -13844,7 +13844,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 12.5]
       orientation: [-0.4251064, 0, 0.9051434, 0]
       scale: [1.237662, 1.237662, 1.237662]
@@ -13858,7 +13858,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, 0, 11.5]
       orientation: [-0.9279503, 0, 0.3727039, 0]
       scale: [1.287848, 1.287848, 1.287848]
@@ -13872,7 +13872,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, 0, 10.5]
       orientation: [-0.01150647, 0, 0.9999338, 0]
       scale: [1.196722, 1.196722, 1.196722]
@@ -13886,7 +13886,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, 0, 13.5]
       orientation: [-0.8051748, 0, 0.5930375, 0]
       scale: [1.010713, 1.010713, 1.010713]
@@ -13900,7 +13900,7 @@ Entities:
       z: 13
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, 0, 12.5]
       orientation: [0.4220974, 0, 0.9065505, 0]
       scale: [1.254739, 1.254739, 1.254739]
@@ -13914,7 +13914,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [16.5, 0, 15.5]
       orientation: [0.7864353, 0, 0.6176727, 0]
       scale: [1.280198, 1.280198, 1.280198]
@@ -13928,7 +13928,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, 0, 16.5]
       orientation: [-0.539428, 0, 0.8420317, 0]
       scale: [1.203621, 1.203621, 1.203621]
@@ -13942,7 +13942,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [13.5, 0, 17.5]
       orientation: [0.3127837, 0, 0.9498244, 0]
       scale: [1.227322, 1.227322, 1.227322]
@@ -13956,7 +13956,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, 0, 16.5]
       orientation: [-0.686028, 0, 0.7275751, 0]
       scale: [1.22294, 1.22294, 1.22294]
@@ -13970,7 +13970,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [14.5, 0, 17.5]
       orientation: [0.07921477, 0, 0.9968576, 0]
       scale: [1.117668, 1.117668, 1.117668]
@@ -13984,7 +13984,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.2110438, 16.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -13998,7 +13998,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, 0, 15.5]
       orientation: [-0.469256, 0, 0.8830622, 0]
       scale: [1.05216, 1.05216, 1.05216]
@@ -14012,7 +14012,7 @@ Entities:
       z: 15
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 17.5]
       orientation: [0.9894984, 0, 0.1445436, 0]
       scale: [1.044734, 1.044734, 1.044734]
@@ -14026,7 +14026,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, 0, 17.5]
       orientation: [0.9538023, 0, 0.3004348, 0]
       scale: [1.298221, 1.298221, 1.298221]
@@ -14040,7 +14040,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, 0, 17.5]
       orientation: [-0.8500988, 0, 0.5266233, 0]
       scale: [1.246571, 1.246571, 1.246571]
@@ -14054,7 +14054,7 @@ Entities:
       z: 17
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, 0, 16.5]
       orientation: [-0.5745647, 0, 0.8184592, 0]
       scale: [1.037555, 1.037555, 1.037555]
@@ -14068,7 +14068,7 @@ Entities:
       z: 16
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.1585497, 11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14082,7 +14082,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.381875, 11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14096,7 +14096,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, -0.475111, 10.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14110,7 +14110,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, -0.2452945, 11.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14124,7 +14124,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, 0, 12.5]
       orientation: [0.9941504, 0, 0.1080045, 0]
       scale: [1.199082, 1.199082, 1.199082]
@@ -14138,7 +14138,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, 0, 12.5]
       orientation: [0.1912548, 0, 0.9815404, 0]
       scale: [1.037769, 1.037769, 1.037769]
@@ -14152,7 +14152,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [10.5, 0, 12.5]
       orientation: [0.363568, 0, 0.9315677, 0]
       scale: [1.063063, 1.063063, 1.063063]
@@ -14166,7 +14166,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 11.5]
       orientation: [-0.7407228, 0, 0.6718107, 0]
       scale: [1.015365, 1.015365, 1.015365]
@@ -14180,7 +14180,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, 0, 10.5]
       orientation: [-0.8000616, 0, 0.5999178, 0]
       scale: [1.010932, 1.010932, 1.010932]
@@ -14194,7 +14194,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [8.5, 0, 11.5]
       orientation: [0.832563, 0, 0.5539303, 0]
       scale: [1.122619, 1.122619, 1.122619]
@@ -14208,7 +14208,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [11.5, 0, 10.5]
       orientation: [-0.4436398, 0, 0.8962052, 0]
       scale: [1.238192, 1.238192, 1.238192]
@@ -14222,7 +14222,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [7.5, 0, 11.5]
       orientation: [0.1701146, 0, 0.9854243, 0]
       scale: [1.146271, 1.146271, 1.146271]
@@ -14236,7 +14236,7 @@ Entities:
       z: 11
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 10.5]
       orientation: [-0.6113292, 0, 0.7913764, 0]
       scale: [1.276262, 1.276262, 1.276262]
@@ -14250,7 +14250,7 @@ Entities:
       z: 10
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 9.5]
       orientation: [-0.7174409, 0, 0.6966194, 0]
       scale: [1.242259, 1.242259, 1.242259]
@@ -14264,7 +14264,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [12.5, 0, 8.5]
       orientation: [0.6469958, 0, 0.7624936, 0]
       scale: [1.211732, 1.211732, 1.211732]
@@ -14278,7 +14278,7 @@ Entities:
       z: 8
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [15.5, 0, 9.5]
       orientation: [-0.535038, 0, 0.844828, 0]
       scale: [1.000846, 1.000846, 1.000846]
@@ -14292,7 +14292,7 @@ Entities:
       z: 9
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [18.5, 0, 12.5]
       orientation: [-0.4682019, 0, 0.8836215, 0]
       scale: [1.213211, 1.213211, 1.213211]
@@ -14306,7 +14306,7 @@ Entities:
       z: 12
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [17.5, 0, 19.5]
       orientation: [0.8723244, 0, 0.4889275, 0]
       scale: [1.193188, 1.193188, 1.193188]
@@ -14320,7 +14320,7 @@ Entities:
       z: 19
   - NameComponent:
       name: Mithril
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.4073618, 23.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14334,7 +14334,7 @@ Entities:
       z: 23
   - NameComponent:
       name: Iron
-    TransformComponent:
+    Transform3DComponent:
       position: [9.5, -0.4073618, -3.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14348,7 +14348,7 @@ Entities:
       z: -4
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.0677385, -12.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14362,7 +14362,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.452896, -11.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14376,7 +14376,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.4175043, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14390,7 +14390,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Tin
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.06349341, -13.5]
       orientation: [1, 0, 0, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14404,7 +14404,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, -0.4844339, -13.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14418,7 +14418,7 @@ Entities:
       z: -14
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-5.5, -0.4566879, -12.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14432,7 +14432,7 @@ Entities:
       z: -13
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.110517, -11.5]
       orientation: [0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14446,7 +14446,7 @@ Entities:
       z: -12
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, -0.3161796, -14.5]
       orientation: [-4.371139e-08, 0, 1, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14460,7 +14460,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Rock
-    TransformComponent:
+    Transform3DComponent:
       position: [-3.5, -0.1540835, -14.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
@@ -14474,7 +14474,7 @@ Entities:
       z: -15
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-2.5, 0, -15.5]
       orientation: [0.9534159, 0, 0.301659, 0]
       scale: [1.164166, 1.164166, 1.164166]
@@ -14488,7 +14488,7 @@ Entities:
       z: -16
   - NameComponent:
       name: Tree
-    TransformComponent:
+    Transform3DComponent:
       position: [-4.5, 0, -10.5]
       orientation: [0.6410521, 0, 0.7674974, 0]
       scale: [1.056515, 1.056515, 1.056515]

--- a/Resources/Scripts/Bob.lua
+++ b/Resources/Scripts/Bob.lua
@@ -4,7 +4,7 @@ end
 
 function OnUpdate(entity, dt)
     TIMER = TIMER + dt
-    local pos = GetTransformComponent(entity)
+    local pos = GetTransform3DComponent(entity)
     pos.position.y = 2 + math.sin(TIMER)
-    SetTransformComponent(entity, pos)
+    SetTransform3DComponent(entity, pos)
 end

--- a/Resources/Scripts/FirstPersonCamera.lua
+++ b/Resources/Scripts/FirstPersonCamera.lua
@@ -8,7 +8,7 @@ function OnUpdate(entity, dt)
     local speed = 10 * dt
     local r = GetRightDir(entity)
     
-    local transform = GetTransformComponent(entity)
+    local transform = GetTransform3DComponent(entity)
     local new_pos = transform.position
     if IsKeyDown(Keyboard.W) then new_pos = new_pos + speed * f end
     if IsKeyDown(Keyboard.S) then new_pos = new_pos - speed * f end
@@ -17,7 +17,7 @@ function OnUpdate(entity, dt)
     if IsKeyDown(Keyboard.SPACE) then new_pos.y = new_pos.y + speed end
     if IsKeyDown(Keyboard.LSHIFT) then new_pos.y = new_pos.y - speed end
     transform.position = new_pos
-    SetTransformComponent(entity, transform)
+    SetTransform3DComponent(entity, transform)
 
     local dx, dy = GetMouseOffset()
     RotateY(entity, 10 * dx)

--- a/Resources/Scripts/Grenade.lua
+++ b/Resources/Scripts/Grenade.lua
@@ -24,11 +24,11 @@ function OnUpdate(entity, dt)
     
     if EXPLODE == true then
         for e in scene:Each() do
-            local pos = GetTransformComponent(entity).position
+            local pos = GetTransform3DComponent(entity).position
             if HasRigidBody3DComponent(e) then
                 local rbc = GetRigidBody3DComponent(e)
                 if rbc.frozen == false then
-                    local e_pos = GetTransformComponent(e).position
+                    local e_pos = GetTransform3DComponent(e).position
                     if Mag(e_pos - pos) < 10 then
                         rbc.velocity = rbc.velocity + 5 * (e_pos - pos)
                     end

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -21,9 +21,9 @@ function OnUpdate(entity, dt)
     
     YAW = YAW - dx * rotateSpeed
 
-    local camera = GetCameraComponent(entity)
+    local camera = GetCamera3DComponent(entity)
     camera.pitch = Clamp(camera.pitch - rotateSpeed * dy, math.rad(-89), math.rad(89))
-    SetCameraComponent(entity, camera)
+    SetCamera3DComponent(entity, camera)
 
     MakeUpright(entity, YAW)
 
@@ -55,10 +55,10 @@ function OnUpdate(entity, dt)
     physics.force = physics.force + (10 * dv) -- TODO: Replace 10 with mass
     SetRigidBody3DComponent(entity, physics)
 
-    local transform = GetTransformComponent(entity)
+    local transform = GetTransform3DComponent(entity)
     if transform.position.y < -1 then
         transform.position = SPAWN_POINT
-        SetTransformComponent(entity, transform)
+        SetTransform3DComponent(entity, transform)
     end
 
 end
@@ -71,11 +71,11 @@ function OnMouseButtonPressedEvent(consumed, button, action, mods)
     local newEntity = NewEntity()
 
     local dir = GetForwardsDir(ENTITY)
-    local pos = GetTransformComponent(ENTITY).position
+    local pos = GetTransform3DComponent(ENTITY).position
     local vel = GetRigidBody3DComponent(ENTITY).velocity
     
-    local tc = TransformComponent(pos + dir, Vec3(0.1, 0.1, 0.1))
-    AddTransformComponent(newEntity, tc)
+    local tc = Transform3DComponent(pos + dir, Vec3(0.1, 0.1, 0.1))
+    AddTransform3DComponent(newEntity, tc)
 
     --local mc = ModelComponent(
     --    "Resources/Models/Sphere.obj", 

--- a/Resources/Scripts/ThirdPersonCamera.lua
+++ b/Resources/Scripts/ThirdPersonCamera.lua
@@ -14,7 +14,7 @@ function Init(entity)
 end
 
 function OnUpdate(entity, dt)
-    local pos = GetTransformComponent(entity).position
+    local pos = GetTransform3DComponent(entity).position
 
     if ABS_VERT == nil then ABS_VERT = pos.y end
 

--- a/Resources/Scripts/noisy.lua
+++ b/Resources/Scripts/noisy.lua
@@ -1,1 +1,0 @@
-print("In this script!")

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -32,7 +32,7 @@ Runtime::Runtime(Window* window)
     d_scene.Add<AnimationSystem>();
     d_scene.Load("Resources/Anvil.yaml");
 
-    d_runtimeCamera = d_scene.Entities().Find<CameraComponent>();
+    d_runtimeCamera = d_scene.Entities().Find<Camera3DComponent>();
 }
 
 void Runtime::OnEvent(Event& event)
@@ -64,8 +64,8 @@ void Runtime::OnUpdate(double dt)
     }
     
     std::vector<ecs::Entity> toDelete;
-    for (auto entity : d_scene.Entities().View<TransformComponent>()) {
-        auto& transform = entity.Get<TransformComponent>();
+    for (auto entity : d_scene.Entities().View<Transform3DComponent>()) {
+        auto& transform = entity.Get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);
         }

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -25,7 +25,7 @@ Runtime::Runtime(Window* window)
     d_window->SetCursorVisibility(false);
     d_entityRenderer.EnableParticles(&d_particleManager);
 
-    d_scene.Add<PhysicsEngine>();
+    d_scene.Add<PhysicsEngine3D>();
     d_scene.Add<ScriptRunner>(d_window);
     d_scene.Add<CameraSystem>(d_window->AspectRatio());
     d_scene.Add<ParticleSystem>(&d_particleManager);

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -11,7 +11,7 @@ class Runtime
     Sprocket::AssetManager d_assetManager;
 
     // Rendering
-    Sprocket::EntityRenderer d_entityRenderer;
+    Sprocket::Scene3DRenderer d_entityRenderer;
     Sprocket::SkyboxRenderer d_skyboxRenderer;
 
     Sprocket::ParticleManager d_particleManager;

--- a/Sprocket/Audio/Listener.cpp
+++ b/Sprocket/Audio/Listener.cpp
@@ -8,8 +8,8 @@ namespace Audio {
 
 void SetListener(const ecs::Entity& entity)
 {
-    if (!entity.Has<TransformComponent>()) { return; }
-    auto tr = entity.Get<TransformComponent>();
+    if (!entity.Has<Transform3DComponent>()) { return; }
+    auto tr = entity.Get<Transform3DComponent>();
     auto pos = tr.position;
     sf::Listener::setPosition(pos.x, pos.y, pos.z);
 

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(Sprocket STATIC
             Scene/Systems/AnimationSystem.cpp
             Scene/Systems/CameraSystem.cpp
             Scene/Systems/ParticleSystem.cpp
-            Scene/Systems/PhysicsEngine.cpp
+            Scene/Systems/PhysicsEngine3D.cpp
             Scene/Systems/ScriptRunner.cpp
             Scene/Systems/GameGrid.cpp
             Scene/Systems/PathFollower.cpp

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -74,7 +74,7 @@ add_library(Sprocket STATIC
             Graphics/VertexArray.cpp
 
             Graphics/Rendering/ColliderRenderer.cpp
-            Graphics/Rendering/EntityRenderer.cpp
+            Graphics/Rendering/Scene3DRenderer.cpp
             Graphics/Rendering/SkyboxRenderer.cpp
 
             Graphics/PostProcessing/Effect.cpp

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -32,8 +32,32 @@
             ]
         },
         {
-            "Name": "TransformComponent",
-            "DisplayName": "Transform",
+            "Name": "Transform2DComponent",
+            "DisplayName": "Transform 2D",
+            "Attributes": [
+                {
+                    "Name": "position",
+                    "DisplayName": "Position",
+                    "Type": "glm::vec2",
+                    "Default": [0.0, 0.0]
+                },
+                {
+                    "Name": "rotation",
+                    "DisplayName": "Rotation",
+                    "Type": "float",
+                    "Default": 0.0
+                },
+                {
+                    "Name": "scale",
+                    "DisplayName": "Scale",
+                    "Type": "glm::vec2",
+                    "Default": [1.0, 1.0]
+                }
+            ]
+        },
+        {
+            "Name": "Transform3DComponent",
+            "DisplayName": "Transform 3D",
             "Attributes": [
                 {
                     "Name": "position",
@@ -287,8 +311,8 @@
             ]
         },
         {
-            "Name": "CameraComponent",
-            "DisplayName": "Camera",
+            "Name": "Camera3DComponent",
+            "DisplayName": "Camera 3D",
             "Attributes": [
                 {
                     "Name": "projection",
@@ -506,8 +530,8 @@
             ]
         },
         {
-            "Name": "AnimationComponent",
-            "DisplayName": "Animation",
+            "Name": "MeshAnimationComponent",
+            "DisplayName": "Mesh Animation",
             "Attributes": [
                 {
                     "Name": "name",

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -34,7 +34,7 @@ void ColliderRenderer::Draw(
     d_vao->SetModel(s_cube.get());
     for (auto entity : scene.Entities().View<BoxCollider3DComponent>()) {
         const auto& c = entity.Get<BoxCollider3DComponent>();
-        auto tr = entity.Get<TransformComponent>();
+        auto tr = entity.Get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(c.position, c.orientation);
         transform = glm::scale(transform, c.halfExtents);
@@ -49,7 +49,7 @@ void ColliderRenderer::Draw(
     d_vao->SetModel(s_sphere.get());
     for (auto entity : scene.Entities().View<SphereCollider3DComponent>()) {
         const auto& c = entity.Get<SphereCollider3DComponent>();
-        auto tr = entity.Get<TransformComponent>();
+        auto tr = entity.Get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(c.position, c.orientation);
         transform = glm::scale(transform, {c.radius, c.radius, c.radius});
@@ -64,7 +64,7 @@ void ColliderRenderer::Draw(
         const auto& c = entity.Get<CapsuleCollider3DComponent>();
 
         {  // Top Hemisphere
-            auto tr = entity.Get<TransformComponent>();
+            auto tr = entity.Get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::translate(transform, {0.0, c.height/2, 0.0});
@@ -75,7 +75,7 @@ void ColliderRenderer::Draw(
         }
 
         {  // Middle Cylinder
-            auto tr = entity.Get<TransformComponent>();
+            auto tr = entity.Get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::scale(transform, {c.radius, c.height, c.radius});
@@ -85,7 +85,7 @@ void ColliderRenderer::Draw(
         }
 
         {  // Bottom Hemisphere
-            auto tr = entity.Get<TransformComponent>();
+            auto tr = entity.Get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::translate(transform, {0.0, -c.height/2, 0.0});

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -52,10 +52,10 @@ void UploadUniforms(
     
     // Load point lights to shader
     std::size_t i = 0;
-    auto lights = scene.Entities().View<LightComponent, TransformComponent>();
+    auto lights = scene.Entities().View<LightComponent, Transform3DComponent>();
     for (auto entity : lights) {
         if (i < MAX_NUM_LIGHTS) {
-            auto position = entity.Get<TransformComponent>().position;
+            auto position = entity.Get<Transform3DComponent>().position;
             auto light = entity.Get<LightComponent>();
             shader.LoadVec3(ArrayName("u_light_pos", i), position);
             shader.LoadVec3(ArrayName("u_light_colour", i), light.colour);
@@ -150,8 +150,8 @@ void EntityRenderer::Draw(
     std::unordered_map<std::pair<std::string, std::string>, std::vector<InstanceData>, HashPair> commands;
 
     d_staticShader.Bind();
-    for (auto entity : scene.Entities().View<ModelComponent, TransformComponent>()) {
-        const auto& tc = entity.Get<TransformComponent>();
+    for (auto entity : scene.Entities().View<ModelComponent, Transform3DComponent>()) {
+        const auto& tc = entity.Get<Transform3DComponent>();
         const auto& mc = entity.Get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         auto mesh = d_assetManager->GetMesh(mc.mesh);
@@ -180,7 +180,7 @@ void EntityRenderer::Draw(
 
     d_animatedShader.Bind();
     for (auto entity : scene.Entities().View<ModelComponent>()) {
-        const auto& tc = entity.Get<TransformComponent>();
+        const auto& tc = entity.Get<Transform3DComponent>();
         const auto& mc = entity.Get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         auto mesh = d_assetManager->GetMesh(mc.mesh);
@@ -191,8 +191,8 @@ void EntityRenderer::Draw(
 
         d_animatedShader.LoadMat4("u_model_matrix", Maths::Transform(tc.position, tc.orientation, tc.scale));
         
-        if (entity.Has<AnimationComponent>()) {
-            const auto& ac = entity.Get<AnimationComponent>();
+        if (entity.Has<MeshAnimationComponent>()) {
+            const auto& ac = entity.Get<MeshAnimationComponent>();
             auto poses = mesh->GetPose(ac.name, ac.time);
             
             int numBones = std::min(MAX_BONES, (int)poses.size());

--- a/Sprocket/Graphics/Rendering/EntityRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/EntityRenderer.cpp
@@ -9,8 +9,16 @@
 #include "Types.h"
 #include "HashPair.h"
 
+#include <algorithm>
+
 namespace Sprocket {
 namespace {
+
+std::array<glm::mat4, EntityRenderer::MAX_BONES> DefaultBoneTransforms() {
+    std::array<glm::mat4, EntityRenderer::MAX_BONES> arr;
+    std::fill(arr.begin(), arr.end(), glm::mat4(1.0));
+    return arr;
+};
 
 std::unique_ptr<Buffer> GetInstanceBuffer()
 {
@@ -199,11 +207,7 @@ void EntityRenderer::Draw(
             d_animatedShader.LoadMat4("u_bone_transforms", poses[0], numBones);
         }
         else {
-            static const auto clear = []() {
-                std::array<glm::mat4, MAX_BONES> arr;
-                for (auto& x : arr) { x = glm::mat4(1.0); }
-                return arr;
-            }();
+            static const std::array<glm::mat4, MAX_BONES> clear = DefaultBoneTransforms();
             d_animatedShader.LoadMat4("u_bone_transforms", clear[0], MAX_BONES);
         }
 

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -1,4 +1,4 @@
-#include "EntityRenderer.h"
+#include "Scene3DRenderer.h"
 #include "Maths.h"
 #include "AssetManager.h"
 #include "RenderContext.h"
@@ -14,8 +14,8 @@
 namespace Sprocket {
 namespace {
 
-std::array<glm::mat4, EntityRenderer::MAX_BONES> DefaultBoneTransforms() {
-    std::array<glm::mat4, EntityRenderer::MAX_BONES> arr;
+std::array<glm::mat4, Scene3DRenderer::MAX_BONES> DefaultBoneTransforms() {
+    std::array<glm::mat4, Scene3DRenderer::MAX_BONES> arr;
     std::fill(arr.begin(), arr.end(), glm::mat4(1.0));
     return arr;
 };
@@ -88,10 +88,10 @@ void UploadMaterial(
     AssetManager* assetManager
 )
 {
-    assetManager->GetTexture(material->albedoMap)->Bind(EntityRenderer::ALBEDO_SLOT);
-    assetManager->GetTexture(material->normalMap)->Bind(EntityRenderer::NORMAL_SLOT);
-    assetManager->GetTexture(material->metallicMap)->Bind(EntityRenderer::METALLIC_SLOT);
-    assetManager->GetTexture(material->roughnessMap)->Bind(EntityRenderer::ROUGHNESS_SLOT);
+    assetManager->GetTexture(material->albedoMap)->Bind(Scene3DRenderer::ALBEDO_SLOT);
+    assetManager->GetTexture(material->normalMap)->Bind(Scene3DRenderer::NORMAL_SLOT);
+    assetManager->GetTexture(material->metallicMap)->Bind(Scene3DRenderer::METALLIC_SLOT);
+    assetManager->GetTexture(material->roughnessMap)->Bind(Scene3DRenderer::ROUGHNESS_SLOT);
 
     shader.LoadFloat("u_use_albedo_map", material->useAlbedoMap ? 1.0f : 0.0f);
     shader.LoadFloat("u_use_normal_map", material->useNormalMap ? 1.0f : 0.0f);
@@ -105,7 +105,7 @@ void UploadMaterial(
 
 }
 
-EntityRenderer::EntityRenderer(AssetManager* assetManager)
+Scene3DRenderer::Scene3DRenderer(AssetManager* assetManager)
     : d_vao(std::make_unique<VertexArray>())
     , d_assetManager(assetManager)
     , d_particleManager(nullptr)
@@ -128,7 +128,7 @@ EntityRenderer::EntityRenderer(AssetManager* assetManager)
     d_animatedShader.Unbind();
 }
 
-void EntityRenderer::EnableShadows(const ShadowMap& shadowMap)
+void Scene3DRenderer::EnableShadows(const ShadowMap& shadowMap)
 {
     d_staticShader.Bind();
     d_staticShader.LoadSampler("shadow_map", SHADOW_MAP_SLOT);
@@ -143,7 +143,7 @@ void EntityRenderer::EnableShadows(const ShadowMap& shadowMap)
     shadowMap.GetShadowMap()->Bind(SHADOW_MAP_SLOT);
 }
 
-void EntityRenderer::Draw(
+void Scene3DRenderer::Draw(
     const glm::mat4& proj,
     const glm::mat4& view,
     Scene& scene)
@@ -218,14 +218,14 @@ void EntityRenderer::Draw(
     d_animatedShader.Unbind();
 }
 
-void EntityRenderer::Draw(const ecs::Entity& camera, Scene& scene)
+void Scene3DRenderer::Draw(const ecs::Entity& camera, Scene& scene)
 {
     glm::mat4 proj = MakeProj(camera);
     glm::mat4 view = MakeView(camera);
     Draw(proj, view, scene);
 }
 
-void EntityRenderer::EnableParticles(ParticleManager* particleManager)
+void Scene3DRenderer::EnableParticles(ParticleManager* particleManager)
 {
     d_particleManager = particleManager;
 }

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.h
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.h
@@ -10,7 +10,10 @@
 
 namespace Sprocket {
 
-class EntityRenderer
+class Scene3DRenderer
+// Renders a scene as a 3D Scene. This makes use of components such as
+// Transform3DComponent and ModelComponent, and will ignore 2D components
+// such as Transform2DComponent and SpriteComponent.
 {
 public:
     // PBR Texture Slots
@@ -38,7 +41,7 @@ private:
     std::vector<InstanceData> d_instanceData;
 
 public:
-    EntityRenderer(AssetManager* assetManager);
+    Scene3DRenderer(AssetManager* assetManager);
 
     void Draw(const ecs::Entity& camera, Scene& scene);
     void Draw(const glm::mat4& proj, const glm::mat4& view, Scene& scene);

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -54,7 +54,7 @@ void ShadowMap::Draw(
 
     std::unordered_map<std::string, std::vector<InstanceData>> commands;
     for (auto entity : scene.Entities().View<ModelComponent>()) {
-        const auto& tc = entity.Get<TransformComponent>();
+        const auto& tc = entity.Get<Transform3DComponent>();
         const auto& mc = entity.Get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         commands[mc.mesh].push_back({ tc.position, tc.orientation, tc.scale });

--- a/Sprocket/Scene/Camera.cpp
+++ b/Sprocket/Scene/Camera.cpp
@@ -6,15 +6,15 @@ namespace Sprocket {
 
 glm::mat4 MakeView(const ecs::Entity& entity)
 {
-    if (!entity.Has<TransformComponent>()) {
+    if (!entity.Has<Transform3DComponent>()) {
         SPKT_LOG_ERROR("Camera has no transform component!");
         return glm::mat4{1.0};
     }
 
-    auto tr = entity.Get<TransformComponent>();
+    auto tr = entity.Get<Transform3DComponent>();
 
-    if (entity.Has<CameraComponent>()) {
-        const auto& c = entity.Get<CameraComponent>();
+    if (entity.Has<Camera3DComponent>()) {
+        const auto& c = entity.Get<Camera3DComponent>();
         tr.orientation *= glm::rotate(glm::identity<glm::quat>(), c.pitch, {1, 0, 0});
     }
 
@@ -23,11 +23,11 @@ glm::mat4 MakeView(const ecs::Entity& entity)
 
 glm::mat4 MakeProj(const ecs::Entity& entity)
 {
-    if (!entity.Has<CameraComponent>()) {
+    if (!entity.Has<Camera3DComponent>()) {
         return glm::mat4(1.0);
     }
 
-    return entity.Get<CameraComponent>().projection;
+    return entity.Get<Camera3DComponent>().projection;
 }
 
 }

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -16,7 +16,14 @@ struct NameComponent
     std::string name = "Entity";
 };
 
-struct TransformComponent
+struct Transform2DComponent
+{
+    glm::vec2 position = glm::vec2{0.0f, 0.0f};
+    float rotation = 0.0f;
+    glm::vec2 scale = glm::vec2{1.0f, 1.0f};
+};
+
+struct Transform3DComponent
 {
     glm::vec3 position = glm::vec3{0.0f, 0.0f, 0.0f};
     glm::quat orientation = glm::quat{1.0f, 0.0f, 0.0f, 0.0f};
@@ -73,7 +80,7 @@ struct ScriptComponent
     bool active = true;
 };
 
-struct CameraComponent
+struct Camera3DComponent
 {
     glm::mat4 projection = glm::mat4{1.0};
     float fov = 70.0f;
@@ -129,7 +136,7 @@ struct ParticleComponent
     float accumulator = 0.0f;
 };
 
-struct AnimationComponent
+struct MeshAnimationComponent
 {
     std::string name = "";
     float time = 0.0f;

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -35,9 +35,17 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::EndMap;
         }
-        if (entity.Has<TransformComponent>()) {
-            const auto& c = entity.Get<TransformComponent>();
-            out << YAML::Key << "TransformComponent" << YAML::BeginMap;
+        if (entity.Has<Transform2DComponent>()) {
+            const auto& c = entity.Get<Transform2DComponent>();
+            out << YAML::Key << "Transform2DComponent" << YAML::BeginMap;
+            out << YAML::Key << "position" << YAML::Value << c.position;
+            out << YAML::Key << "rotation" << YAML::Value << c.rotation;
+            out << YAML::Key << "scale" << YAML::Value << c.scale;
+            out << YAML::EndMap;
+        }
+        if (entity.Has<Transform3DComponent>()) {
+            const auto& c = entity.Get<Transform3DComponent>();
+            out << YAML::Key << "Transform3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
             out << YAML::Key << "scale" << YAML::Value << c.scale;
@@ -97,9 +105,9 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "active" << YAML::Value << c.active;
             out << YAML::EndMap;
         }
-        if (entity.Has<CameraComponent>()) {
-            const auto& c = entity.Get<CameraComponent>();
-            out << YAML::Key << "CameraComponent" << YAML::BeginMap;
+        if (entity.Has<Camera3DComponent>()) {
+            const auto& c = entity.Get<Camera3DComponent>();
+            out << YAML::Key << "Camera3DComponent" << YAML::BeginMap;
             out << YAML::Key << "fov" << YAML::Value << c.fov;
             out << YAML::Key << "pitch" << YAML::Value << c.pitch;
             out << YAML::EndMap;
@@ -156,9 +164,9 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "life" << YAML::Value << c.life;
             out << YAML::EndMap;
         }
-        if (entity.Has<AnimationComponent>()) {
-            const auto& c = entity.Get<AnimationComponent>();
-            out << YAML::Key << "AnimationComponent" << YAML::BeginMap;
+        if (entity.Has<MeshAnimationComponent>()) {
+            const auto& c = entity.Get<MeshAnimationComponent>();
+            out << YAML::Key << "MeshAnimationComponent" << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::Key << "time" << YAML::Value << c.time;
             out << YAML::Key << "speed" << YAML::Value << c.speed;
@@ -205,12 +213,19 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.name = spec["name"] ? spec["name"].as<std::string>() : "Entity";
             e.Add<NameComponent>(c);
         }
-        if (auto spec = entity["TransformComponent"]) {
-            TransformComponent c;
+        if (auto spec = entity["Transform2DComponent"]) {
+            Transform2DComponent c;
+            c.position = spec["position"] ? spec["position"].as<glm::vec2>() : glm::vec2{0.0f, 0.0f};
+            c.rotation = spec["rotation"] ? spec["rotation"].as<float>() : 0.0f;
+            c.scale = spec["scale"] ? spec["scale"].as<glm::vec2>() : glm::vec2{1.0f, 1.0f};
+            e.Add<Transform2DComponent>(c);
+        }
+        if (auto spec = entity["Transform3DComponent"]) {
+            Transform3DComponent c;
             c.position = spec["position"] ? spec["position"].as<glm::vec3>() : glm::vec3{0.0f, 0.0f, 0.0f};
             c.orientation = spec["orientation"] ? spec["orientation"].as<glm::quat>() : glm::quat{1.0f, 0.0f, 0.0f, 0.0f};
             c.scale = spec["scale"] ? spec["scale"].as<glm::vec3>() : glm::vec3{1.0f, 1.0f, 1.0f};
-            e.Add<TransformComponent>(c);
+            e.Add<Transform3DComponent>(c);
         }
         if (auto spec = entity["ModelComponent"]) {
             ModelComponent c;
@@ -260,11 +275,11 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.active = spec["active"] ? spec["active"].as<bool>() : true;
             e.Add<ScriptComponent>(c);
         }
-        if (auto spec = entity["CameraComponent"]) {
-            CameraComponent c;
+        if (auto spec = entity["Camera3DComponent"]) {
+            Camera3DComponent c;
             c.fov = spec["fov"] ? spec["fov"].as<float>() : 70.0f;
             c.pitch = spec["pitch"] ? spec["pitch"].as<float>() : 0.0f;
-            e.Add<CameraComponent>(c);
+            e.Add<Camera3DComponent>(c);
         }
         if (auto spec = entity["SelectComponent"]) {
             SelectComponent c;
@@ -311,12 +326,12 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.life = spec["life"] ? spec["life"].as<float>() : 1.0f;
             e.Add<ParticleComponent>(c);
         }
-        if (auto spec = entity["AnimationComponent"]) {
-            AnimationComponent c;
+        if (auto spec = entity["MeshAnimationComponent"]) {
+            MeshAnimationComponent c;
             c.name = spec["name"] ? spec["name"].as<std::string>() : "";
             c.time = spec["time"] ? spec["time"].as<float>() : 0.0f;
             c.speed = spec["speed"] ? spec["speed"].as<float>() : 1.0f;
-            e.Add<AnimationComponent>(c);
+            e.Add<MeshAnimationComponent>(c);
         }
     }
 }
@@ -330,8 +345,11 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
     if (entity.Has<NameComponent>()) {
         e.Add<NameComponent>(entity.Get<NameComponent>());
     }
-    if (entity.Has<TransformComponent>()) {
-        e.Add<TransformComponent>(entity.Get<TransformComponent>());
+    if (entity.Has<Transform2DComponent>()) {
+        e.Add<Transform2DComponent>(entity.Get<Transform2DComponent>());
+    }
+    if (entity.Has<Transform3DComponent>()) {
+        e.Add<Transform3DComponent>(entity.Get<Transform3DComponent>());
     }
     if (entity.Has<ModelComponent>()) {
         e.Add<ModelComponent>(entity.Get<ModelComponent>());
@@ -351,8 +369,8 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
     if (entity.Has<ScriptComponent>()) {
         e.Add<ScriptComponent>(entity.Get<ScriptComponent>());
     }
-    if (entity.Has<CameraComponent>()) {
-        e.Add<CameraComponent>(entity.Get<CameraComponent>());
+    if (entity.Has<Camera3DComponent>()) {
+        e.Add<Camera3DComponent>(entity.Get<Camera3DComponent>());
     }
     if (entity.Has<SelectComponent>()) {
         e.Add<SelectComponent>(entity.Get<SelectComponent>());
@@ -375,8 +393,8 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
     if (entity.Has<ParticleComponent>()) {
         e.Add<ParticleComponent>(entity.Get<ParticleComponent>());
     }
-    if (entity.Has<AnimationComponent>()) {
-        e.Add<AnimationComponent>(entity.Get<AnimationComponent>());
+    if (entity.Has<MeshAnimationComponent>()) {
+        e.Add<MeshAnimationComponent>(entity.Get<MeshAnimationComponent>());
     }
     return e;
 }

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -20,7 +20,7 @@ void Save(const std::string& file, ecs::Registry* reg)
     out << YAML::Key << "Version" << YAML::Value << 2;
 
     out << YAML::Key << "Entities" << YAML::BeginSeq;
-    for (auto entity : reg->Fast()) {
+    for (auto entity : reg->Each()) {
         if (entity.Has<TemporaryComponent>()) { return; }
         out << YAML::BeginMap;
 #ifdef DATAMATIC_BLOCK SAVABLE=true
@@ -44,7 +44,7 @@ void Load(const std::string& file, ecs::Registry* reg)
 {
     // Must be a clean scene
     u32 count = 0;
-    for (ecs::Entity e : reg->Fast()) {
+    for (ecs::Entity e : reg->Each()) {
         if (!e.Has<TemporaryComponent>()) ++count;
     }
     assert(count == 0);
@@ -86,7 +86,7 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 
 void Copy(ecs::Registry* source, ecs::Registry* target)
 {
-    for (auto entity : source->Fast()) {
+    for (auto entity : source->Each()) {
         Copy(target, entity);
     }
 }

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -7,8 +7,8 @@ namespace Sprocket {
 
 void AnimationSystem::OnUpdate(Scene& scene, double dt)
 {
-    for (auto entity : scene.Entities().View<AnimationComponent>()) {
-        auto& ac = entity.Get<AnimationComponent>();
+    for (auto entity : scene.Entities().View<MeshAnimationComponent>()) {
+        auto& ac = entity.Get<MeshAnimationComponent>();
         ac.time += (float)dt * ac.speed;
     }
 }

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -12,8 +12,8 @@ CameraSystem::CameraSystem(float aspectRatio)
 
 void CameraSystem::OnStartup(Scene& scene)
 {
-    scene.Entities().OnAdd<CameraComponent>([&](ecs::Entity entity) {
-        auto& camera = entity.Get<CameraComponent>();
+    scene.Entities().OnAdd<Camera3DComponent>([&](ecs::Entity entity) {
+        auto& camera = entity.Get<Camera3DComponent>();
         camera.projection = glm::perspective(
             camera.fov, d_aspectRatio, 0.1f, 1000.0f
         );
@@ -25,8 +25,8 @@ void CameraSystem::OnEvent(Scene& scene, Event& event)
     if (auto e = event.As<WindowResizeEvent>()) {
         d_aspectRatio = e->AspectRatio();
 
-        for (auto entity : scene.Entities().View<CameraComponent>()) {
-            auto& camera = entity.Get<CameraComponent>();
+        for (auto entity : scene.Entities().View<Camera3DComponent>()) {
+            auto& camera = entity.Get<Camera3DComponent>();
             camera.projection = glm::perspective(
                 camera.fov, d_aspectRatio, 0.1f, 1000.0f
             );

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -33,7 +33,7 @@ void GameGrid::OnStartup(Scene& scene)
     auto& n1 = d_hoveredSquare.Add<NameComponent>();
     d_hoveredSquare.Add<TemporaryComponent>();
     n1.name = "Hovered Grid Highlighter";
-    auto& tr1 = d_hoveredSquare.Add<TransformComponent>();
+    auto& tr1 = d_hoveredSquare.Add<Transform3DComponent>();
     tr1.scale = {0.3f, 0.3f, 0.3f};
     auto& model1 = d_hoveredSquare.Add<ModelComponent>();
     model1.mesh = gridSquare;
@@ -42,13 +42,13 @@ void GameGrid::OnStartup(Scene& scene)
     auto& n2 = d_selectedSquare.Add<NameComponent>();
     d_selectedSquare.Add<TemporaryComponent>();
     n2.name = "Selected Grid Highlighter";
-    auto& tr2 = d_selectedSquare.Add<TransformComponent>();
+    auto& tr2 = d_selectedSquare.Add<Transform3DComponent>();
     tr2.scale = {0.5f, 0.5f, 0.5f};
     auto& model2 = d_selectedSquare.Add<ModelComponent>();
     model2.mesh = gridSquare;
 
     scene.Entities().OnAdd<GridComponent>([&](ecs::Entity entity) {
-        auto& transform = entity.Get<TransformComponent>();
+        auto& transform = entity.Get<Transform3DComponent>();
         const auto& gc = entity.Get<GridComponent>();
 
         assert(!d_gridEntities.contains({gc.x, gc.z}));
@@ -73,7 +73,7 @@ void GameGrid::OnStartup(Scene& scene)
 
 void GameGrid::OnUpdate(Sprocket::Scene&, double dt)
 {
-    auto& camTr = d_camera.Get<TransformComponent>();
+    auto& camTr = d_camera.Get<Transform3DComponent>();
 
     glm::vec3 cameraPos = camTr.position;
     glm::vec3 direction = Maths::GetMouseRay(
@@ -88,11 +88,11 @@ void GameGrid::OnUpdate(Sprocket::Scene&, double dt)
     glm::vec3 mousePos = cameraPos + lambda * direction;
     d_hovered = {(int)std::floor(mousePos.x), (int)std::floor(mousePos.z)};
 
-    d_hoveredSquare.Get<TransformComponent>().position = { d_hovered.x + 0.5f, 0.05f, d_hovered.y + 0.5f };
+    d_hoveredSquare.Get<Transform3DComponent>().position = { d_hovered.x + 0.5f, 0.05f, d_hovered.y + 0.5f };
     if (d_selected.has_value()) {
-        d_selectedSquare.Get<TransformComponent>().position = { d_selected.value().x + 0.5f, 0.05f, d_selected.value().y + 0.5f };
+        d_selectedSquare.Get<Transform3DComponent>().position = { d_selected.value().x + 0.5f, 0.05f, d_selected.value().y + 0.5f };
     } else {
-        d_selectedSquare.Get<TransformComponent>().position = { 0.5f, -1.0f, 0.5f };
+        d_selectedSquare.Get<Transform3DComponent>().position = { 0.5f, -1.0f, 0.5f };
     }
 }
 

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -12,7 +12,7 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 void ParticleSystem::OnUpdate(Scene& scene, double dt)
 {
     for (auto entity : scene.Entities().View<ParticleComponent>()) {
-        auto& tc = entity.Get<TransformComponent>();
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& pc = entity.Get<ParticleComponent>();
 
         pc.accumulator += dt;

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -7,7 +7,7 @@ namespace Sprocket {
 void PathFollower::OnUpdate(Sprocket::Scene& scene, double dt)
 {
     for (auto entity : scene.Entities().View<PathComponent>()) {
-        auto& transform = entity.Get<TransformComponent>();
+        auto& transform = entity.Get<Transform3DComponent>();
         auto& path = entity.Get<PathComponent>();
         if (path.markers.empty()) { return; }
         

--- a/Sprocket/Scene/Systems/PhysicsEngine.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine.cpp
@@ -52,7 +52,7 @@ rp3d::Transform Convert(const glm::vec3& position, const glm::quat& orientation)
     return t;
 }
 
-rp3d::Transform Convert(const TransformComponent& transform)
+rp3d::Transform Convert(const Transform3DComponent& transform)
 {
     return Convert(transform.position, transform.orientation);
 }
@@ -131,8 +131,8 @@ PhysicsEngine::PhysicsEngine(const glm::vec3& gravity)
 void PhysicsEngine::OnStartup(Scene& scene)
 {
     scene.Entities().OnAdd<RigidBody3DComponent>([&](ecs::Entity entity) {
-        assert(entity.Has<TransformComponent>());
-        auto& tc = entity.Get<TransformComponent>();
+        assert(entity.Has<Transform3DComponent>());
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& rc = entity.Get<RigidBody3DComponent>();
 
         auto& entry = d_impl->entityData[entity];
@@ -152,10 +152,10 @@ void PhysicsEngine::OnStartup(Scene& scene)
     });
 
     scene.Entities().OnAdd<BoxCollider3DComponent>([&](ecs::Entity entity) {
-        assert(entity.Has<TransformComponent>());
+        assert(entity.Has<Transform3DComponent>());
         assert(entity.Has<RigidBody3DComponent>());
 
-        auto& tc = entity.Get<TransformComponent>();
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& bc = entity.Get<BoxCollider3DComponent>();
         auto& entry = d_impl->entityData[entity];
 
@@ -174,10 +174,10 @@ void PhysicsEngine::OnStartup(Scene& scene)
     });
 
     scene.Entities().OnAdd<SphereCollider3DComponent>([&](ecs::Entity entity) {
-        assert(entity.Has<TransformComponent>());
+        assert(entity.Has<Transform3DComponent>());
         assert(entity.Has<RigidBody3DComponent>());
 
-        auto& tc = entity.Get<TransformComponent>();
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& sc = entity.Get<SphereCollider3DComponent>();
         auto& entry = d_impl->entityData[entity];
         
@@ -194,10 +194,10 @@ void PhysicsEngine::OnStartup(Scene& scene)
     });
 
     scene.Entities().OnAdd<CapsuleCollider3DComponent>([&](ecs::Entity entity) {
-        assert(entity.Has<TransformComponent>());
+        assert(entity.Has<Transform3DComponent>());
         assert(entity.Has<RigidBody3DComponent>());
 
-        auto& tc = entity.Get<TransformComponent>();
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& cc = entity.Get<CapsuleCollider3DComponent>();
         auto& entry = d_impl->entityData[entity];
         
@@ -220,7 +220,7 @@ void PhysicsEngine::OnUpdate(Scene& scene, double dt)
     // Do this even if not running so that the physics engine stays up
     // to date with the scene.
     for (auto entity : scene.Entities().View<RigidBody3DComponent>()) {
-        const auto& tc = entity.Get<TransformComponent>();
+        const auto& tc = entity.Get<Transform3DComponent>();
         const auto& physics = entity.Get<RigidBody3DComponent>();
 
         auto& entry = d_impl->entityData[entity];
@@ -265,7 +265,7 @@ void PhysicsEngine::OnUpdate(Scene& scene, double dt)
 
     // Post Update
     for (auto entity : scene.Entities().View<RigidBody3DComponent>()) {
-        auto& tc = entity.Get<TransformComponent>();
+        auto& tc = entity.Get<Transform3DComponent>();
         auto& rc = entity.Get<RigidBody3DComponent>();
         const rp3d::RigidBody* body = d_impl->entityData[entity].body;
 

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -1,4 +1,4 @@
-#include "PhysicsEngine.h"
+#include "PhysicsEngine3D.h"
 #include "Log.h"
 #include "Scene.h"
 #include "Components.h"
@@ -97,7 +97,7 @@ struct EntityData
     rp3d::Collider* capsuleCollider = nullptr;
 };
 
-struct PhysicsEngineImpl
+struct PhysicsEngine3DImpl
 {
     rp3d::PhysicsCommon pc;
     rp3d::PhysicsWorld* world;
@@ -106,7 +106,7 @@ struct PhysicsEngineImpl
 
     std::unordered_map<ecs::Entity, EntityData> entityData;
 
-    PhysicsEngineImpl(const glm::vec3& gravity)
+    PhysicsEngine3DImpl(const glm::vec3& gravity)
     {
         rp3d::PhysicsWorld::WorldSettings settings;
         settings.gravity = Convert(gravity);
@@ -114,7 +114,7 @@ struct PhysicsEngineImpl
         world = pc.createPhysicsWorld(settings);
     }
 
-    ~PhysicsEngineImpl()
+    ~PhysicsEngine3DImpl()
     {
         for (auto& [entity, data] : entityData) {
             world->destroyRigidBody(data.body);
@@ -123,12 +123,12 @@ struct PhysicsEngineImpl
     }
 };
 
-PhysicsEngine::PhysicsEngine(const glm::vec3& gravity)
-    : d_impl(std::make_unique<PhysicsEngineImpl>(gravity))
+PhysicsEngine3D::PhysicsEngine3D(const glm::vec3& gravity)
+    : d_impl(std::make_unique<PhysicsEngine3DImpl>(gravity))
 {
 }
 
-void PhysicsEngine::OnStartup(Scene& scene)
+void PhysicsEngine3D::OnStartup(Scene& scene)
 {
     scene.Entities().OnAdd<RigidBody3DComponent>([&](ecs::Entity entity) {
         assert(entity.Has<Transform3DComponent>());
@@ -214,7 +214,7 @@ void PhysicsEngine::OnStartup(Scene& scene)
     });
 }
 
-void PhysicsEngine::OnUpdate(Scene& scene, double dt)
+void PhysicsEngine3D::OnUpdate(Scene& scene, double dt)
 {
     // Pre Update
     // Do this even if not running so that the physics engine stays up
@@ -278,7 +278,7 @@ void PhysicsEngine::OnUpdate(Scene& scene, double dt)
     }
 }
 
-ecs::Entity PhysicsEngine::Raycast(const glm::vec3& base,
+ecs::Entity PhysicsEngine3D::Raycast(const glm::vec3& base,
                                    const glm::vec3& direction)
 {
     glm::vec3 d = glm::normalize(direction);
@@ -293,7 +293,7 @@ ecs::Entity PhysicsEngine::Raycast(const glm::vec3& base,
     return cb.GetEntity();
 }
 
-bool PhysicsEngine::IsOnFloor(ecs::Entity entity) const
+bool PhysicsEngine3D::IsOnFloor(ecs::Entity entity) const
 {
     // Get the point at the bottom of the rigid body.
     auto aabb = d_impl->entityData[entity].body->getAABB();

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -16,10 +16,6 @@ class PhysicsEngine3D : public EntitySystem
 
     std::unique_ptr<PhysicsEngine3DImpl> d_impl;
 
-    bool IsOnFloor(ecs::Entity entity) const; 
-        // Returns true if the given Entity is colliding with another
-        // Entity directly below it. TODO: Make this more general.
-
 public:
     PhysicsEngine3D(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
     ~PhysicsEngine3D() = default;

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -8,21 +8,21 @@
 
 namespace Sprocket {
 
-struct PhysicsEngineImpl;
+struct PhysicsEngine3DImpl;
 
-class PhysicsEngine : public EntitySystem
+class PhysicsEngine3D : public EntitySystem
 {
     static constexpr float TIME_STEP = 1.0f / 60.0f;
 
-    std::unique_ptr<PhysicsEngineImpl> d_impl;
+    std::unique_ptr<PhysicsEngine3DImpl> d_impl;
 
     bool IsOnFloor(ecs::Entity entity) const; 
         // Returns true if the given Entity is colliding with another
         // Entity directly below it. TODO: Make this more general.
 
 public:
-    PhysicsEngine(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
-    ~PhysicsEngine() = default;
+    PhysicsEngine3D(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
+    ~PhysicsEngine3D() = default;
 
     void OnStartup(Scene& scene) override;
     void OnUpdate(Scene& scene, double dt) override;

--- a/Sprocket/Scripting/LuaComponents.dm.cpp
+++ b/Sprocket/Scripting/LuaComponents.dm.cpp
@@ -36,6 +36,13 @@ int Push(lua_State* L, const bool& value)
     return 1;
 }
 
+int Push(lua_State* L, const glm::vec2& value)
+{
+    lua_pushnumber(L, value.x);
+    lua_pushnumber(L, value.y);
+    return 3;
+}
+
 int Push(lua_State* L, const glm::vec3& value)
 {
     lua_pushnumber(L, value.x);
@@ -79,6 +86,13 @@ template <> glm::vec3 Pull(lua_State* L, int& count)
     return {x, y, z};
 }
 
+template <> glm::vec2 Pull(lua_State* L, int& count)
+{
+    float x = (float)lua_tonumber(L, count++);
+    float y = (float)lua_tonumber(L, count++);
+    return {x, y};
+}
+
 template <> glm::quat Pull(lua_State* L, int& count)
 {
     float x = (float)lua_tonumber(L, count++);
@@ -99,6 +113,7 @@ template <> constexpr int Dimension<int>() { return 1; }
 template <> constexpr int Dimension<float>() { return 1; }
 template <> constexpr int Dimension<bool>() { return 1; }
 template <> constexpr int Dimension<std::string>() { return 1; }
+template <> constexpr int Dimension<glm::vec2>() { return 2; }
 template <> constexpr int Dimension<glm::vec3>() { return 3; }
 template <> constexpr int Dimension<glm::quat>() { return 4; }
 
@@ -116,7 +131,7 @@ template<typename T> int Lua_Has(lua_State* L)
 {
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
-    ECS::Entity entity = *static_cast<ECS::Entity*>(lua_touserdata(L, 1));
+    ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
     lua_pushboolean(L, entity.Has<T>());
     return 1;
 }
@@ -141,7 +156,7 @@ int Get{{Comp.Name}}(lua_State* L)
 {
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
-    ECS::Entity e = *static_cast<ECS::Entity*>(lua_touserdata(L, 1));
+    ecs::Entity e = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
     assert(e.Has<{{Comp.Name}}>());
 
     int count = 0;
@@ -155,7 +170,7 @@ int Set{{Comp.Name}}(lua_State* L)
     if (!CheckArgCount(L, {{Comp.Name}}Dimension() + 1)) { return luaL_error(L, "Bad number of args"); }
 
     int count = 2;
-    ECS::Entity e = *static_cast<ECS::Entity*>(lua_touserdata(L, 1));
+    ecs::Entity e = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
     auto& c = e.Get<{{Comp.Name}}>();
     c.{{Attr.Name}} = Pull<{{Attr.Type}}>(L, count);
     return 0;
@@ -166,7 +181,7 @@ int Add{{Comp.Name}}(lua_State* L)
     if (!CheckArgCount(L, {{Comp.Name}}Dimension() + 1)) { return luaL_error(L, "Bad number of args"); }
 
     int count = 2;
-    ECS::Entity e = *static_cast<ECS::Entity*>(lua_touserdata(L, 1));
+    ecs::Entity e = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
     assert(!e.Has<{{Comp.Name}}>());
 
     {{Comp.Name}} c;

--- a/Sprocket/Scripting/LuaComponents.h
+++ b/Sprocket/Scripting/LuaComponents.h
@@ -12,9 +12,13 @@ int GetNameComponent(lua_State* L);
 int SetNameComponent(lua_State* L);
 int AddNameComponent(lua_State* L);
 
-int GetTransformComponent(lua_State* L);
-int SetTransformComponent(lua_State* L);
-int AddTransformComponent(lua_State* L);
+int GetTransform2DComponent(lua_State* L);
+int SetTransform2DComponent(lua_State* L);
+int AddTransform2DComponent(lua_State* L);
+
+int GetTransform3DComponent(lua_State* L);
+int SetTransform3DComponent(lua_State* L);
+int AddTransform3DComponent(lua_State* L);
 
 int GetModelComponent(lua_State* L);
 int SetModelComponent(lua_State* L);
@@ -40,9 +44,9 @@ int GetScriptComponent(lua_State* L);
 int SetScriptComponent(lua_State* L);
 int AddScriptComponent(lua_State* L);
 
-int GetCameraComponent(lua_State* L);
-int SetCameraComponent(lua_State* L);
-int AddCameraComponent(lua_State* L);
+int GetCamera3DComponent(lua_State* L);
+int SetCamera3DComponent(lua_State* L);
+int AddCamera3DComponent(lua_State* L);
 
 int GetSelectComponent(lua_State* L);
 int SetSelectComponent(lua_State* L);
@@ -72,9 +76,9 @@ int GetParticleComponent(lua_State* L);
 int SetParticleComponent(lua_State* L);
 int AddParticleComponent(lua_State* L);
 
-int GetAnimationComponent(lua_State* L);
-int SetAnimationComponent(lua_State* L);
-int AddAnimationComponent(lua_State* L);
+int GetMeshAnimationComponent(lua_State* L);
+int SetMeshAnimationComponent(lua_State* L);
+int AddMeshAnimationComponent(lua_State* L);
 
 
 }

--- a/Sprocket/Scripting/LuaTransform.cpp
+++ b/Sprocket/Scripting/LuaTransform.cpp
@@ -39,7 +39,7 @@ int SetLookAt(lua_State* L)
     float ty = (float)lua_tonumber(L, 6);
     float tz = (float)lua_tonumber(L, 7);
 
-    auto& tr = entity.Get<TransformComponent>();
+    auto& tr = entity.Get<Transform3DComponent>();
     tr.position = {px, py, pz};
     tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, {tx, ty, tz}, {0.0, 1.0, 0.0})));
     return 0;
@@ -50,7 +50,7 @@ int RotateY(lua_State* L)
     if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); };
 
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    auto& tr = entity.Get<TransformComponent>();
+    auto& tr = entity.Get<Transform3DComponent>();
 
     float yaw = (float)lua_tonumber(L, 2);
     tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
@@ -62,11 +62,11 @@ int GetForwardsDir(lua_State* L)
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    auto& tr = entity.Get<TransformComponent>();
+    auto& tr = entity.Get<Transform3DComponent>();
     auto o = tr.orientation;
     
-    if (entity.Has<CameraComponent>()) {
-        auto pitch = entity.Get<CameraComponent>().pitch;
+    if (entity.Has<Camera3DComponent>()) {
+        auto pitch = entity.Get<Camera3DComponent>().pitch;
         o = glm::rotate(o, pitch, {1, 0, 0});
     }
 
@@ -83,7 +83,7 @@ int GetRightDir(lua_State* L)
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    auto& tr = entity.Get<TransformComponent>();
+    auto& tr = entity.Get<Transform3DComponent>();
     auto right = Maths::Right(tr.orientation);
     lua_pushnumber(L, right.x);
     lua_pushnumber(L, right.y);
@@ -95,7 +95,7 @@ int MakeUpright(lua_State* L)
 {
     if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    auto& tr = entity.Get<TransformComponent>();
+    auto& tr = entity.Get<Transform3DComponent>();
     float yaw = (float)lua_tonumber(L, 2);
     tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
     return 0;

--- a/Sprocket/Scripting/Sprocket_Components.lua
+++ b/Sprocket/Scripting/Sprocket_Components.lua
@@ -17,22 +17,42 @@ function AddNameComponent(entity, c)
 end
 
 
-TransformComponent = Class(function(self, position, scale)
+Transform2DComponent = Class(function(self, position, rotation, scale)
+    self.position = position
+    self.rotation = rotation
+    self.scale = scale
+end)
+
+function GetTransform2DComponent(entity)
+    x0, x1, x2, x3, x4 = Lua_GetTransform2DComponent(entity)
+    return Transform2DComponent(Vec3(x0, x1), x2, Vec3(x3, x4))
+end
+
+function SetTransform2DComponent(entity, c)
+    Lua_SetTransform2DComponent(entity, c.position, c.rotation, c.scale)
+end
+
+function AddTransform2DComponent(entity, c)
+    Lua_AddTransform2DComponent(entity, c.position, c.rotation, c.scale)
+end
+
+
+Transform3DComponent = Class(function(self, position, scale)
     self.position = position
     self.scale = scale
 end)
 
-function GetTransformComponent(entity)
-    x0, x1, x2, x3, x4, x5 = Lua_GetTransformComponent(entity)
-    return TransformComponent(Vec3(x0, x1, x2), Vec3(x3, x4, x5))
+function GetTransform3DComponent(entity)
+    x0, x1, x2, x3, x4, x5 = Lua_GetTransform3DComponent(entity)
+    return Transform3DComponent(Vec3(x0, x1, x2), Vec3(x3, x4, x5))
 end
 
-function SetTransformComponent(entity, c)
-    Lua_SetTransformComponent(entity, c.position.x, c.position.y, c.position.z, c.scale.x, c.scale.y, c.scale.z)
+function SetTransform3DComponent(entity, c)
+    Lua_SetTransform3DComponent(entity, c.position.x, c.position.y, c.position.z, c.scale.x, c.scale.y, c.scale.z)
 end
 
-function AddTransformComponent(entity, c)
-    Lua_AddTransformComponent(entity, c.position.x, c.position.y, c.position.z, c.scale.x, c.scale.y, c.scale.z)
+function AddTransform3DComponent(entity, c)
+    Lua_AddTransform3DComponent(entity, c.position.x, c.position.y, c.position.z, c.scale.x, c.scale.y, c.scale.z)
 end
 
 
@@ -161,22 +181,22 @@ function AddScriptComponent(entity, c)
 end
 
 
-CameraComponent = Class(function(self, fov, pitch)
+Camera3DComponent = Class(function(self, fov, pitch)
     self.fov = fov
     self.pitch = pitch
 end)
 
-function GetCameraComponent(entity)
-    x0, x1 = Lua_GetCameraComponent(entity)
-    return CameraComponent(x0, x1)
+function GetCamera3DComponent(entity)
+    x0, x1 = Lua_GetCamera3DComponent(entity)
+    return Camera3DComponent(x0, x1)
 end
 
-function SetCameraComponent(entity, c)
-    Lua_SetCameraComponent(entity, c.fov, c.pitch)
+function SetCamera3DComponent(entity, c)
+    Lua_SetCamera3DComponent(entity, c.fov, c.pitch)
 end
 
-function AddCameraComponent(entity, c)
-    Lua_AddCameraComponent(entity, c.fov, c.pitch)
+function AddCamera3DComponent(entity, c)
+    Lua_AddCamera3DComponent(entity, c.fov, c.pitch)
 end
 
 
@@ -318,23 +338,23 @@ function AddParticleComponent(entity, c)
 end
 
 
-AnimationComponent = Class(function(self, name, time, speed)
+MeshAnimationComponent = Class(function(self, name, time, speed)
     self.name = name
     self.time = time
     self.speed = speed
 end)
 
-function GetAnimationComponent(entity)
-    x0, x1, x2 = Lua_GetAnimationComponent(entity)
-    return AnimationComponent(x0, x1, x2)
+function GetMeshAnimationComponent(entity)
+    x0, x1, x2 = Lua_GetMeshAnimationComponent(entity)
+    return MeshAnimationComponent(x0, x1, x2)
 end
 
-function SetAnimationComponent(entity, c)
-    Lua_SetAnimationComponent(entity, c.name, c.time, c.speed)
+function SetMeshAnimationComponent(entity, c)
+    Lua_SetMeshAnimationComponent(entity, c.name, c.time, c.speed)
 end
 
-function AddAnimationComponent(entity, c)
-    Lua_AddAnimationComponent(entity, c.name, c.time, c.speed)
+function AddMeshAnimationComponent(entity, c)
+    Lua_AddMeshAnimationComponent(entity, c.name, c.time, c.speed)
 end
 
 

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -80,7 +80,7 @@
 #include "Graphics/PostProcessing/Negative.h"
 
 #include "Graphics/Rendering/ColliderRenderer.h"
-#include "Graphics/Rendering/EntityRenderer.h"
+#include "Graphics/Rendering/Scene3DRenderer.h"
 #include "Graphics/Rendering/SkyboxRenderer.h"
 
 // AUDIO

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -29,7 +29,7 @@
 #include "Scene/Systems/AnimationSystem.h"
 #include "Scene/Systems/CameraSystem.h"
 #include "Scene/Systems/ParticleSystem.h"
-#include "Scene/Systems/PhysicsEngine.h"
+#include "Scene/Systems/PhysicsEngine3D.h"
 #include "Scene/Systems/GameGrid.h"
 #include "Scene/Systems/PathFollower.h"
 #include "Scene/Systems/ScriptRunner.h"

--- a/Sprocket/Utility/Yaml.cpp
+++ b/Sprocket/Utility/Yaml.cpp
@@ -117,6 +117,13 @@ bool convert<glm::mat4>::decode(const Node& node, glm::mat4& rhs)
 
 namespace Sprocket {
 
+YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v)
+{
+    out << YAML::Flow;
+    out << YAML::BeginSeq << v.x << v.y << YAML::EndSeq;
+    return out;
+}
+
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec3& v)
 {
     out << YAML::Flow;

--- a/Sprocket/Utility/Yaml.h
+++ b/Sprocket/Utility/Yaml.h
@@ -38,7 +38,8 @@ struct convert<glm::mat4>
 }
 
 namespace Sprocket {
- 
+
+YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec3& v);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::quat& q);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::mat4& m);


### PR DESCRIPTION
In the next future, I will be adding support for 2D games. Because of this, several classes need to be renamed as they are 3D only and there will be new 2D analogues of them.
- Rename `TransformComponent` to `Transform3DComponent`
- Rename `CameraComponent` to `Camera3DComponent`.
- Rename `AnimationComponent` to `MeshAnimationComponent`.
- Rename `PhysicsEngine` to `PhysicsEngine3D`.
- Added `Transform2DComponent`.
- Added support for `glm::vec2` translations to Lua.
- Fix some of the datamatic files which hadn't been ran in a while.
- Removed the `InOnFloor` function from the private section of `PhysicsEngine3D`. This now only exists in the `.cpp` file. It never needed to be in the interface as all of the data for the physics engine is contained in the pimpl.