### PR TITLE
Custom Logging Improvements

### DIFF
--- a/Sprocket/Utility/FileBrowser.cpp
+++ b/Sprocket/Utility/FileBrowser.cpp
@@ -1,7 +1,8 @@
 #include "FileBrowser.h"
 
-#include <GLFW/glfw3.h>
+#ifdef _WIN32
 
+#include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 #include <Windows.h>
@@ -51,3 +52,4 @@ std::string SaveFile(Window* window, const char* filter)
 }
 
 }
+#endif

--- a/Sprocket/Utility/FileBrowser.h
+++ b/Sprocket/Utility/FileBrowser.h
@@ -1,6 +1,10 @@
 #pragma once
-#include "Window.h"
+// This uses the Windows API under the hood, so these functions are only available
+// on Windows. Other platforms should be implemented when needed.
 
+#ifdef _WIN32
+
+#include "Window.h"
 #include <string>
 
 namespace Sprocket {
@@ -9,3 +13,5 @@ std::string OpenFile(Window* window, const char* filter);
 std::string SaveFile(Window* window, const char* filter);
 
 }
+
+#endif

--- a/Sprocket/Utility/Log.cpp
+++ b/Sprocket/Utility/Log.cpp
@@ -2,6 +2,9 @@
 
 #include <fmt/core.h>
 #include <fmt/color.h>
+#include <fmt/chrono.h>
+
+#include <chrono>
 
 #ifdef _WIN32
 #include "Windows.h"
@@ -9,6 +12,17 @@
 
 namespace Sprocket {
 namespace log {
+namespace {
+
+std::chrono::system_clock::duration time_today()
+{
+	using days = std::chrono::duration<int, std::ratio<86400>>; // Will be in C++20
+
+	auto now = std::chrono::system_clock::now();
+	return now - std::chrono::floor<days>(now);
+}
+
+}
 
 void init()
 {
@@ -22,6 +36,13 @@ void init()
 		inited = true;
 	}
 #endif
+}
+
+void prefixed_log(std::string_view prefix, std::string_view message)
+{
+	fmt::print(fmt::fg(fmt::color::white), "{:%H:%M:%S} [", time_today());
+    fmt::print(prefix);
+    fmt::print(fmt::fg(fmt::color::white), "] {}\n", message);
 }
 
 }

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -7,34 +7,44 @@
 namespace Sprocket {
 namespace log {
 
+constexpr fmt::color BASE = fmt::color::ghost_white;
+
 void init();
 
 template <typename Format, typename... Args>
 void warn(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(fmt::color::azure), "[WARN]: {}\n", message);
+    fmt::print(fmt::fg(BASE), "[");
+    fmt::print(fmt::fg(fmt::color::aqua), "WARN");
+    fmt::print(fmt::fg(BASE), "]: {}\n", message);
 }
 
 template <typename Format, typename... Args>
 void info(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(fmt::color::light_green), "[INFO]: {}\n", message);
+    fmt::print(fmt::fg(BASE), "[");
+    fmt::print(fmt::fg(fmt::color::light_green), "INFO");
+    fmt::print(fmt::fg(BASE), "]: {}\n", message);
 }
 
 template <typename Format, typename... Args>
 void error(Format&& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(fmt::color::orange), "[ERROR]: {}\n", message);
+    fmt::print(fmt::fg(BASE), "[");
+    fmt::print(fmt::fg(fmt::color::orange), "ERROR");
+    fmt::print(fmt::fg(BASE), "]: {}\n", message);
 }
 
 template <typename Format, typename... Args>
 void fatal(Format& format, Args&&... args)
 {
     std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(fmt::color::magenta), "[FATAL]: {}\n", message);
+    fmt::print(fmt::fg(BASE), "[");
+    fmt::print(fmt::fg(fmt::color::magenta), "FATAL");
+    fmt::print(fmt::fg(BASE), "]: {}\n", message);
 }
 
 }

