### PR TITLE
Input Proxy Cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,5 +96,7 @@
         "bit": "cpp",
         "compare": "cpp",
         "stop_token": "cpp",
+        "typeindex": "cpp",
+        "typeinfo": "cpp"
     }
 }

--- a/Anvil/Camera.cpp
+++ b/Anvil/Camera.cpp
@@ -16,12 +16,6 @@ Camera::Camera(Window* window, const glm::vec3& target)
     , d_absMin(2.0f)
     , d_absMax(10.0f)
 {
-    d_input.ConsumeEventsFor(Keyboard::W);
-    d_input.ConsumeEventsFor(Keyboard::A);
-    d_input.ConsumeEventsFor(Keyboard::S);
-    d_input.ConsumeEventsFor(Keyboard::D);
-    d_input.ConsumeEventsFor(Keyboard::Q);
-    d_input.ConsumeEventsFor(Keyboard::E);
 }
 
 void Camera::OnUpdate(double dt)
@@ -36,34 +30,34 @@ void Camera::OnUpdate(double dt)
     glm::vec3 up{0, 1, 0};
     glm::vec3 r = glm::cross(f, up);
 
-    if (d_input.IsKeyboardDown(Keyboard::W)) {
+    if (d_input.is_keyboard_down(Keyboard::W)) {
         d_target += moveSpeed * f;
     }
-    if (d_input.IsKeyboardDown(Keyboard::S)) {
+    if (d_input.is_keyboard_down(Keyboard::S)) {
         d_target -= moveSpeed * f;
     }
-    if (d_input.IsKeyboardDown(Keyboard::D)) {
+    if (d_input.is_keyboard_down(Keyboard::D)) {
         d_target += moveSpeed * r;
     }
-    if (d_input.IsKeyboardDown(Keyboard::A)) {
+    if (d_input.is_keyboard_down(Keyboard::A)) {
         d_target -= moveSpeed * r;
     }
 
-    if (d_input.IsKeyboardDown(Keyboard::E)) {
+    if (d_input.is_keyboard_down(Keyboard::E)) {
         d_yaw -= horizSpeed;
     }
-    if (d_input.IsKeyboardDown(Keyboard::Q)) {
+    if (d_input.is_keyboard_down(Keyboard::Q)) {
         d_yaw += horizSpeed;
     }
 
-    if (d_input.IsKeyboardDown(Keyboard::SPACE)) {
+    if (d_input.is_keyboard_down(Keyboard::SPACE)) {
         d_position.y += d_moveSpeed * dt;
         d_target.y += d_moveSpeed * dt;
         d_absVert += d_moveSpeed * dt;
         d_absMin += d_moveSpeed * dt;
         d_absMax += d_moveSpeed * dt;
     }
-    if (d_input.IsKeyboardDown(Keyboard::LSHIFT)) {
+    if (d_input.is_keyboard_down(Keyboard::LSHIFT)) {
         d_position.y -= d_moveSpeed * dt;
         d_target.y -= d_moveSpeed * dt;
         d_absVert -= d_moveSpeed * dt;
@@ -82,7 +76,7 @@ void Camera::OnUpdate(double dt)
 
 void Camera::OnEvent(ev::Event& event)
 {
-    d_input.OnEvent(event);
+    d_input.on_event(event);
 
     if (auto data = event.get_if<ev::MouseScrolled>()) {
         if (event.is_consumed()) { return; }

--- a/Game/Main.m.cpp
+++ b/Game/Main.m.cpp
@@ -6,10 +6,9 @@ using namespace Sprocket;
 
 int main()
 {
-    //Sprocket::Window window("Game");
-    //WorldLayer game(&window);
-    //Sprocket::RunOptions options;
-    //options.showFramerate = true;
-    //return Sprocket::Run(game, window, options);
-    log::info("{}", spkt::type_hash<int>);
+    Sprocket::Window window("Game");
+    WorldLayer game(&window);
+    Sprocket::RunOptions options;
+    options.showFramerate = true;
+    return Sprocket::Run(game, window, options);
 }

--- a/Game/Main.m.cpp
+++ b/Game/Main.m.cpp
@@ -6,9 +6,10 @@ using namespace Sprocket;
 
 int main()
 {
-    Sprocket::Window window("Game");
-    WorldLayer game(&window);
-    Sprocket::RunOptions options;
-    options.showFramerate = true;
-    return Sprocket::Run(game, window, options);
+    //Sprocket::Window window("Game");
+    //WorldLayer game(&window);
+    //Sprocket::RunOptions options;
+    //options.showFramerate = true;
+    //return Sprocket::Run(game, window, options);
+    log::info("{}", spkt::type_hash<int>);
 }

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -25,6 +25,7 @@ public:
 	bool is_consumed() const noexcept { return d_consumed; }
 	void consume() noexcept { d_consumed = true; }
 
+	// Implementation defined name, should only be used for logging.
 	std::string type_name() const noexcept { return d_event.type().name(); }
 };
 

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -61,11 +61,13 @@ void ScriptRunner::OnUpdate(Scene& scene, double dt)
 
 void ScriptRunner::OnEvent(Scene& scene, ev::Event& event)
 {
-    d_input.OnEvent(event);
+    d_input.on_event(event);
 
-    const auto handler = [&event](lua::Script& script, const char* f, auto&&... args)
+    const auto handler = [&](lua::Script& script, const char* f, auto&&... args)
     {
-        if (script.has_function(f) && script.call_function<bool>(f, args...)) {
+        if (script.has_function(f) &&
+            script.call_function<bool>(f, std::forward<decltype(args)>(args)...))
+        {
             event.consume();
         }
     };

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -63,6 +63,10 @@ void ScriptRunner::OnEvent(Scene& scene, ev::Event& event)
 {
     d_input.on_event(event);
 
+    // This may be overly strict, change this if we ever need to react to consumed
+    // events in scripts.
+    if (event.is_consumed()) { return; }
+
     const auto handler = [&](lua::Script& script, const char* f, auto&&... args)
     {
         if (script.has_function(f) &&

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -174,7 +174,7 @@ void register_input_functions(lua::Script& script, InputProxy& input)
 
         if (auto ip = get_pointer<InputProxy>(L, "__input__"); ip) {
             int x = (int)lua_tointeger(L, 1);
-            lua_pushboolean(L, ip->IsKeyboardDown(x));
+            lua_pushboolean(L, ip->is_keyboard_down(x));
         }
         else {
             lua_pushboolean(L, false);
@@ -188,7 +188,7 @@ void register_input_functions(lua::Script& script, InputProxy& input)
 
         if (auto ip = get_pointer<InputProxy>(L, "__input__"); ip) {
             int x = (int)lua_tointeger(L, 1);
-            lua_pushboolean(L, ip->IsMouseDown(x));
+            lua_pushboolean(L, ip->is_mouse_down(x));
         }
         else {
             lua_pushboolean(L, false);

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -173,7 +173,7 @@ void register_input_functions(lua::Script& script, InputProxy& input)
 
         if (auto ip = get_pointer<InputProxy>(L, "__input__"); ip) {
             int x = (int)lua_tointeger(L, 1);
-            lua_pushboolean(L, ip->IsKeyboardDown(x));
+            lua_pushboolean(L, ip->is_keyboard_down(x));
         }
         else {
             lua_pushboolean(L, false);
@@ -187,7 +187,7 @@ void register_input_functions(lua::Script& script, InputProxy& input)
 
         if (auto ip = get_pointer<InputProxy>(L, "__input__"); ip) {
             int x = (int)lua_tointeger(L, 1);
-            lua_pushboolean(L, ip->IsMouseDown(x));
+            lua_pushboolean(L, ip->is_mouse_down(x));
         }
         else {
             lua_pushboolean(L, false);

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -235,8 +235,8 @@ void UIEngine::OnEvent(ev::Event& event)
     if (auto data = event.get_if<ev::MouseButtonPressed>()) {
         if (data->button == Mouse::LEFT) {
             d_mouseClicked = true;
-            if (d_consumeMouseEvents) { event.consume(); }
         }
+        if (d_consumeMouseEvents) { event.consume(); }
     }
     if (auto data = event.get_if<ev::MouseButtonReleased>()) {
         if (data->button == Mouse::LEFT) {

--- a/Sprocket/Utility/Hashing.h
+++ b/Sprocket/Utility/Hashing.h
@@ -4,7 +4,8 @@
 
 namespace spkt {
 
-struct hash_pair { 
+struct hash_pair
+{ 
     template <class T1, class T2> 
     std::size_t operator()(const std::pair<T1, T2>& p) const
     { 
@@ -19,7 +20,7 @@ constexpr std::size_t sdbm_type_hash()
 {
     std::size_t hash = 0;
     for (const auto& c : std::string_view{__FUNCSIG__}) {
-        hash = static_cast<std::size_t>(c) + (hash << 6) + (hash << 16) - hash;
+        hash = c + 65599 * hash;
     }
     return hash;
 };

--- a/Sprocket/Utility/InputProxy.cpp
+++ b/Sprocket/Utility/InputProxy.cpp
@@ -1,43 +1,43 @@
 #include "InputProxy.h"
 #include "Events.h"
 
+#include <cassert>
+
 namespace Sprocket {
+
+InputProxy::InputProxy()
+{
+    d_keyboard.fill(false);
+    d_mouse.fill(false);
+}
     
-void InputProxy::OnEvent(ev::Event& event)
+void InputProxy::on_event(ev::Event& event)
 {
     if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
         if (event.is_consumed()) { return; }
-        d_keys[data->key] = true;
-        if (d_consumedKeys.contains(data->key)) { event.consume(); }
+        d_keyboard[data->key] = true;
     }
     else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
-        d_keys[data->key] = false;
+        d_keyboard[data->key] = false;
     }
     else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
         if (event.is_consumed()) { return; }
-        d_buttons[data->button] = true;
+        d_mouse[data->button] = true;
     }
     else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
-        d_buttons[data->button] = false;
+        d_mouse[data->button] = false;
     }
 }
 
-bool InputProxy::IsMouseDown(int button) const
+bool InputProxy::is_mouse_down(int button) const
 {
-    return d_buttons[button];
+    return d_mouse[button];
 }
 
-bool InputProxy::IsKeyboardDown(int key) const
+bool InputProxy::is_keyboard_down(int key) const
 {
-    if (auto it = d_keys.find(key); it != d_keys.end()) {
-        return it->second;
-    }
-    return false;
-}
-
-void InputProxy::ConsumeEventsFor(int key)
-{
-    d_consumedKeys.insert(key);
+    assert(key < NUM_KEYS);
+    return d_keyboard[key];
 }
 
 }

--- a/Sprocket/Utility/InputProxy.h
+++ b/Sprocket/Utility/InputProxy.h
@@ -8,20 +8,20 @@ namespace ev { class Event; }
 
 class InputProxy
 {
-    // Mouse
-    std::array<bool, 5> d_buttons;
+public:
+    static constexpr std::size_t NUM_KEYS = 512;
 
-    // Keyboard
-    std::unordered_map<int, bool> d_keys;
-    std::unordered_set<int> d_consumedKeys;
+private:
+    std::array<bool, NUM_KEYS> d_keyboard;
+    std::array<bool, 5> d_mouse;
 
 public:
-    void OnEvent(ev::Event& event);
+    InputProxy();
 
-    bool IsMouseDown(int button) const;
-    bool IsKeyboardDown(int key) const;
+    void on_event(ev::Event& event);
 
-    void ConsumeEventsFor(int key);
+    bool is_mouse_down(int button) const;
+    bool is_keyboard_down(int key) const;
 };
     
 }

--- a/Sprocket/Utility/InputProxy.h
+++ b/Sprocket/Utility/InputProxy.h
@@ -1,7 +1,5 @@
 #pragma once
 #include <array>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace Sprocket {
 namespace ev { class Event; }


### PR DESCRIPTION
- `InputProxy` now stores keyboard presses in an array rather than an unordered map.
- Renamed functions to use snake_case.
- Remove the `ConsumeEventsFor` functionality as it wasn't needed and was a clunky API.
- Stop sending consumed events to scripts. This should have been done in an earlier PR when we removed sending the consumed flag.