### PR TITLE
Custom Logging Functions

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -167,34 +167,34 @@ void Anvil::OnRender()
             if (ImGui::MenuItem("New")) {
                 std::string file = SaveFile(d_window, "*.yaml");
                 if (!file.empty()) {
-                    SPKT_LOG_INFO("Creating {}...", d_sceneFile);
+                    log::info("Creating {}...", d_sceneFile);
                     d_sceneFile = file;
                     d_scene->Clear();
-                    SPKT_LOG_INFO("...done!");
+                    log::info("...done!");
                 }
             }
             if (ImGui::MenuItem("Open")) {
                 std::string file = OpenFile(d_window, "*.yaml");
                 if (!file.empty()) {
-                    SPKT_LOG_INFO("Loading {}...", d_sceneFile);
+                    log::info("Loading {}...", d_sceneFile);
                     d_sceneFile = file;
                     d_scene->Clear();
                     Loader::Load(file, &d_scene->Entities());
-                    SPKT_LOG_INFO("...done!");
+                    log::info("...done!");
                 }
             }
             if (ImGui::MenuItem("Save")) {
-                SPKT_LOG_INFO("Saving {}...", d_sceneFile);
+                log::info("Saving {}...", d_sceneFile);
                 Loader::Save(d_sceneFile, &d_scene->Entities());
-                SPKT_LOG_INFO("...done!");
+                log::info("...done!");
             }
             if (ImGui::MenuItem("Save As")) {
                 std::string file = SaveFile(d_window, "*.yaml");
                 if (!file.empty()) {
-                    SPKT_LOG_INFO("Saving as {}...", file);
+                    log::info("Saving as {}...", file);
                     d_sceneFile = file;
                     Loader::Save(file, &d_scene->Entities());
-                    SPKT_LOG_INFO("...done!");
+                    log::info("...done!");
                 }
             }
             ImGui::EndMenu();

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -417,7 +417,12 @@ void WorldLayer::OnRender()
     d_escapeMenu.StartPanel("Button Panel", &shape2, PanelType::DRAGGABLE);
     d_escapeMenu.Text("Buttons", 36.0f, {0, 0, 400, 100});
     glm::vec4 buttonQuad{10, 100, 400 - 20, 50};
-    d_escapeMenu.Button("Button 1", buttonQuad);
+    if (d_escapeMenu.Button("Button 1", buttonQuad)) {
+        log::warn("Warn");
+        log::info("Info");
+        log::error("Error");
+        log::fatal("Fatal");
+    }
     buttonQuad.y += 60;
     d_escapeMenu.Button("Button 2", buttonQuad);
     buttonQuad.y += 60;

