### PR TITLE
Remove ev::Event Handling from lua::Script

### DIFF
--- a/Game/Main.m.cpp
+++ b/Game/Main.m.cpp
@@ -16,7 +16,7 @@ int main()
     //options.showFramerate = true;
     //return Sprocket::Run(game, window, options);
 
-    lua::Script script;
-    double value = script.call_function<double>("Sin", 50);
+    lua::Script script("Resources/Temp.lua");
+    int value = script.call_function<int>("foo", 50);
     log::info("Got value {}", value);
 }

--- a/Game/Main.m.cpp
+++ b/Game/Main.m.cpp
@@ -10,9 +10,13 @@ using namespace Sprocket;
 
 int main()
 {
-    Sprocket::Window window("Game");
-    WorldLayer game(&window);
-    Sprocket::RunOptions options;
-    options.showFramerate = true;
-    return Sprocket::Run(game, window, options);
+    //Sprocket::Window window("Game");
+    //WorldLayer game(&window);
+    //Sprocket::RunOptions options;
+    //options.showFramerate = true;
+    //return Sprocket::Run(game, window, options);
+
+    lua::Script script;
+    double value = script.call_function<double>("Sin", 50);
+    log::info("Got value {}", value);
 }

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -64,9 +64,7 @@ function OnUpdate(entity, dt)
 end
 
 
-function OnMouseButtonPressedEvent(consumed, button, action, mods)
-    if consumed then return false end
-
+function OnMouseButtonPressedEvent(button, action, mods)
     local newEntity = NewEntity()
 
     local dir = GetForwardsDir(ENTITY)

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -65,7 +65,6 @@ end
 
 
 function OnMouseButtonPressedEvent(consumed, button, action, mods)
-
     if consumed then return false end
 
     local newEntity = NewEntity()

--- a/Resources/Scripts/ThirdPersonCamera.lua
+++ b/Resources/Scripts/ThirdPersonCamera.lua
@@ -62,12 +62,9 @@ function OnUpdate(entity, dt)
     SetLookAt(entity, pos, TARGET)
 end
 
-function OnMouseButtonPressedEvent(consumed, button, action, mods) end
+function OnMouseButtonPressedEvent(button, action, mods) end
 
-function OnMouseScrolledEvent(consumed, xOffset, yOffset)
-    if consumed then return false end
-        -- Don't react to consumed events
-
+function OnMouseScrolledEvent(xOffset, yOffset)
     if ABS_VERT == nil then return false end
         -- If we receive an event before update, just ignore it
 
@@ -75,4 +72,4 @@ function OnMouseScrolledEvent(consumed, xOffset, yOffset)
     return true
 end
 
-function OnWindowResizeEvent(consumed, width, height) end
+function OnWindowResizeEvent(width, height) end

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -26,7 +26,7 @@ void ScriptRunner::OnStartup(Scene& scene)
         lua::register_entity_transformation_functions(script);
         lua::register_entity_component_functions(script);
 
-        script.call_function("Init", entity);
+        script.call_function<void>("Init", entity);
         script.print_globals();
         d_engines.emplace(entity, std::make_pair(std::move(script), true));
     });
@@ -50,7 +50,7 @@ void ScriptRunner::OnUpdate(Scene& scene, double dt)
 
         if (alive) {
             if (entity.Get<ScriptComponent>().active) {
-                script.call_function("OnUpdate", entity, dt);
+                script.call_function<void>("OnUpdate", entity, dt);
             }
             ++it;
         } else {

--- a/Sprocket/Scripting/LuaScript.cpp
+++ b/Sprocket/Scripting/LuaScript.cpp
@@ -110,64 +110,6 @@ bool Script::has_function(const std::string& function)
     return true;
 }
 
-void Script::on_event(ev::Event& event)
-{
-    const auto handler = [this, &event](const char* f, auto&&... args) {
-        if (has_function(f) && call_function<bool>(f, std::forward<decltype(args)>(args)...))
-        {
-            log::info("[Lua] Consuming event {}", event.type_name());
-            event.consume();
-        }
-    };
-
-    if (auto x = event.get_if<ev::WindowResize>()) {
-        handler("OnWindowResizeEvent", x->width, x->height);
-    }
-    else if (auto x = event.get_if<ev::WindowGotFocus>()) {
-        handler("OnWindowGotFocusEvent");
-    }
-    else if (auto x = event.get_if<ev::WindowLostFocus>()) {
-        handler("OnWindowLostFocusEvent");
-    }
-    else if (auto x = event.get_if<ev::WindowMaximize>()) {
-        handler("OnWindowMaximizeEvent");
-    }
-    else if (auto x = event.get_if<ev::WindowMinimize>()) {
-        handler("OnWindowMinimizeEvent");
-    }
-    else if (auto x = event.get_if<ev::WindowClosed>()) {
-        // pass
-    }
-    else if (auto x = event.get_if<ev::MouseButtonPressed>()) {
-        handler("OnMouseButtonPressedEvent", x->button, x->action, x->mods);
-    }
-    else if (auto x = event.get_if<ev::MouseButtonReleased>()) {
-        handler("OnMouseButtonReleasedEvent", x->button, x->action, x->mods);
-    }
-    else if (auto x = event.get_if<ev::MouseMoved>()) {
-        handler("OnMouseMovedEvent", x->x_pos, x->y_pos);
-    }
-    else if (auto x = event.get_if<ev::MouseScrolled>()) {
-        handler("OnMouseScrolledEvent", x->x_offset, x->y_offset);
-    }
-    else if (auto x = event.get_if<ev::KeyboardButtonPressed>()) {
-        handler("OnKeyboardButtonPressedEvent", x->key, x->scancode, x->mods);
-    }
-    else if (auto x = event.get_if<ev::KeyboardButtonReleased>()) {
-        handler("OnKeyboardButtonReleasedEvent", x->key, x->scancode, x->mods);
-    }
-    else if (auto x = event.get_if<ev::KeyboardButtonHeld>()) {
-        handler("OnKeyboardButtonHeldEvent", x->key, x->scancode, x->mods);
-    }
-    else if (auto x = event.get_if<ev::KeyboardTyped>()) {
-        handler("OnKeyboardKeyTypedEvent", x->key);
-    }
-    else {
-        log::warn("Event with unknown type {}", event.type_name());
-        return;
-    }
-}
-
 void Script::print_globals()
 {
     log::info("Starting globals");

--- a/Sprocket/Scripting/LuaScript.cpp
+++ b/Sprocket/Scripting/LuaScript.cpp
@@ -24,7 +24,7 @@ Script::Script(const std::string& file)
     lua_State* L = d_L.get();
     luaL_openlibs(L);
     do_file(L, "Sprocket/Scripting/Sprocket_Base.lua");
-    do_file(d_L.get(), file.c_str());
+    do_file(L, file.c_str());
 }
 
 Script::Script()