--- a/Sprocket/Utility/Log.h
+++ b/Sprocket/Utility/Log.h
@@ -7,45 +7,41 @@
 namespace Sprocket {
 namespace log {
 
-constexpr fmt::color BASE = fmt::color::ghost_white;
-
 void init();
 
-template <typename Format, typename... Args>
-void warn(Format&& format, Args&&... args)
+template <typename... Args>
+void warn(std::string_view format, Args&&... args)
 {
-    std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(BASE), "[");
-    fmt::print(fmt::fg(fmt::color::aqua), "WARN");
-    fmt::print(fmt::fg(BASE), "]: {}\n", message);
+    std::string prefix = fmt::format(fmt::fg(fmt::color::aqua), "WARN");
+    std::string log = fmt::format(format, std::forward<Args>(args)...);
+    prefixed_log(prefix, log);
 }
 
-template <typename Format, typename... Args>
-void info(Format&& format, Args&&... args)
+template <typename... Args>
+void info(std::string_view format, Args&&... args)
 {
-    std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(BASE), "[");
-    fmt::print(fmt::fg(fmt::color::light_green), "INFO");
-    fmt::print(fmt::fg(BASE), "]: {}\n", message);
+    std::string prefix = fmt::format(fmt::fg(fmt::color::light_green), "INFO");
+    std::string log = fmt::format(format, std::forward<Args>(args)...);
+    prefixed_log(prefix, log);
 }
 
-template <typename Format, typename... Args>
-void error(Format&& format, Args&&... args)
+template <typename... Args>
+void error(std::string_view format, Args&&... args)
 {
-    std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(BASE), "[");
-    fmt::print(fmt::fg(fmt::color::orange), "ERROR");
-    fmt::print(fmt::fg(BASE), "]: {}\n", message);
+    std::string prefix = fmt::format(fmt::fg(fmt::color::orange), "ERROR");
+    std::string log = fmt::format(format, std::forward<Args>(args)...);
+    prefixed_log(prefix, log);
 }
 
-template <typename Format, typename... Args>
-void fatal(Format& format, Args&&... args)
+template <typename... Args>
+void fatal(std::string_view format, Args&&... args)
 {
-    std::string message = fmt::format(format, std::forward<Args>(args)...);
-    fmt::print(fmt::fg(BASE), "[");
-    fmt::print(fmt::fg(fmt::color::magenta), "FATAL");
-    fmt::print(fmt::fg(BASE), "]: {}\n", message);
+    std::string prefix = fmt::format(fmt::fg(fmt::color::magenta), "FATAL");
+    std::string log = fmt::format(format, std::forward<Args>(args)...);
+    prefixed_log(prefix, log);
 }
+
+void prefixed_log(std::string_view prefix, std::string_view message);
 
 }
 }

--- a/imgui.ini
+++ b/imgui.ini
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=971,389
-Size=309,264
+Pos=971,409
+Size=309,244
 Collapsed=0
 DockId=0x00000005,0
 
@@ -132,7 +132,7 @@ Collapsed=0
 
 [Window][Explorer]
 Pos=971,21
-Size=309,366
+Size=309,386
 Collapsed=0
 DockId=0x00000003,0
 
@@ -163,11 +163,11 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
+DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
   DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=969,699 CentralNode=1 Selected=0x995B0CF8
   DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=309,699 Split=Y Selected=0x1E89CEB8
     DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0x1E89CEB8
-      DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=309,366 Selected=0x1E89CEB8
-      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=309,264 Selected=0xF02CD328
+      DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=309,386 Selected=0x1E89CEB8
+      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=309,244 Selected=0xF02CD328
     DockNode    ID=0x00000002 Parent=0x00000008 SizeRef=320,65 Selected=0x1F88C31B
 


### PR DESCRIPTION
- Made the output prettier, rather than having the whole line be one colour, only the level is coloured.
- Add the time back to log lines.
- Wrapped the windows specific stuff in `FileBrowser` in the `_WIN32` symbol check. These functions will be be available on other platforms.