--- a/Game/PathCalculator.cpp
+++ b/Game/PathCalculator.cpp
@@ -76,7 +76,7 @@ std::queue<glm::vec3> GenerateAStarPath(
     std::queue<glm::vec3> path;
 
     if (current->position != p2) {
-        SPKT_LOG_INFO("No path found!");
+        log::info("No path found!");
         return path;
     }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 - glad 
 - glm 
 - fmt
-- spdlog 
 - freetype 
 - assimp
 - imgui

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(glfw3 CONFIG REQUIRED)
 find_package(glad CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
-find_package(spdlog CONFIG REQUIRED)
 find_package(freetype CONFIG REQUIRED)
 find_package(assimp CONFIG REQUIRED)
 find_package(lua REQUIRED)
@@ -109,7 +108,6 @@ target_link_libraries(Sprocket PUBLIC
                       glad::glad
                       glm
                       fmt::fmt
-                      spdlog::spdlog
                       freetype
                       assimp::assimp
                       sfml-system

--- a/Sprocket/Core/Window.cpp
+++ b/Sprocket/Core/Window.cpp
@@ -21,7 +21,7 @@ Window::Window(const std::string& name, u32 width, u32 height)
 	, d_data({name, width, height})
 	, d_clearColour({1.0, 1.0, 1.0})
 {
-	Log::Init();
+	log::init();
 	
 	glfwInit();
 
@@ -43,7 +43,7 @@ Window::Window(const std::string& name, u32 width, u32 height)
 	int versionMinor;
 	glGetIntegerv(GL_MAJOR_VERSION, &versionMajor);
 	glGetIntegerv(GL_MINOR_VERSION, &versionMinor);
-	SPKT_LOG_INFO("OpenGL version: {}.{}", versionMajor, versionMinor);
+	log::info("OpenGL version: {}.{}", versionMajor, versionMinor);
 
 	// Set OpenGL error callback
 	glEnable(GL_DEBUG_OUTPUT);
@@ -52,13 +52,13 @@ Window::Window(const std::string& name, u32 width, u32 height)
 		switch (severity) {
 			case GL_DEBUG_SEVERITY_NOTIFICATION: return;
 			case GL_DEBUG_SEVERITY_LOW: {
-				SPKT_LOG_TRACE("{}, {}, {}, {}, {}", source, type, id, length, message);
+				log::info("{}, {}, {}, {}, {}", source, type, id, length, message);
 			} break;
 			case GL_DEBUG_SEVERITY_MEDIUM: {
-				SPKT_LOG_WARN("{}, {}, {}, {}, {}", source, type, id, length, message);
+				log::warn("{}, {}, {}, {}, {}", source, type, id, length, message);
 			} break;
 			case GL_DEBUG_SEVERITY_HIGH: {
-				SPKT_LOG_ERROR("{}, {}, {}, {}, {}", source, type, id, length, message);
+				log::error("{}, {}, {}, {}, {}", source, type, id, length, message);
 			} break;
 		}
 	}, nullptr);

--- a/Sprocket/Graphics/DepthBuffer.cpp
+++ b/Sprocket/Graphics/DepthBuffer.cpp
@@ -22,7 +22,7 @@ DepthBuffer::DepthBuffer(int width, int height)
     
      // Validate the framebuffer.
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        SPKT_LOG_ERROR("Created FBO is not complete!");
+        log::error("Created FBO is not complete!");
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/Sprocket/Graphics/FrameBuffer.cpp
+++ b/Sprocket/Graphics/FrameBuffer.cpp
@@ -63,7 +63,7 @@ void FrameBuffer::SetScreenSize(int width, int height)
 
     // Validate the framebuffer.
     if (glCheckNamedFramebufferStatus(d_fbo, GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        SPKT_LOG_ERROR("Created FBO is not complete!");
+        log::error("Created FBO is not complete!");
     }
 
     d_width = width;

--- a/Sprocket/Graphics/Shader.cpp
+++ b/Sprocket/Graphics/Shader.cpp
@@ -19,7 +19,7 @@ namespace {
 std::string ParseShader(const std::string& filepath)
 {
 	if (!std::filesystem::exists(filepath)) {
-		SPKT_LOG_FATAL("Shader file '{}' does not exist!", filepath);
+		log::fatal("Shader file '{}' does not exist!", filepath);
 	}
 	std::ifstream stream(filepath);
 	std::string shader((std::istreambuf_iterator<char>(stream)),
@@ -76,7 +76,7 @@ u32 Shader::CompileShader(u32 type, const std::string& source)
 	glGetShaderiv(id, GL_COMPILE_STATUS, &result);
 
 	if (result == GL_FALSE) {
-        SPKT_LOG_ERROR("Could not compile shader {}", (type == GL_VERTEX_SHADER) ? "VERTEX" : "FRAGMENT");
+        log::error("Could not compile shader {}", (type == GL_VERTEX_SHADER) ? "VERTEX" : "FRAGMENT");
 		glDeleteShader(id);
 		return 0;
 	}

--- a/Sprocket/Graphics/StreamBuffer.cpp
+++ b/Sprocket/Graphics/StreamBuffer.cpp
@@ -51,7 +51,7 @@ void StreamBuffer::SetBufferLayout(const BufferLayout& layout) const
         Unbind();
     }
     else {
-        SPKT_LOG_ERROR("Buffer layout is not complete!");
+        log::error("Buffer layout is not complete!");
     }
 }
 

--- a/Sprocket/Scene/Camera.cpp
+++ b/Sprocket/Scene/Camera.cpp
@@ -8,7 +8,7 @@ namespace Sprocket {
 glm::mat4 MakeView(const ecs::Entity& entity)
 {
     if (!entity.Has<Transform3DComponent>()) {
-        SPKT_LOG_ERROR("Camera has no transform component!");
+        log::error("Camera has no transform component!");
         return glm::mat4{1.0};
     }
 

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -63,7 +63,7 @@ void GameGrid::OnStartup(Scene& scene)
 
         auto it = d_gridEntities.find({gc.x, gc.z});
         if (it == d_gridEntities.end()) {
-            SPKT_LOG_WARN("No entity exists at this coord!");
+            log::warn("No entity exists at this coord!");
         }
         else {
             d_gridEntities.erase(it);

--- a/Sprocket/Scripting/LuaEngine.cpp
+++ b/Sprocket/Scripting/LuaEngine.cpp
@@ -17,7 +17,7 @@ namespace {
 void DoFile(lua_State* L, const char* file)
 {
     if (luaL_dofile(L, file)) {
-        SPKT_LOG_ERROR("[Lua]: Could not load {}", lua_tostring(L, -1));
+        log::error("[Lua]: Could not load {}", lua_tostring(L, -1));
     }
 }
 
@@ -53,23 +53,23 @@ void LuaEngine::PrintErrors(int rc) const
     std::string err = lua_tostring(d_L, -1);
     switch (rc) {
         case LUA_ERRRUN:
-            SPKT_LOG_ERROR("[Lua]: Runtime error: {}", err);
+            log::error("[Lua]: Runtime error: {}", err);
             return;
         case LUA_ERRMEM:
-            SPKT_LOG_ERROR("[Lua]: Memory allocation error: {}", err);
+            log::error("[Lua]: Memory allocation error: {}", err);
             return;
         case LUA_ERRERR:
-            SPKT_LOG_ERROR("[Lua]: Error handler func failed: {}", err);
+            log::error("[Lua]: Error handler func failed: {}", err);
             return;
         default:
-            SPKT_LOG_ERROR("[Lua]: Unknown error: {}", err);
+            log::error("[Lua]: Unknown error: {}", err);
     }
 }
 
 void LuaEngine::RunScript(const std::string& filename)
 {
     if (filename.empty()) {
-        SPKT_LOG_WARN("Tried to start an empty script!");
+        log::warn("Tried to start an empty script!");
         return;
     }
     
@@ -325,17 +325,17 @@ void LuaEngine::CallOnKeyboardKeyTypedEvent(KeyboardKeyTypedEvent* e)
 
 void LuaEngine::PrintGlobals()
 {
-    SPKT_LOG_INFO("Starting globals");
+    log::info("Starting globals");
     lua_pushglobaltable(d_L);
     lua_pushnil(d_L);
     while (lua_next(d_L, -2) != 0) {
         if (lua_isnumber(d_L, -1)) {
-            SPKT_LOG_INFO("{} = {}", lua_tostring(d_L, -2), lua_tonumber(d_L, -1));
+            log::info("{} = {}", lua_tostring(d_L, -2), lua_tonumber(d_L, -1));
         }
         lua_pop(d_L, 1);
     }
     lua_pop(d_L, 1);
-    SPKT_LOG_INFO("Ending globals");
+    log::info("Ending globals");
 }
 
 }

--- a/Sprocket/Scripting/LuaGlobals.cpp
+++ b/Sprocket/Scripting/LuaGlobals.cpp
@@ -42,7 +42,7 @@ bool CheckReturnCode(lua_State* L, int rc)
 {
     if (rc != LUA_OK) {
         const char* error = lua_tostring(L, -1);
-        SPKT_LOG_ERROR("[Lua]: {}", error);
+        log::error("[Lua]: {}", error);
         return false;
     }
     return true;
@@ -52,7 +52,7 @@ bool CheckArgCount(lua_State* L, int argc)
 {
     int args = lua_gettop(L);
     if (args != argc) {
-        SPKT_LOG_ERROR("[Lua]: Expected {} args, got {}", argc, args);
+        log::error("[Lua]: Expected {} args, got {}", argc, args);
         return false;
     }
     return true;

--- a/Sprocket/UI/Font/Font.cpp
+++ b/Sprocket/UI/Font/Font.cpp
@@ -169,7 +169,7 @@ bool Font::LoadGlyph(char c, float size)
     FT_Bitmap bitmap  = slot->bitmap;
     auto region = d_atlas.GetRegion(bitmap.width, bitmap.rows);
     if (region.x < 0) {
-        SPKT_LOG_ERROR("Texture atlas is full!");
+        log::error("Texture atlas is full!");
         FT_Done_Face(face);
         FT_Done_FreeType(library);
         return false;

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -62,7 +62,7 @@ void DrawCommand::AddText(std::string_view text,
                           const TextProperties& properties)
 {
     if (font == nullptr) {
-        SPKT_LOG_ERROR("Tried to add text to a draw command with no font!");
+        log::error("Tried to add text to a draw command with no font!");
         return;
     }
 

--- a/Sprocket/Utility/Log.cpp
+++ b/Sprocket/Utility/Log.cpp
@@ -1,28 +1,49 @@
 #include "Log.h"
 
-#include <exception>
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
-#include <spdlog/sinks/stdout_color_sinks.h>
+#include <iostream>
 
 namespace Sprocket {
 namespace Log {
-
 namespace {
-	std::shared_ptr<spdlog::logger> s_logger_p;
+
+#ifdef _WIN32
+HANDLE g_stdin;
+DWORD  g_old_mode;
+#endif
+
 }
 
 void Init()
 {
-	if (s_logger_p == nullptr) {
-		spdlog::set_pattern("%^[%T] %n: %v%$");
-		s_logger_p = spdlog::stdout_color_mt("Sprocket");
-		s_logger_p->set_level(spdlog::level::trace);
+#ifdef _WIN32
+	g_stdin = GetStdHandle(STD_INPUT_HANDLE);
+	if (g_stdin == INVALID_HANDLE_VALUE) {
+		std::cerr << "Could not get stdin handle\n";
+		return;
 	}
-}
 
-std::shared_ptr<spdlog::logger>& Logger()
-{
-	return s_logger_p;
+	//if (!GetConsoleMode(g_stdin, &g_old_mode)) {
+	//	std::cerr << "Could not get current console mode\n";
+	//	return;
+	//}
+//
+	//DWORD mode = g_old_mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	//if (!SetConsoleMode(g_stdin, mode)) {
+	//	std::cerr << "Failed to set console colouring\n";
+	//	return;
+	//}
+
+	for (int k = 1; k < 255; ++k)
+	{
+		// pick the colorattribute k you want
+		SetConsoleTextAttribute(g_stdin, k);
+		std::cout << k << " I want to be nice today!" << std::endl;
+	}
+#endif
 }
 
 }

--- a/Sprocket/Utility/Log.cpp
+++ b/Sprocket/Utility/Log.cpp
@@ -9,21 +9,17 @@
 
 namespace Sprocket {
 namespace log {
-namespace {
-
-bool g_inited = false;
-
-}
 
 void init()
 {
 #ifdef _WIN32
-	if (!g_inited) {
+	static bool inited = false;
+	if (!inited) {
 		DWORD termFlags;
 		HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
 		if (GetConsoleMode(handle, &termFlags))
 			SetConsoleMode(handle, termFlags | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-		g_inited = true;
+		inited = true;
 	}
 #endif
 }

--- a/Sprocket/Utility/Log.cpp
+++ b/Sprocket/Utility/Log.cpp
@@ -1,47 +1,29 @@
 #include "Log.h"
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
+#include <fmt/core.h>
+#include <fmt/color.h>
 
-#include <iostream>
+#ifdef _WIN32
+#include "Windows.h"
+#endif
 
 namespace Sprocket {
-namespace Log {
+namespace log {
 namespace {
 
-#ifdef _WIN32
-HANDLE g_stdin;
-DWORD  g_old_mode;
-#endif
+bool g_inited = false;
 
 }
 
-void Init()
+void init()
 {
 #ifdef _WIN32
-	g_stdin = GetStdHandle(STD_INPUT_HANDLE);
-	if (g_stdin == INVALID_HANDLE_VALUE) {
-		std::cerr << "Could not get stdin handle\n";
-		return;
-	}
-
-	//if (!GetConsoleMode(g_stdin, &g_old_mode)) {
-	//	std::cerr << "Could not get current console mode\n";
-	//	return;
-	//}
-//
-	//DWORD mode = g_old_mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-	//if (!SetConsoleMode(g_stdin, mode)) {
-	//	std::cerr << "Failed to set console colouring\n";
-	//	return;
-	//}
-
-	for (int k = 1; k < 255; ++k)
-	{
-		// pick the colorattribute k you want
-		SetConsoleTextAttribute(g_stdin, k);
-		std::cout << k << " I want to be nice today!" << std::endl;
+	if (!g_inited) {
+		DWORD termFlags;
+		HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
+		if (GetConsoleMode(handle, &termFlags))
+			SetConsoleMode(handle, termFlags | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+		g_inited = true;
 	}
 #endif
 }

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -9,32 +9,33 @@ namespace log {
 
 void init();
 
-template <typename... Args>
-void warn(const char* format, Args&&... args)
+template <typename Format, typename... Args>
+void warn(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
     fmt::print(fmt::fg(fmt::color::azure), "[WARN]: {}\n", message);
 }
 
-template <typename... Args>
-void info(const char* format, Args&&... args)
+template <typename Format, typename... Args>
+void info(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
     fmt::print(fmt::fg(fmt::color::light_green), "[INFO]: {}\n", message);
 }
 
-template <typename... Args>
-void error(const char* format, Args&&... args)
+template <typename Format, typename... Args>
+void error(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
     fmt::print(fmt::fg(fmt::color::orange), "[ERROR]: {}\n", message);
 }
 
-template <typename... Args>
-void fatal(const char* format, Args&&... args)
+template <typename Format, typename... Args>
+void fatal(Format& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
     fmt::print(fmt::fg(fmt::color::magenta), "[FATAL]: {}\n", message);
 }
+
 }
 }

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -1,26 +1,40 @@
 #pragma once
-#include <string_view>
+#include <string>
 #include <fmt/core.h>
 #include <fmt/color.h>
 
 namespace Sprocket {
-namespace Log {
+namespace log {
 
-void Init();
+void init();
 
-template <typename Format, typename... Args>
-void Info(Format&& format, Args&&... args)
+template <typename... Args>
+void warn(const char* format, Args&&... args)
 {
-    fmt::print(fmt::fg(fmt::color::yellow), format, std::forward<Args>(args)...);
+    fmt::print(fmt::fg(fmt::color::azure), format, std::forward<Args>(args)...);
+    fmt::print("\n");
+}
+
+template <typename... Args>
+void info(const char* format, Args&&... args)
+{
+    fmt::print(fmt::fg(fmt::color::light_green), format, std::forward<Args>(args)...);
+    fmt::print("\n");
+}
+
+template <typename... Args>
+void error(const char* format, Args&&... args)
+{
+    fmt::print(fmt::fg(fmt::color::orange), format, std::forward<Args>(args)...);
+    fmt::print("\n");
+}
+
+template <typename... Args>
+void fatal(const char* format, Args&&... args)
+{
+    fmt::print(fmt::fg(fmt::color::magenta), format, std::forward<Args>(args)...);
     fmt::print("\n");
 }
 
 }
 }
-
-// Log macros
-#define SPKT_LOG_TRACE(...) ::Sprocket::Log::Info(__VA_ARGS__);
-#define SPKT_LOG_INFO(...)  ::Sprocket::Log::Info(__VA_ARGS__);
-#define SPKT_LOG_WARN(...)  ::Sprocket::Log::Info(__VA_ARGS__);
-#define SPKT_LOG_ERROR(...) ::Sprocket::Log::Info(__VA_ARGS__);
-#define SPKT_LOG_FATAL(...) ::Sprocket::Log::Info(__VA_ARGS__);

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -1,22 +1,26 @@
 #pragma once
-#include <memory>
-#include <iostream>
-
-#include <spdlog/spdlog.h>
+#include <string_view>
+#include <fmt/core.h>
+#include <fmt/color.h>
 
 namespace Sprocket {
 namespace Log {
 
 void Init();
 
-std::shared_ptr<spdlog::logger> &Logger();
+template <typename Format, typename... Args>
+void Info(Format&& format, Args&&... args)
+{
+    fmt::print(fmt::fg(fmt::color::yellow), format, std::forward<Args>(args)...);
+    fmt::print("\n");
+}
 
 }
 }
 
 // Log macros
-#define SPKT_LOG_TRACE(...) ::Sprocket::Log::Logger()->trace(__VA_ARGS__)
-#define SPKT_LOG_INFO(...)  ::Sprocket::Log::Logger()->info(__VA_ARGS__)
-#define SPKT_LOG_WARN(...)  ::Sprocket::Log::Logger()->warn(__VA_ARGS__)
-#define SPKT_LOG_ERROR(...) ::Sprocket::Log::Logger()->error(__VA_ARGS__)
-#define SPKT_LOG_FATAL(...) ::Sprocket::Log::Logger()->critical(__VA_ARGS__)
+#define SPKT_LOG_TRACE(...) ::Sprocket::Log::Info(__VA_ARGS__);
+#define SPKT_LOG_INFO(...)  ::Sprocket::Log::Info(__VA_ARGS__);
+#define SPKT_LOG_WARN(...)  ::Sprocket::Log::Info(__VA_ARGS__);
+#define SPKT_LOG_ERROR(...) ::Sprocket::Log::Info(__VA_ARGS__);
+#define SPKT_LOG_FATAL(...) ::Sprocket::Log::Info(__VA_ARGS__);

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <memory>
 #include <fmt/core.h>
 #include <fmt/color.h>
 
@@ -11,30 +12,29 @@ void init();
 template <typename... Args>
 void warn(const char* format, Args&&... args)
 {
-    fmt::print(fmt::fg(fmt::color::azure), format, std::forward<Args>(args)...);
-    fmt::print("\n");
+    std::string message = fmt::format(format, std::forward<Args>(args)...);
+    fmt::print(fmt::fg(fmt::color::azure), "[WARN]: {}\n", message);
 }
 
 template <typename... Args>
 void info(const char* format, Args&&... args)
 {
-    fmt::print(fmt::fg(fmt::color::light_green), format, std::forward<Args>(args)...);
-    fmt::print("\n");
+    std::string message = fmt::format(format, std::forward<Args>(args)...);
+    fmt::print(fmt::fg(fmt::color::light_green), "[INFO]: {}\n", message);
 }
 
 template <typename... Args>
 void error(const char* format, Args&&... args)
 {
-    fmt::print(fmt::fg(fmt::color::orange), format, std::forward<Args>(args)...);
-    fmt::print("\n");
+    std::string message = fmt::format(format, std::forward<Args>(args)...);
+    fmt::print(fmt::fg(fmt::color::orange), "[ERROR]: {}\n", message);
 }
 
 template <typename... Args>
 void fatal(const char* format, Args&&... args)
 {
-    fmt::print(fmt::fg(fmt::color::magenta), format, std::forward<Args>(args)...);
-    fmt::print("\n");
+    std::string message = fmt::format(format, std::forward<Args>(args)...);
+    fmt::print(fmt::fg(fmt::color::magenta), "[FATAL]: {}\n", message);
 }
-
 }
 }

--- a/imgui.ini
+++ b/imgui.ini
@@ -59,8 +59,8 @@ Size=500,400
 Collapsed=0
 
 [Window][Sun]
-Pos=638,211
-Size=214,106
+Pos=640,155
+Size=344,165
 Collapsed=0
 
 [Window][Shadow Map]
@@ -163,7 +163,7 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
+DockSpace       ID=0x8B93E3BD Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
   DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=969,699 CentralNode=1 Selected=0x995B0CF8
   DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=309,699 Split=Y Selected=0x1E89CEB8
     DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0x1E89CEB8


### PR DESCRIPTION
- Now that we are using `{{fmt}}` directly, remove `spdlog` and replace with some simple logging functions.
- The reasoning for this is that we simply don't need all of the features `spdlog` has, we just want printing to the console.
- The `log::init` function is still required on Windows as it sets a console flag to allow for coloured printing.
- Replace the logging macros with actual function calls.
- All of the logging functions are in `snake_case`, going to move all of Sprocket to it since it looks nicer and matches the standard library.