--- a/Sprocket/Scripting/LuaScript.cpp
+++ b/Sprocket/Scripting/LuaScript.cpp
@@ -113,7 +113,8 @@ bool Script::has_function(const std::string& function)
 void Script::on_event(ev::Event& event)
 {
     const auto handler = [this, &event](const char* f, auto&&... args) {
-        if (has_function(f) && call_function<bool>(f, event.is_consumed(), std::forward<decltype(args)>(args)...)) {
+        if (has_function(f) && call_function<bool>(f, std::forward<decltype(args)>(args)...))
+        {
             log::info("[Lua] Consuming event {}", event.type_name());
             event.consume();
         }

--- a/Sprocket/Scripting/LuaScript.h
+++ b/Sprocket/Scripting/LuaScript.h
@@ -22,6 +22,8 @@ public:
     // TODO: Remove
     void print_globals();
 
+    bool has_function(const std::string& function);
+
     template <typename Return, typename... Args>
     Return call_function(const std::string& function, Args&&... args);
 
@@ -91,7 +93,9 @@ Return Script::call_function(const std::string& function, Args&&... args)
         }
         if constexpr (std::is_same_v<Return, bool>) {
             assert(lua_isboolean(L, -1));
-            return static_cast<bool>(lua_toboolean(L, -1));
+            int y = lua_toboolean(L, -1);
+            log::info("Here! {}", y);
+            return y;
         }
         else if constexpr (std::is_integral_v<Return>) {
             assert(lua_isinteger(L, -1));

--- a/Sprocket/Scripting/LuaScript.h
+++ b/Sprocket/Scripting/LuaScript.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Events.h"
 #include "Log.h"
 
 #include <string>
@@ -29,8 +28,6 @@ public:
 
     template <typename Type>
     void set_value(const std::string& name, Type&& value);
-
-    void on_event(ev::Event& event);
 
     lua_State* native_handle() const { return d_L.get(); }
 
@@ -94,7 +91,6 @@ Return Script::call_function(const std::string& function, Args&&... args)
         if constexpr (std::is_same_v<Return, bool>) {
             assert(lua_isboolean(L, -1));
             int y = lua_toboolean(L, -1);
-            log::info("Here! {}", y);
             return y;
         }
         else if constexpr (std::is_integral_v<Return>) {

--- a/Sprocket/Scripting/LuaScript.h
+++ b/Sprocket/Scripting/LuaScript.h
@@ -87,8 +87,7 @@ Return Script::call_function(const std::string& function, Args&&... args)
         int rc = lua_pcall(L, sizeof...(Args), 1, 0);
         print_errors(rc);
         if (rc != LUA_OK) {
-            log::fatal("Lua function returning a value failed, could fall into undefined state!");
-            std::abort();
+            return {};
         }
         if constexpr (std::is_same_v<Return, bool>) {
             assert(lua_isboolean(L, -1));

--- a/Sprocket/Scripting/Sprocket_Base.lua
+++ b/Sprocket/Scripting/Sprocket_Base.lua
@@ -109,3 +109,7 @@ function Normalised(vector)
    end
    return Vec3(vector.x / mag, vector.y / mag, vector.z / mag)
 end
+
+function Sin(x)
+   return math.sin(x)
+end


### PR DESCRIPTION
- Remove `lua::Script::on_event`. This was the last thing in the class that was there exclusively for use in the game loop via the `ScriptRunner`. Now, it is a standalone class with enough functionality that everything can be pushed outside of it.
- All event logic is now handled in `ScriptRunner::OnEvent`.
- This is made possible by an enhancement to `lua::Script::call_function`. The return type is now templated. All current calls to the function are now `lua::Script::call_function<void>`.
- If `call_function` return void, then the Lua function is expected to return nil. Otherwise, it expects a return value that it can cast to the specified type.
- With this, event functions can be called from `ScriptRunner`, eg `bool consumed = script.call_function<bool>("OnMousePressedEvent", event->button, event->action, event->mods);`
- Removed the first `consumed` arg from all event functions as nothing was using it and it looks messy.