### PR TITLE
Event Dispatcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -97,6 +97,7 @@
         "compare": "cpp",
         "stop_token": "cpp",
         "typeindex": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "coroutine": "cpp"
     }
 }

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -11,8 +11,8 @@ namespace {
 
 std::string Name(const ecs::Entity& entity)
 {
-    if (entity.Has<NameComponent>()) {
-        return entity.Get<NameComponent>().name;
+    if (entity.has<NameComponent>()) {
+        return entity.get<NameComponent>().name;
     }
     return "Entity";
 }
@@ -51,7 +51,7 @@ Anvil::Anvil(Window* window)
     d_scene->Load(d_sceneFile);
 
     d_runtimeCamera = d_scene->Entities().Find([](ecs::Entity entity) {
-        return entity.Has<Camera3DComponent>();
+        return entity.has<Camera3DComponent>();
     });
 
     d_activeScene = d_scene;
@@ -115,7 +115,7 @@ void Anvil::OnUpdate(double dt)
     
     std::vector<ecs::Entity> toDelete;
     for (auto entity : d_activeScene->Entities().View<Transform3DComponent>()) {
-        auto& transform = entity.Get<Transform3DComponent>();
+        auto& transform = entity.get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);
         }
@@ -232,8 +232,8 @@ void Anvil::OnRender()
 
         ImGuiXtra::Image(d_viewport.GetTexture());
 
-        if (!IsGameRunning() && d_selected.valid() && d_selected.Has<Transform3DComponent>()) {
-            auto& c = d_selected.Get<Transform3DComponent>();
+        if (!IsGameRunning() && d_selected.valid() && d_selected.has<Transform3DComponent>()) {
+            auto& c = d_selected.get<Transform3DComponent>();
             auto tr = Maths::Transform(c.position, c.orientation, c.scale);
             ImGuiXtra::Guizmo(&tr, view, proj, d_inspector.Operation(), d_inspector.Mode());
             Maths::Decompose(tr, &c.position, &c.orientation, &c.scale);

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -263,7 +263,7 @@ void Anvil::OnRender()
             if (ImGui::BeginTabItem("Entities")) {
                 ImGui::BeginChild("Entity List");
                 int i = 0;
-                for (auto entity : d_scene->Entities().Each()) {
+                for (auto entity : d_scene->Entities().all()) {
                     if (SubstringCI(Name(entity), search)) {
                         ImGui::PushID(i);
                         if (ImGui::Selectable(Name(entity).c_str())) {

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -114,7 +114,7 @@ void Anvil::OnUpdate(double dt)
     }
     
     std::vector<ecs::Entity> toDelete;
-    for (auto entity : d_activeScene->Entities().View<Transform3DComponent>()) {
+    for (auto entity : d_activeScene->Entities().view<Transform3DComponent>()) {
         auto& transform = entity.get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -232,7 +232,7 @@ void Anvil::OnRender()
 
         ImGuiXtra::Image(d_viewport.GetTexture());
 
-        if (!IsGameRunning() && d_selected.Valid() && d_selected.Has<Transform3DComponent>()) {
+        if (!IsGameRunning() && d_selected.valid() && d_selected.Has<Transform3DComponent>()) {
             auto& c = d_selected.Get<Transform3DComponent>();
             auto tr = Maths::Transform(c.position, c.orientation, c.scale);
             ImGuiXtra::Guizmo(&tr, view, proj, d_inspector.Operation(), d_inspector.Mode());

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -50,7 +50,7 @@ Anvil::Anvil(Window* window)
     d_scene = std::make_shared<Scene>();    
     d_scene->Load(d_sceneFile);
 
-    d_runtimeCamera = d_scene->Entities().Find([](ecs::Entity entity) {
+    d_runtimeCamera = d_scene->Entities().find([](ecs::Entity entity) {
         return entity.has<Camera3DComponent>();
     });
 
@@ -94,7 +94,7 @@ void Anvil::OnEvent(ev::Event& event)
 void Anvil::OnUpdate(double dt)
 {
     d_ui.OnUpdate(dt);
-    d_window->SetWindowName(fmt::format("Anvil: {}", d_sceneFile));
+    //d_window->SetWindowName(fmt::format("Anvil: {}", d_sceneFile));
 
     // Create the Shadow Map
     //float lambda = 5.0f; // TODO: Calculate the floor intersection point
@@ -210,7 +210,7 @@ void Anvil::OnRender()
                 Loader::Copy(&d_scene->Entities(), &d_activeScene->Entities());
 
                 d_playingGame = true;
-                d_runtimeCamera = d_activeScene->Entities().Find<Camera3DComponent>();
+                d_runtimeCamera = d_activeScene->Entities().find<Camera3DComponent>();
                 d_window->SetCursorVisibility(false);
             }
             ImGui::EndMenu();

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -121,7 +121,7 @@ void Anvil::OnUpdate(double dt)
         }
     }
     for (auto entity : toDelete) {
-        entity.Delete();
+        entity.destroy();
     }
 }
 

--- a/Anvil/Main.m.cpp
+++ b/Anvil/Main.m.cpp
@@ -1,6 +1,15 @@
 #include <Sprocket.h>
 #include "Anvil.h"
 
+struct foo
+{
+    //std::any a;
+    std::unique_ptr<void, void(*)(void*)> a;
+    std::size_t x;
+    std::string_view y;
+    bool consumed;
+};
+
 int main()
 {
     Sprocket::Window window("Anvil");

--- a/Anvil/Main.m.cpp
+++ b/Anvil/Main.m.cpp
@@ -5,5 +5,7 @@ int main()
 {
     Sprocket::Window window("Anvil");
     Sprocket::Anvil editor(&window);
-    return Sprocket::Run(editor, window);
+    Sprocket::RunOptions options;
+    options.showFramerate = true;
+    return Sprocket::Run(editor, window, options);
 }

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -24,69 +24,69 @@ void Inspector::Show(Anvil& editor)
     }
     int count = 0;
 
-    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), guid::Stringify(entity.Id()).c_str());
+    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), guid::Stringify(entity.id()).c_str());
 
-    if (entity.Has<TemporaryComponent>()) {
-        auto& c = entity.Get<TemporaryComponent>();
+    if (entity.has<TemporaryComponent>()) {
+        auto& c = entity.get<TemporaryComponent>();
         if (ImGui::CollapsingHeader("Temporary")) {
             ImGui::PushID(count++);
             
-            if (ImGui::Button("Delete")) { entity.Remove<TemporaryComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<TemporaryComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<NameComponent>()) {
-        auto& c = entity.Get<NameComponent>();
+    if (entity.has<NameComponent>()) {
+        auto& c = entity.get<NameComponent>();
         if (ImGui::CollapsingHeader("Name")) {
             ImGui::PushID(count++);
             ImGuiXtra::TextModifiable(c.name);
             
-            if (ImGui::Button("Delete")) { entity.Remove<NameComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<NameComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<Transform2DComponent>()) {
-        auto& c = entity.Get<Transform2DComponent>();
+    if (entity.has<Transform2DComponent>()) {
+        auto& c = entity.get<Transform2DComponent>();
         if (ImGui::CollapsingHeader("Transform 2D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat2("Position", &c.position.x, 0.1f);
             ImGui::DragFloat("Rotation", &c.rotation, 0.01f);
             ImGui::DragFloat2("Scale", &c.scale.x, 0.1f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<Transform2DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<Transform2DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<Transform3DComponent>()) {
-        auto& c = entity.Get<Transform3DComponent>();
+    if (entity.has<Transform3DComponent>()) {
+        auto& c = entity.get<Transform3DComponent>();
         if (ImGui::CollapsingHeader("Transform 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
             ImGuiXtra::Euler("Orientation", &c.orientation);
             ImGui::DragFloat3("Scale", &c.scale.x, 0.1f);
             ImGuiXtra::GuizmoSettings(d_operation, d_mode, d_useSnap, d_snap);
-            if (ImGui::Button("Delete")) { entity.Remove<Transform3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<Transform3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<ModelComponent>()) {
-        auto& c = entity.Get<ModelComponent>();
+    if (entity.has<ModelComponent>()) {
+        auto& c = entity.get<ModelComponent>();
         if (ImGui::CollapsingHeader("Model")) {
             ImGui::PushID(count++);
             ImGuiXtra::File("Mesh", editor.GetWindow(), &c.mesh, "*.obj");
             ImGuiXtra::File("Material", editor.GetWindow(), &c.material, "*.yaml");
             
-            if (ImGui::Button("Delete")) { entity.Remove<ModelComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<ModelComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<RigidBody3DComponent>()) {
-        auto& c = entity.Get<RigidBody3DComponent>();
+    if (entity.has<RigidBody3DComponent>()) {
+        auto& c = entity.get<RigidBody3DComponent>();
         if (ImGui::CollapsingHeader("Rigid Body 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Velocity", &c.velocity.x, 0.1f);
@@ -98,13 +98,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat3("Force", &c.force.x, 0.1f);
             ImGui::Checkbox("OnFloor", &c.onFloor);
             
-            if (ImGui::Button("Delete")) { entity.Remove<RigidBody3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<RigidBody3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<BoxCollider3DComponent>()) {
-        auto& c = entity.Get<BoxCollider3DComponent>();
+    if (entity.has<BoxCollider3DComponent>()) {
+        auto& c = entity.get<BoxCollider3DComponent>();
         if (ImGui::CollapsingHeader("Box Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -113,13 +113,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat3("Half Extents", &c.halfExtents.x, 0.1f);
             ImGui::Checkbox("Apply Scale", &c.applyScale);
             
-            if (ImGui::Button("Delete")) { entity.Remove<BoxCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<BoxCollider3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<SphereCollider3DComponent>()) {
-        auto& c = entity.Get<SphereCollider3DComponent>();
+    if (entity.has<SphereCollider3DComponent>()) {
+        auto& c = entity.get<SphereCollider3DComponent>();
         if (ImGui::CollapsingHeader("Sphere Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -127,13 +127,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Mass", &c.mass, 0.01f);
             ImGui::DragFloat("Radius", &c.radius, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<SphereCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<SphereCollider3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<CapsuleCollider3DComponent>()) {
-        auto& c = entity.Get<CapsuleCollider3DComponent>();
+    if (entity.has<CapsuleCollider3DComponent>()) {
+        auto& c = entity.get<CapsuleCollider3DComponent>();
         if (ImGui::CollapsingHeader("Capsule Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -142,86 +142,86 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Radius", &c.radius, 0.01f);
             ImGui::DragFloat("Height", &c.height, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<CapsuleCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<CapsuleCollider3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<ScriptComponent>()) {
-        auto& c = entity.Get<ScriptComponent>();
+    if (entity.has<ScriptComponent>()) {
+        auto& c = entity.get<ScriptComponent>();
         if (ImGui::CollapsingHeader("Script")) {
             ImGui::PushID(count++);
             ImGuiXtra::File("Script", editor.GetWindow(), &c.script, "*.lua");
             ImGui::Checkbox("Active", &c.active);
             
-            if (ImGui::Button("Delete")) { entity.Remove<ScriptComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<ScriptComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<Camera3DComponent>()) {
-        auto& c = entity.Get<Camera3DComponent>();
+    if (entity.has<Camera3DComponent>()) {
+        auto& c = entity.get<Camera3DComponent>();
         if (ImGui::CollapsingHeader("Camera 3D")) {
             ImGui::PushID(count++);
             ;
             ImGui::DragFloat("FOV", &c.fov, 0.01f);
             ImGui::DragFloat("Pitch", &c.pitch, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<Camera3DComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<Camera3DComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<SelectComponent>()) {
-        auto& c = entity.Get<SelectComponent>();
+    if (entity.has<SelectComponent>()) {
+        auto& c = entity.get<SelectComponent>();
         if (ImGui::CollapsingHeader("Select")) {
             ImGui::PushID(count++);
             ImGui::Checkbox("Selected", &c.selected);
             ImGui::Checkbox("Hovered", &c.hovered);
             
-            if (ImGui::Button("Delete")) { entity.Remove<SelectComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<SelectComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<PathComponent>()) {
-        auto& c = entity.Get<PathComponent>();
+    if (entity.has<PathComponent>()) {
+        auto& c = entity.get<PathComponent>();
         if (ImGui::CollapsingHeader("Path")) {
             ImGui::PushID(count++);
             ;
             ImGui::DragFloat("Speed", &c.speed, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<PathComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<PathComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<GridComponent>()) {
-        auto& c = entity.Get<GridComponent>();
+    if (entity.has<GridComponent>()) {
+        auto& c = entity.get<GridComponent>();
         if (ImGui::CollapsingHeader("Grid")) {
             ImGui::PushID(count++);
             ;
             ;
             
-            if (ImGui::Button("Delete")) { entity.Remove<GridComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<GridComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<LightComponent>()) {
-        auto& c = entity.Get<LightComponent>();
+    if (entity.has<LightComponent>()) {
+        auto& c = entity.get<LightComponent>();
         if (ImGui::CollapsingHeader("Light")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
             ImGui::DragFloat("Brightness", &c.brightness, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<LightComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<LightComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<SunComponent>()) {
-        auto& c = entity.Get<SunComponent>();
+    if (entity.has<SunComponent>()) {
+        auto& c = entity.get<SunComponent>();
         if (ImGui::CollapsingHeader("Sun")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
@@ -229,25 +229,25 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat3("Direction", &c.direction.x, 0.1f);
             ImGui::Checkbox("Shadows", &c.shadows);
             
-            if (ImGui::Button("Delete")) { entity.Remove<SunComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<SunComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<AmbienceComponent>()) {
-        auto& c = entity.Get<AmbienceComponent>();
+    if (entity.has<AmbienceComponent>()) {
+        auto& c = entity.get<AmbienceComponent>();
         if (ImGui::CollapsingHeader("Ambience")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
             ImGui::DragFloat("Brightness", &c.brightness, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<AmbienceComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<AmbienceComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<ParticleComponent>()) {
-        auto& c = entity.Get<ParticleComponent>();
+    if (entity.has<ParticleComponent>()) {
+        auto& c = entity.get<ParticleComponent>();
         if (ImGui::CollapsingHeader("Particle")) {
             ImGui::PushID(count++);
             ImGui::DragFloat("Interval", &c.interval, 0.01f);
@@ -258,20 +258,20 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Life", &c.life, 0.01f);
             ImGui::DragFloat("Accumulator", &c.accumulator, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<ParticleComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<ParticleComponent>(); }
             ImGui::PopID();
         }
     }
 
-    if (entity.Has<MeshAnimationComponent>()) {
-        auto& c = entity.Get<MeshAnimationComponent>();
+    if (entity.has<MeshAnimationComponent>()) {
+        auto& c = entity.get<MeshAnimationComponent>();
         if (ImGui::CollapsingHeader("Mesh Animation")) {
             ImGui::PushID(count++);
             ImGuiXtra::TextModifiable(c.name);
             ImGui::DragFloat("Time", &c.time, 0.01f);
             ImGui::DragFloat("Speed", &c.speed, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.Remove<MeshAnimationComponent>(); }
+            if (ImGui::Button("Delete")) { entity.remove<MeshAnimationComponent>(); }
             ImGui::PopID();
         }
     }
@@ -283,81 +283,81 @@ void Inspector::Show(Anvil& editor)
     }
 
     if (ImGui::BeginPopup("missing_components_list")) {
-        if (!entity.Has<TemporaryComponent>() && ImGui::Selectable("Temporary")) {
+        if (!entity.has<TemporaryComponent>() && ImGui::Selectable("Temporary")) {
             TemporaryComponent c;
-            entity.Add<TemporaryComponent>(c);
+            entity.add<TemporaryComponent>(c);
         }
-        if (!entity.Has<NameComponent>() && ImGui::Selectable("Name")) {
+        if (!entity.has<NameComponent>() && ImGui::Selectable("Name")) {
             NameComponent c;
-            entity.Add<NameComponent>(c);
+            entity.add<NameComponent>(c);
         }
-        if (!entity.Has<Transform2DComponent>() && ImGui::Selectable("Transform 2D")) {
+        if (!entity.has<Transform2DComponent>() && ImGui::Selectable("Transform 2D")) {
             Transform2DComponent c;
-            entity.Add<Transform2DComponent>(c);
+            entity.add<Transform2DComponent>(c);
         }
-        if (!entity.Has<Transform3DComponent>() && ImGui::Selectable("Transform 3D")) {
+        if (!entity.has<Transform3DComponent>() && ImGui::Selectable("Transform 3D")) {
             Transform3DComponent c;
-            entity.Add<Transform3DComponent>(c);
+            entity.add<Transform3DComponent>(c);
         }
-        if (!entity.Has<ModelComponent>() && ImGui::Selectable("Model")) {
+        if (!entity.has<ModelComponent>() && ImGui::Selectable("Model")) {
             ModelComponent c;
-            entity.Add<ModelComponent>(c);
+            entity.add<ModelComponent>(c);
         }
-        if (!entity.Has<RigidBody3DComponent>() && ImGui::Selectable("Rigid Body 3D")) {
+        if (!entity.has<RigidBody3DComponent>() && ImGui::Selectable("Rigid Body 3D")) {
             RigidBody3DComponent c;
-            entity.Add<RigidBody3DComponent>(c);
+            entity.add<RigidBody3DComponent>(c);
         }
-        if (!entity.Has<BoxCollider3DComponent>() && ImGui::Selectable("Box Collider 3D")) {
+        if (!entity.has<BoxCollider3DComponent>() && ImGui::Selectable("Box Collider 3D")) {
             BoxCollider3DComponent c;
-            entity.Add<BoxCollider3DComponent>(c);
+            entity.add<BoxCollider3DComponent>(c);
         }
-        if (!entity.Has<SphereCollider3DComponent>() && ImGui::Selectable("Sphere Collider 3D")) {
+        if (!entity.has<SphereCollider3DComponent>() && ImGui::Selectable("Sphere Collider 3D")) {
             SphereCollider3DComponent c;
-            entity.Add<SphereCollider3DComponent>(c);
+            entity.add<SphereCollider3DComponent>(c);
         }
-        if (!entity.Has<CapsuleCollider3DComponent>() && ImGui::Selectable("Capsule Collider 3D")) {
+        if (!entity.has<CapsuleCollider3DComponent>() && ImGui::Selectable("Capsule Collider 3D")) {
             CapsuleCollider3DComponent c;
-            entity.Add<CapsuleCollider3DComponent>(c);
+            entity.add<CapsuleCollider3DComponent>(c);
         }
-        if (!entity.Has<ScriptComponent>() && ImGui::Selectable("Script")) {
+        if (!entity.has<ScriptComponent>() && ImGui::Selectable("Script")) {
             ScriptComponent c;
-            entity.Add<ScriptComponent>(c);
+            entity.add<ScriptComponent>(c);
         }
-        if (!entity.Has<Camera3DComponent>() && ImGui::Selectable("Camera 3D")) {
+        if (!entity.has<Camera3DComponent>() && ImGui::Selectable("Camera 3D")) {
             Camera3DComponent c;
-            entity.Add<Camera3DComponent>(c);
+            entity.add<Camera3DComponent>(c);
         }
-        if (!entity.Has<SelectComponent>() && ImGui::Selectable("Select")) {
+        if (!entity.has<SelectComponent>() && ImGui::Selectable("Select")) {
             SelectComponent c;
-            entity.Add<SelectComponent>(c);
+            entity.add<SelectComponent>(c);
         }
-        if (!entity.Has<PathComponent>() && ImGui::Selectable("Path")) {
+        if (!entity.has<PathComponent>() && ImGui::Selectable("Path")) {
             PathComponent c;
-            entity.Add<PathComponent>(c);
+            entity.add<PathComponent>(c);
         }
-        if (!entity.Has<GridComponent>() && ImGui::Selectable("Grid")) {
+        if (!entity.has<GridComponent>() && ImGui::Selectable("Grid")) {
             GridComponent c;
-            entity.Add<GridComponent>(c);
+            entity.add<GridComponent>(c);
         }
-        if (!entity.Has<LightComponent>() && ImGui::Selectable("Light")) {
+        if (!entity.has<LightComponent>() && ImGui::Selectable("Light")) {
             LightComponent c;
-            entity.Add<LightComponent>(c);
+            entity.add<LightComponent>(c);
         }
-        if (!entity.Has<SunComponent>() && ImGui::Selectable("Sun")) {
+        if (!entity.has<SunComponent>() && ImGui::Selectable("Sun")) {
             SunComponent c;
-            entity.Add<SunComponent>(c);
+            entity.add<SunComponent>(c);
         }
-        if (!entity.Has<AmbienceComponent>() && ImGui::Selectable("Ambience")) {
+        if (!entity.has<AmbienceComponent>() && ImGui::Selectable("Ambience")) {
             AmbienceComponent c;
-            entity.Add<AmbienceComponent>(c);
+            entity.add<AmbienceComponent>(c);
         }
-        if (!entity.Has<ParticleComponent>() && ImGui::Selectable("Particle")) {
+        if (!entity.has<ParticleComponent>() && ImGui::Selectable("Particle")) {
             ParticleComponent c;
-            entity.Add<ParticleComponent>(c);
+            entity.add<ParticleComponent>(c);
         }
-        if (!entity.Has<MeshAnimationComponent>() && ImGui::Selectable("Mesh Animation")) {
+        if (!entity.has<MeshAnimationComponent>() && ImGui::Selectable("Mesh Animation")) {
             MeshAnimationComponent c;
-            entity.Add<MeshAnimationComponent>(c);
+            entity.add<MeshAnimationComponent>(c);
         }
         ImGui::EndMenu();
     }

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -17,7 +17,7 @@ void Inspector::Show(Anvil& editor)
 
     if (!editor.Selected().valid()) {
         if (ImGui::Button("New Entity")) {
-            auto e = editor.GetScene()->Entities().New();
+            auto e = editor.GetScene()->Entities().create();
             editor.SetSelected(e);
         }
         return;

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -15,7 +15,7 @@ void Inspector::Show(Anvil& editor)
 {
     ecs::Entity entity = editor.Selected();
 
-    if (!editor.Selected().Valid()) {
+    if (!editor.Selected().valid()) {
         if (ImGui::Button("New Entity")) {
             auto e = editor.GetScene()->Entities().New();
             editor.SetSelected(e);

--- a/Anvil/Panels/Inspector.cpp
+++ b/Anvil/Panels/Inspector.cpp
@@ -367,7 +367,7 @@ void Inspector::Show(Anvil& editor)
         editor.SetSelected(copy);
     }
     if (ImGui::Button("Delete Entity")) {
-        entity.Delete();
+        entity.destroy();
         editor.ClearSelected();
     }
 }

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -14,25 +14,25 @@ void Inspector::Show(Anvil& editor)
 {
     ecs::Entity entity = editor.Selected();
 
-    if (!editor.Selected().Valid()) {
+    if (!editor.Selected().valid()) {
         if (ImGui::Button("New Entity")) {
-            auto e = editor.GetScene()->Entities().New();
+            auto e = editor.GetScene()->Entities().create();
             editor.SetSelected(e);
         }
         return;
     }
     int count = 0;
 
-    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), guid::Stringify(entity.Id()).c_str());
+    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), guid::Stringify(entity.id()).c_str());
 
 #ifdef DATAMATIC_BLOCK
-    if (entity.Has<{{Comp.Name}}>()) {
-        auto& c = entity.Get<{{Comp.Name}}>();
+    if (entity.has<{{Comp.Name}}>()) {
+        auto& c = entity.get<{{Comp.Name}}>();
         if (ImGui::CollapsingHeader("{{Comp.DisplayName}}")) {
             ImGui::PushID(count++);
             {{Attr.Inspector.Display}};
             {{Comp.Inspector.GuizmoSettings}}
-            if (ImGui::Button("Delete")) { entity.Remove<{{Comp.Name}}>(); }
+            if (ImGui::Button("Delete")) { entity.remove<{{Comp.Name}}>(); }
             ImGui::PopID();
         }
     }
@@ -46,9 +46,9 @@ void Inspector::Show(Anvil& editor)
 
     if (ImGui::BeginPopup("missing_components_list")) {
 #ifdef DATAMATIC_BLOCK
-        if (!entity.Has<{{Comp.Name}}>() && ImGui::Selectable("{{Comp.DisplayName}}")) {
+        if (!entity.has<{{Comp.Name}}>() && ImGui::Selectable("{{Comp.DisplayName}}")) {
             {{Comp.Name}} c;
-            entity.Add<{{Comp.Name}}>(c);
+            entity.add<{{Comp.Name}}>(c);
         }
 #endif
         ImGui::EndMenu();
@@ -59,7 +59,7 @@ void Inspector::Show(Anvil& editor)
         editor.SetSelected(copy);
     }
     if (ImGui::Button("Delete Entity")) {
-        entity.Delete();
+        entity.destroy();
         editor.ClearSelected();
     }
 }

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -92,7 +92,7 @@ WorldLayer::WorldLayer(Window* window)
 
     d_cycle.SetAngle(3.14195f);
 
-    auto& sun = d_scene.Entities().Find<SunComponent>().get<SunComponent>();
+    auto& sun = d_scene.Entities().find<SunComponent>().get<SunComponent>();
     sun.direction = d_cycle.GetSunDir();
 
     d_postProcessor.AddEffect<GaussianVert>();
@@ -114,11 +114,11 @@ void WorldLayer::LoadScene(std::string_view file)
 
     d_sceneFile = file;
 
-    d_worker = d_scene.Entities().Find<NameComponent>([](ecs::Entity entity) {
+    d_worker = d_scene.Entities().find<NameComponent>([](ecs::Entity entity) {
         return entity.get<NameComponent>().name == "Worker";
     });
 
-    d_camera = d_scene.Entities().Find<NameComponent>([](ecs::Entity entity) {
+    d_camera = d_scene.Entities().find<NameComponent>([](ecs::Entity entity) {
         return entity.get<NameComponent>().name == "Camera";
     });
 
@@ -212,7 +212,7 @@ void WorldLayer::OnUpdate(double dt)
         d_cycle.OnUpdate(dt);
     }
     
-    auto& sun = d_scene.Entities().Find<SunComponent>().get<SunComponent>();
+    auto& sun = d_scene.Entities().find<SunComponent>().get<SunComponent>();
     float factor = (-d_cycle.GetSunDir().y + 1.0f) / 2.0f;
     float facSq = factor * factor;
     auto skyColour = (1.0f - facSq) * NAVY_NIGHT + facSq * LIGHT_BLUE;
@@ -246,7 +246,7 @@ void WorldLayer::OnRender()
     auto& tc = d_camera.get<Transform3DComponent>();
     glm::vec3 target = tc.position + lambda * Maths::Forwards(tc.orientation);
     d_shadowMap.Draw(
-        d_scene.Entities().Find<SunComponent>().get<SunComponent>().direction,
+        d_scene.Entities().find<SunComponent>().get<SunComponent>().direction,
         target,
         d_scene
     );

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -316,7 +316,7 @@ void WorldLayer::OnRender()
 
 
         auto hovered = grid.Hovered();
-        if (hovered.Valid()) {
+        if (hovered.valid()) {
             float width = 200;
             float height = 50;
             float x = std::min(mouse.x - 5, w - width - 10);

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -92,7 +92,7 @@ WorldLayer::WorldLayer(Window* window)
 
     d_cycle.SetAngle(3.14195f);
 
-    auto& sun = d_scene.Entities().Find<SunComponent>().Get<SunComponent>();
+    auto& sun = d_scene.Entities().Find<SunComponent>().get<SunComponent>();
     sun.direction = d_cycle.GetSunDir();
 
     d_postProcessor.AddEffect<GaussianVert>();
@@ -115,11 +115,11 @@ void WorldLayer::LoadScene(std::string_view file)
     d_sceneFile = file;
 
     d_worker = d_scene.Entities().Find<NameComponent>([](ecs::Entity entity) {
-        return entity.Get<NameComponent>().name == "Worker";
+        return entity.get<NameComponent>().name == "Worker";
     });
 
     d_camera = d_scene.Entities().Find<NameComponent>([](ecs::Entity entity) {
-        return entity.Get<NameComponent>().name == "Camera";
+        return entity.get<NameComponent>().name == "Camera";
     });
 
     d_scene.Get<GameGrid>().SetCamera(d_camera);
@@ -158,7 +158,7 @@ void WorldLayer::OnEvent(Sprocket::ev::Event& event)
     }
 
     if (auto data = event.get_if<ev::MouseButtonPressed>()) {
-        auto& tr = d_camera.Get<Transform3DComponent>();
+        auto& tr = d_camera.get<Transform3DComponent>();
         if (data->mods & KeyModifier::CTRL) {
             glm::vec3 cameraPos = tr.position;
             glm::vec3 direction = Maths::GetMouseRay(
@@ -173,11 +173,11 @@ void WorldLayer::OnEvent(Sprocket::ev::Event& event)
             glm::vec3 mousePos = cameraPos + lambda * direction;
             mousePos.y = 0.5f;
             
-            auto& path = d_worker.Get<PathComponent>();
+            auto& path = d_worker.get<PathComponent>();
 
             if (data->button == Mouse::LEFT) {
                 std::queue<glm::vec3>().swap(path.markers);
-                auto pos = d_worker.Get<Transform3DComponent>().position;
+                auto pos = d_worker.get<Transform3DComponent>().position;
                 if (glm::distance(pos, mousePos) > 1.0f) {
                     path.markers = GenerateAStarPath(
                         pos,
@@ -212,7 +212,7 @@ void WorldLayer::OnUpdate(double dt)
         d_cycle.OnUpdate(dt);
     }
     
-    auto& sun = d_scene.Entities().Find<SunComponent>().Get<SunComponent>();
+    auto& sun = d_scene.Entities().Find<SunComponent>().get<SunComponent>();
     float factor = (-d_cycle.GetSunDir().y + 1.0f) / 2.0f;
     float facSq = factor * factor;
     auto skyColour = (1.0f - facSq) * NAVY_NIGHT + facSq * LIGHT_BLUE;
@@ -243,10 +243,10 @@ void WorldLayer::OnRender()
 
     // Create the Shadow Map
     float lambda = 5.0f; // TODO: Calculate the floor intersection point
-    auto& tc = d_camera.Get<Transform3DComponent>();
+    auto& tc = d_camera.get<Transform3DComponent>();
     glm::vec3 target = tc.position + lambda * Maths::Forwards(tc.orientation);
     d_shadowMap.Draw(
-        d_scene.Entities().Find<SunComponent>().Get<SunComponent>().direction,
+        d_scene.Entities().Find<SunComponent>().get<SunComponent>().direction,
         target,
         d_scene
     );
@@ -325,8 +325,8 @@ void WorldLayer::OnRender()
             glm::vec4 region{x, y, width, height};
             d_hoveredEntityUI.StartPanel("Hovered", &region, PanelType::UNCLICKABLE);
             std::string name = "Unnamed";
-            if (hovered.Has<NameComponent>()) {
-                name = hovered.Get<NameComponent>().name;
+            if (hovered.has<NameComponent>()) {
+                name = hovered.get<NameComponent>().name;
             }
             d_hoveredEntityUI.Text(name, 36.0f, {0, 0, width, height});
             d_hoveredEntityUI.EndPanel();
@@ -452,21 +452,21 @@ void WorldLayer::AddTree(const glm::ivec2& pos)
 
     auto newEntity = d_scene.Entities().New();
 
-    auto& name = newEntity.Add<NameComponent>();
+    auto& name = newEntity.add<NameComponent>();
     name.name = "Tree";
 
-    auto& tr = newEntity.Add<Transform3DComponent>();
+    auto& tr = newEntity.add<Transform3DComponent>();
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), Random(0.0f, 360.0f), {0, 1, 0});
     float r = Random(1.0f, 1.3f);
     tr.scale = {r, r, r};
 
-    auto& modelData = newEntity.Add<ModelComponent>();
+    auto& modelData = newEntity.add<ModelComponent>();
     modelData.mesh = "Resources/Models/BetterTree.obj";
     modelData.material = "Resources/Materials/tree.yaml";
-    newEntity.Add<SelectComponent>();
+    newEntity.add<SelectComponent>();
 
     GridComponent gc = {pos.x, pos.y};
-    newEntity.Add<GridComponent>(gc);
+    newEntity.add<GridComponent>(gc);
 }
 
 void WorldLayer::AddRockBase(
@@ -477,22 +477,22 @@ void WorldLayer::AddRockBase(
     using namespace Sprocket;
 
     auto newEntity = d_scene.Entities().New();
-    auto& n = newEntity.Add<NameComponent>();
+    auto& n = newEntity.add<NameComponent>();
     n.name = name;
 
-    auto& tr = newEntity.Add<Transform3DComponent>();
+    auto& tr = newEntity.add<Transform3DComponent>();
     tr.position.y -= Random(0.0f, 0.5f);
     float randomRotation = glm::half_pi<float>() * Random(0, 3);
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), randomRotation, {0.0, 1.0, 0.0});
     tr.scale = {1.1f, 1.1f, 1.1f};
 
-    auto& modelData = newEntity.Add<ModelComponent>();
+    auto& modelData = newEntity.add<ModelComponent>();
     modelData.mesh = "Resources/Models/Rock.obj";
     modelData.material = material;
-    newEntity.Add<SelectComponent>();
+    newEntity.add<SelectComponent>();
 
     GridComponent gc = {pos.x, pos.y};
-    newEntity.Add<GridComponent>(gc);
+    newEntity.add<GridComponent>(gc);
 }
 
 void WorldLayer::AddRock(const glm::ivec2& pos)

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -450,7 +450,7 @@ void WorldLayer::AddTree(const glm::ivec2& pos)
 {
     using namespace Sprocket;
 
-    auto newEntity = d_scene.Entities().New();
+    auto newEntity = d_scene.Entities().create();
 
     auto& name = newEntity.add<NameComponent>();
     name.name = "Tree";
@@ -476,7 +476,7 @@ void WorldLayer::AddRockBase(
 {
     using namespace Sprocket;
 
-    auto newEntity = d_scene.Entities().New();
+    auto newEntity = d_scene.Entities().create();
     auto& n = newEntity.add<NameComponent>();
     n.name = name;
 

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -283,32 +283,32 @@ void WorldLayer::OnRender()
                 
             auto pos = grid.SelectedPosition().value();
             if (d_hoveredEntityUI.Button("+Tree", {0, 0, width, 50})) {
-                selected.Delete();
+                selected.destroy();
                 AddTree(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Rock", {0, 60, width, 50})) {
-                selected.Delete();
+                selected.destroy();
                 AddRock(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Iron", {0, 120, width, 50})) {
-                selected.Delete();
+                selected.destroy();
                 AddIron(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Tin", {0, 180, width, 50})) {
-                selected.Delete();
+                selected.destroy();
                 AddTin(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Mithril", {0, 240, width, 50})) {
-                selected.Delete();
+                selected.destroy();
                 AddMithril(pos);
             }
 
             if (d_hoveredEntityUI.Button("Clear", {0, 300, width, 50})) {
-                selected.Delete();
+                selected.destroy();
             }
 
             d_hoveredEntityUI.EndPanel();

--- a/Game/Main.m.cpp
+++ b/Game/Main.m.cpp
@@ -4,6 +4,13 @@
 
 using namespace Sprocket;
 
+struct Foo
+{
+    int x;
+    double y;
+    float z;
+};
+
 int main()
 {
     Sprocket::Window window("Game");

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -32,7 +32,7 @@ Runtime::Runtime(Window* window)
     d_scene.Add<AnimationSystem>();
     d_scene.Load("Resources/Anvil.yaml");
 
-    d_runtimeCamera = d_scene.Entities().Find<Camera3DComponent>();
+    d_runtimeCamera = d_scene.Entities().find<Camera3DComponent>();
 }
 
 void Runtime::OnEvent(ev::Event& event)

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -71,7 +71,7 @@ void Runtime::OnUpdate(double dt)
         }
     }
     for (auto entity : toDelete) {
-        entity.Delete();
+        entity.destroy();
     }
 }
 

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -65,7 +65,7 @@ void Runtime::OnUpdate(double dt)
     
     std::vector<ecs::Entity> toDelete;
     for (auto entity : d_scene.Entities().View<Transform3DComponent>()) {
-        auto& transform = entity.Get<Transform3DComponent>();
+        auto& transform = entity.get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);
         }

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -64,7 +64,7 @@ void Runtime::OnUpdate(double dt)
     }
     
     std::vector<ecs::Entity> toDelete;
-    for (auto entity : d_scene.Entities().View<Transform3DComponent>()) {
+    for (auto entity : d_scene.Entities().view<Transform3DComponent>()) {
         auto& transform = entity.get<Transform3DComponent>();
         if (transform.position.y < -50) {
             toDelete.push_back(entity);

--- a/Sprocket/Audio/Listener.cpp
+++ b/Sprocket/Audio/Listener.cpp
@@ -8,8 +8,8 @@ namespace Audio {
 
 void SetListener(const ecs::Entity& entity)
 {
-    if (!entity.Has<Transform3DComponent>()) { return; }
-    auto tr = entity.Get<Transform3DComponent>();
+    if (!entity.has<Transform3DComponent>()) { return; }
+    auto tr = entity.get<Transform3DComponent>();
     auto pos = tr.position;
     sf::Listener::setPosition(pos.x, pos.y, pos.z);
 

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -61,7 +61,7 @@ public:
 	template <typename T>
 	void subscribe(const EventHandlerTyped<T>& handler)
 	{
-		d_handlers[typeid(T)].push_back([handler](ev::Event& event) {
+		d_handlers[typeid(T)].push_back([&](ev::Event& event) {
 			handler(event, event.get<T>());
 		});
 	}

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -22,7 +22,7 @@ public:
 	{}
 
 	template <typename T> bool is() const noexcept { return d_event.type() == typeid(T); }
-	template <typename T> T get() const { return std::any_cast<T>(d_event); }
+	template <typename T> const T& get() const { return std::any_cast<const T&>(d_event); }
 	template <typename T> const T* get_if() const noexcept { return std::any_cast<T>(&d_event); }
 
 	bool is_consumed() const noexcept { return d_consumed; }

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -45,6 +45,9 @@ class Dispatcher
 public:
 	using EventHandler = std::function<void(ev::Event&)>;
 
+	template <typename T>
+	using EventHandlerTyped = std::function<void(ev::Event&, const T&)>;
+
 private:
 	std::unordered_map<std::type_index, std::vector<EventHandler>> d_handlers;
 
@@ -53,6 +56,14 @@ public:
 	void subscribe(const EventHandler& handler)
 	{
 		d_handlers[typeid(T)].push_back(handler);
+	}
+
+	template <typename T>
+	void subscribe(const EventHandlerTyped<T>& handler)
+	{
+		d_handlers[typeid(T)].push_back([handler](ev::Event& event) {
+			handler(event, event.get<T>());
+		});
 	}
 
 	void publish(ev::Event& event) const

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <any>
 #include <string>
+#include <typeinfo> // TODO: Replace with own version
+#include <typeindex>
+#include <functional>
 
 #include "Types.h"
 
@@ -27,6 +30,8 @@ public:
 
 	// Implementation defined name, should only be used for logging.
 	std::string type_name() const noexcept { return d_event.type().name(); }
+
+	const std::type_info& type_info() const noexcept { return d_event.type(); }
 };
 
 template <typename T, typename... Args>
@@ -34,6 +39,31 @@ Event make_event(Args&&... args)
 {
 	return Event(std::in_place_type<T>, std::forward<Args>(args)...);
 }
+
+class Dispatcher
+{
+public:
+	using EventHandler = std::function<void(ev::Event&)>;
+
+private:
+	std::unordered_map<std::type_index, std::vector<EventHandler>> d_handlers;
+
+public:
+	template <typename T>
+	void subscribe(const EventHandler& handler)
+	{
+		d_handlers[typeid(T)].push_back(handler);
+	}
+
+	void publish(ev::Event& event) const
+	{
+		if (auto it = d_handlers.find(event.type_info()); it != d_handlers.end()) {
+			for (auto& handler : it->second) {
+				handler(event);
+			}
+		}
+	}
+};
 
 // KEYBOARD EVENTS 
 struct KeyboardButtonPressed {

--- a/Sprocket/Graphics/AssetManager.h
+++ b/Sprocket/Graphics/AssetManager.h
@@ -18,11 +18,11 @@ class AssetManager
     std::unordered_map<std::string, std::future<std::unique_ptr<TextureData>>> d_loadingTextures;
 
     // Primitives
-    std::unordered_map<std::string, std::unique_ptr<Mesh>>    d_meshes;
-    std::unordered_map<std::string, std::unique_ptr<Texture>> d_textures;
+    std::unordered_map<std::string, const std::unique_ptr<Mesh>>    d_meshes;
+    std::unordered_map<std::string, const std::unique_ptr<Texture>> d_textures;
     
     // Composites
-    std::unordered_map<std::string, std::unique_ptr<Material>> d_materials;
+    std::unordered_map<std::string, const std::unique_ptr<Material>> d_materials;
 
     // Defaults
     std::unique_ptr<Mesh>     d_defaultMesh;

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -33,8 +33,8 @@ void ColliderRenderer::Draw(
     static auto s_cube = Mesh::FromFile("Resources/Models/Cube.obj");
     d_vao->SetModel(s_cube.get());
     for (auto entity : scene.Entities().View<BoxCollider3DComponent>()) {
-        const auto& c = entity.Get<BoxCollider3DComponent>();
-        auto tr = entity.Get<Transform3DComponent>();
+        const auto& c = entity.get<BoxCollider3DComponent>();
+        auto tr = entity.get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(c.position, c.orientation);
         transform = glm::scale(transform, c.halfExtents);
@@ -48,8 +48,8 @@ void ColliderRenderer::Draw(
     static auto s_sphere = Mesh::FromFile("Resources/Models/LowPolySphere.obj");
     d_vao->SetModel(s_sphere.get());
     for (auto entity : scene.Entities().View<SphereCollider3DComponent>()) {
-        const auto& c = entity.Get<SphereCollider3DComponent>();
-        auto tr = entity.Get<Transform3DComponent>();
+        const auto& c = entity.get<SphereCollider3DComponent>();
+        auto tr = entity.get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
         transform *= Maths::Transform(c.position, c.orientation);
         transform = glm::scale(transform, {c.radius, c.radius, c.radius});
@@ -61,10 +61,10 @@ void ColliderRenderer::Draw(
     static auto s_cylinder = Mesh::FromFile("Resources/Models/Cylinder.obj");
 
     for (auto entity : scene.Entities().View<CapsuleCollider3DComponent>()) {
-        const auto& c = entity.Get<CapsuleCollider3DComponent>();
+        const auto& c = entity.get<CapsuleCollider3DComponent>();
 
         {  // Top Hemisphere
-            auto tr = entity.Get<Transform3DComponent>();
+            auto tr = entity.get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::translate(transform, {0.0, c.height/2, 0.0});
@@ -75,7 +75,7 @@ void ColliderRenderer::Draw(
         }
 
         {  // Middle Cylinder
-            auto tr = entity.Get<Transform3DComponent>();
+            auto tr = entity.get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::scale(transform, {c.radius, c.height, c.radius});
@@ -85,7 +85,7 @@ void ColliderRenderer::Draw(
         }
 
         {  // Bottom Hemisphere
-            auto tr = entity.Get<Transform3DComponent>();
+            auto tr = entity.get<Transform3DComponent>();
             glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
             transform *= Maths::Transform(c.position, c.orientation);
             transform = glm::translate(transform, {0.0, -c.height/2, 0.0});

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -32,7 +32,7 @@ void ColliderRenderer::Draw(
     
     static auto s_cube = Mesh::FromFile("Resources/Models/Cube.obj");
     d_vao->SetModel(s_cube.get());
-    for (auto entity : scene.Entities().View<BoxCollider3DComponent>()) {
+    for (auto entity : scene.Entities().view<BoxCollider3DComponent>()) {
         const auto& c = entity.get<BoxCollider3DComponent>();
         auto tr = entity.get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
@@ -47,7 +47,7 @@ void ColliderRenderer::Draw(
 
     static auto s_sphere = Mesh::FromFile("Resources/Models/LowPolySphere.obj");
     d_vao->SetModel(s_sphere.get());
-    for (auto entity : scene.Entities().View<SphereCollider3DComponent>()) {
+    for (auto entity : scene.Entities().view<SphereCollider3DComponent>()) {
         const auto& c = entity.get<SphereCollider3DComponent>();
         auto tr = entity.get<Transform3DComponent>();
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
@@ -60,7 +60,7 @@ void ColliderRenderer::Draw(
     static auto s_hemisphere = Mesh::FromFile("Resources/Models/Hemisphere.obj");
     static auto s_cylinder = Mesh::FromFile("Resources/Models/Cylinder.obj");
 
-    for (auto entity : scene.Entities().View<CapsuleCollider3DComponent>()) {
+    for (auto entity : scene.Entities().view<CapsuleCollider3DComponent>()) {
         const auto& c = entity.get<CapsuleCollider3DComponent>();
 
         {  // Top Hemisphere

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -45,7 +45,7 @@ void UploadUniforms(
 
     // Load sun to shader
     if (const auto& s = scene.Entities().Find<SunComponent>(); s != ecs::Null) {
-        const auto& sun = s.Get<SunComponent>();
+        const auto& sun = s.get<SunComponent>();
         shader.LoadVec3("u_sun_direction", sun.direction);
         shader.LoadVec3("u_sun_colour", sun.colour);
         shader.LoadFloat("u_sun_brightness", sun.brightness);
@@ -53,7 +53,7 @@ void UploadUniforms(
 
     // Load ambience to shader
     if (const auto& a = scene.Entities().Find<AmbienceComponent>(); a != ecs::Null) {
-        const auto& ambience = a.Get<AmbienceComponent>();
+        const auto& ambience = a.get<AmbienceComponent>();
         shader.LoadVec3("u_ambience_colour", ambience.colour);
         shader.LoadFloat("u_ambience_brightness", ambience.brightness);
     }
@@ -63,8 +63,8 @@ void UploadUniforms(
     auto lights = scene.Entities().View<LightComponent, Transform3DComponent>();
     for (auto entity : lights) {
         if (i < MAX_NUM_LIGHTS) {
-            auto position = entity.Get<Transform3DComponent>().position;
-            auto light = entity.Get<LightComponent>();
+            auto position = entity.get<Transform3DComponent>().position;
+            auto light = entity.get<LightComponent>();
             shader.LoadVec3(ArrayName("u_light_pos", i), position);
             shader.LoadVec3(ArrayName("u_light_colour", i), light.colour);
             shader.LoadFloat(ArrayName("u_light_brightness", i), light.brightness);
@@ -163,8 +163,8 @@ void Scene3DRenderer::Draw(
 
     d_staticShader.Bind();
     for (auto entity : scene.Entities().View<ModelComponent, Transform3DComponent>()) {
-        const auto& tc = entity.Get<Transform3DComponent>();
-        const auto& mc = entity.Get<ModelComponent>();
+        const auto& tc = entity.get<Transform3DComponent>();
+        const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         auto mesh = d_assetManager->GetMesh(mc.mesh);
         if (mesh->IsAnimated()) { continue; }
@@ -192,8 +192,8 @@ void Scene3DRenderer::Draw(
 
     d_animatedShader.Bind();
     for (auto entity : scene.Entities().View<ModelComponent>()) {
-        const auto& tc = entity.Get<Transform3DComponent>();
-        const auto& mc = entity.Get<ModelComponent>();
+        const auto& tc = entity.get<Transform3DComponent>();
+        const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         auto mesh = d_assetManager->GetMesh(mc.mesh);
         if (!mesh->IsAnimated()) { continue; }
@@ -203,8 +203,8 @@ void Scene3DRenderer::Draw(
 
         d_animatedShader.LoadMat4("u_model_matrix", Maths::Transform(tc.position, tc.orientation, tc.scale));
         
-        if (entity.Has<MeshAnimationComponent>()) {
-            const auto& ac = entity.Get<MeshAnimationComponent>();
+        if (entity.has<MeshAnimationComponent>()) {
+            const auto& ac = entity.get<MeshAnimationComponent>();
             auto poses = mesh->GetPose(ac.name, ac.time);
             
             int numBones = std::min(MAX_BONES, (int)poses.size());

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -44,7 +44,7 @@ void UploadUniforms(
     shader.LoadMat4("u_view_matrix", view);
 
     // Load sun to shader
-    if (const auto& s = scene.Entities().Find<SunComponent>(); s != ecs::Null) {
+    if (const auto& s = scene.Entities().find<SunComponent>(); s != ecs::Null) {
         const auto& sun = s.get<SunComponent>();
         shader.LoadVec3("u_sun_direction", sun.direction);
         shader.LoadVec3("u_sun_colour", sun.colour);
@@ -52,7 +52,7 @@ void UploadUniforms(
     }
 
     // Load ambience to shader
-    if (const auto& a = scene.Entities().Find<AmbienceComponent>(); a != ecs::Null) {
+    if (const auto& a = scene.Entities().find<AmbienceComponent>(); a != ecs::Null) {
         const auto& ambience = a.get<AmbienceComponent>();
         shader.LoadVec3("u_ambience_colour", ambience.colour);
         shader.LoadFloat("u_ambience_brightness", ambience.brightness);

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -60,7 +60,7 @@ void UploadUniforms(
     
     // Load point lights to shader
     std::size_t i = 0;
-    auto lights = scene.Entities().View<LightComponent, Transform3DComponent>();
+    auto lights = scene.Entities().view<LightComponent, Transform3DComponent>();
     for (auto entity : lights) {
         if (i < MAX_NUM_LIGHTS) {
             auto position = entity.get<Transform3DComponent>().position;
@@ -162,7 +162,7 @@ void Scene3DRenderer::Draw(
     > commands;
 
     d_staticShader.Bind();
-    for (auto entity : scene.Entities().View<ModelComponent, Transform3DComponent>()) {
+    for (auto entity : scene.Entities().view<ModelComponent, Transform3DComponent>()) {
         const auto& tc = entity.get<Transform3DComponent>();
         const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
@@ -191,7 +191,7 @@ void Scene3DRenderer::Draw(
     }
 
     d_animatedShader.Bind();
-    for (auto entity : scene.Entities().View<ModelComponent>()) {
+    for (auto entity : scene.Entities().view<ModelComponent>()) {
         const auto& tc = entity.get<Transform3DComponent>();
         const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -53,8 +53,8 @@ void ShadowMap::Draw(
 
     std::unordered_map<std::string, std::vector<InstanceData>> commands;
     for (auto entity : scene.Entities().View<ModelComponent>()) {
-        const auto& tc = entity.Get<Transform3DComponent>();
-        const auto& mc = entity.Get<ModelComponent>();
+        const auto& tc = entity.get<Transform3DComponent>();
+        const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }
         commands[mc.mesh].push_back({ tc.position, tc.orientation, tc.scale });
     }

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -52,7 +52,7 @@ void ShadowMap::Draw(
     glCullFace(GL_FRONT);
 
     std::unordered_map<std::string, std::vector<InstanceData>> commands;
-    for (auto entity : scene.Entities().View<ModelComponent>()) {
+    for (auto entity : scene.Entities().view<ModelComponent>()) {
         const auto& tc = entity.get<Transform3DComponent>();
         const auto& mc = entity.get<ModelComponent>();
         if (mc.mesh.empty()) { continue; }

--- a/Sprocket/Scene/Camera.cpp
+++ b/Sprocket/Scene/Camera.cpp
@@ -7,15 +7,15 @@ namespace Sprocket {
 
 glm::mat4 MakeView(const ecs::Entity& entity)
 {
-    if (!entity.Has<Transform3DComponent>()) {
+    if (!entity.has<Transform3DComponent>()) {
         log::error("Camera has no transform component!");
         return glm::mat4{1.0};
     }
 
-    auto tr = entity.Get<Transform3DComponent>();
+    auto tr = entity.get<Transform3DComponent>();
 
-    if (entity.Has<Camera3DComponent>()) {
-        const auto& c = entity.Get<Camera3DComponent>();
+    if (entity.has<Camera3DComponent>()) {
+        const auto& c = entity.get<Camera3DComponent>();
         tr.orientation *= glm::rotate(glm::identity<glm::quat>(), c.pitch, {1, 0, 0});
     }
 
@@ -26,8 +26,8 @@ glm::mat4 MakeProj(const ecs::Entity& entity)
 {
     float fov = glm::radians(70.0f);
 
-    if (entity.Has<Camera3DComponent>()) {
-        fov = glm::radians(entity.Get<Camera3DComponent>().fov);
+    if (entity.has<Camera3DComponent>()) {
+        fov = glm::radians(entity.get<Camera3DComponent>().fov);
     }
 
     return glm::perspective(fov, Viewport::CurrentAspectRatio(), 0.01f, 1000.0f);

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -152,7 +152,7 @@ void Registry::reset()
     d_pool.clear();
 }
 
-std::size_t Registry::Size() const
+std::size_t Registry::size() const
 {
     return d_entities.Size();
 }
@@ -167,7 +167,7 @@ void Registry::emit(ev::Event& event)
     d_callback(event);
 }
 
-cppcoro::generator<Entity> Registry::Each()
+cppcoro::generator<Entity> Registry::all()
 {
     for (const auto& [index, guid] : d_entities.Fast()) {
         co_yield {this, index, guid};

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -57,7 +57,7 @@ void Entity::destroy()
     if (valid()) {
         // Clean up all components
         for (auto& [type, data] : d_registry->d_comps) {
-            if (Has(type)) { Remove(type); }
+            if (has(type)) { remove(type); }
         }
         d_registry->d_entities.Erase(d_index);
         d_registry->d_pool.push_back(d_index);
@@ -65,15 +65,15 @@ void Entity::destroy()
     }
 }
 
-guid::GUID Entity::Id() const
+guid::GUID Entity::id() const
 {
     return d_guid;
 }
 
-void Entity::Remove(std::size_t type) const
+void Entity::remove(std::size_t type) const
 {
     assert(valid());
-    if (!Has(type)) { return; }
+    if (!has(type)) { return; }
 
     auto& data = d_registry->d_comps[type];
     
@@ -87,7 +87,7 @@ void Entity::Remove(std::size_t type) const
     }
 }
 
-bool Entity::Has(std::size_t type) const
+bool Entity::has(std::size_t type) const
 {
     if (auto it = d_registry->d_comps.find(type); it != d_registry->d_comps.end()) {
         if (it->second.instances.Has(d_index)) {

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -98,13 +98,13 @@ bool Entity::has(std::size_t type) const
     return false;
 }
 
-Entity Registry::New()
+Entity Registry::create()
 {
     guid::GUID guid = d_generator.New();
-    return New(guid);
+    return create(guid);
 }
 
-Entity Registry::New(const guid::GUID& guid)
+Entity Registry::create(const guid::GUID& guid)
 {
     assert(guid != guid::Zero);
 
@@ -121,7 +121,7 @@ Entity Registry::New(const guid::GUID& guid)
     return {this, index, guid};
 }
 
-Entity Registry::Get(const guid::GUID& guid)
+Entity Registry::get(const guid::GUID& guid)
 {
     auto it = d_lookup.find(guid);
     if (it != d_lookup.end()) {

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -52,7 +52,7 @@ bool Entity::valid() const
          && d_registry->d_entities[d_index] == d_guid;
 }
 
-void Entity::Delete() 
+void Entity::destroy() 
 {
     if (valid()) {
         // Clean up all components
@@ -134,7 +134,7 @@ void Registry::DeleteAll()
 {
     // Clean up components, triggering on remove behaviour
     for (const auto& [index, guid] : d_entities.Safe()) {
-        Entity{this, index, guid}.Delete();
+        Entity{this, index, guid}.destroy();
     }
 
     // Reset all entity storage

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -44,7 +44,7 @@ Entity& Entity::operator=(Entity other)
     return *this;
 }
 
-bool Entity::Valid() const
+bool Entity::valid() const
 {
      return *this != ecs::Null
          && d_registry
@@ -54,7 +54,7 @@ bool Entity::Valid() const
 
 void Entity::Delete() 
 {
-    if (Valid()) {
+    if (valid()) {
         // Clean up all components
         for (auto& [type, data] : d_registry->d_comps) {
             if (Has(type)) { Remove(type); }
@@ -72,7 +72,7 @@ guid::GUID Entity::Id() const
 
 void Entity::Remove(std::size_t type) const
 {
-    assert(Valid());
+    assert(valid());
     if (!Has(type)) { return; }
 
     auto& data = d_registry->d_comps[type];

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -130,7 +130,7 @@ Entity Registry::get(const guid::GUID& guid)
     return ecs::Null;
 }
 
-void Registry::DeleteAll()
+void Registry::clear()
 {
     // Clean up components, triggering on remove behaviour
     for (const auto& [index, guid] : d_entities.Safe()) {
@@ -142,7 +142,7 @@ void Registry::DeleteAll()
     d_pool.clear();
 }
 
-void Registry::Clear()
+void Registry::reset()
 {
     // Reset all components and remove all callbacks
     d_comps.clear();

--- a/Sprocket/Scene/ECS.cpp
+++ b/Sprocket/Scene/ECS.cpp
@@ -70,7 +70,7 @@ guid::GUID Entity::id() const
     return d_guid;
 }
 
-void Entity::remove(std::size_t type) const
+void Entity::remove(spkt::type_info_t type) const
 {
     assert(valid());
     if (!has(type)) { return; }
@@ -87,7 +87,7 @@ void Entity::remove(std::size_t type) const
     }
 }
 
-bool Entity::has(std::size_t type) const
+bool Entity::has(spkt::type_info_t type) const
 {
     if (auto it = d_registry->d_comps.find(type); it != d_registry->d_comps.end()) {
         if (it->second.instances.Has(d_index)) {

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -51,17 +51,17 @@ public:
 };
 
 template <typename Comp>
-struct ComponentAddedEvent
+struct Added
 {
     ecs::Entity entity;
-    ComponentAddedEvent(ecs::Entity& e) : entity(e) {}
+    Added(ecs::Entity& e) : entity(e) {}
 };
 
 template <typename Comp>
-struct ComponentRemovedEvent
+struct Removed
 {
     ecs::Entity entity;
-    ComponentRemovedEvent(ecs::Entity& e) : entity(e) {}
+    Removed(ecs::Entity& e) : entity(e) {}
 };
 
 class Registry
@@ -206,7 +206,7 @@ Comp& Entity::add(Args&&... args)
     // the type of the component is not available at deletion time.
     if (!data.make_remove_event) {
         data.make_remove_event = [](ecs::Entity entity) -> ev::Event {
-            return ev::make_event<ecs::ComponentRemovedEvent<Comp>>(entity);
+            return ev::make_event<ecs::Removed<Comp>>(entity);
         };
     }
 
@@ -214,7 +214,7 @@ Comp& Entity::add(Args&&... args)
         d_index, std::make_any<Comp&>(std::forward<Args>(args)...)
     );
 
-    ev::Event event = ev::make_event<ComponentAddedEvent<Comp>>(*this);
+    ev::Event event = ev::make_event<Added<Comp>>(*this);
     d_registry->d_callback(event);
 
     return std::any_cast<Comp&>(entry);

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -102,20 +102,19 @@ private:
 
     Registry& operator=(const Registry&) = delete;
     Registry(const Registry&) = delete;
-    Registry(Registry&&) = delete;
 
 public:
     Registry() = default;
 
     // Creates a new entity with no components. This is guaranteed to be a valid handle.
-    Entity New();
+    Entity create();
 
     // Creates a new entity with no components and with the given guid. No checks on the
     // validity of the guid are made, except for that it cannot be guid::Zero.
-    Entity New(const guid::GUID& guid);
+    Entity create(const guid::GUID& guid);
 
     // Returns the entity corresponding to the given GUID, and ecs::Null otherwise.
-    Entity Get(const guid::GUID& guid);
+    Entity get(const guid::GUID& guid);
 
     // Loops through all entities and deletes their components. This will trigger
     // the OnRemove functionality. Callbacks are not removed.

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -125,7 +125,7 @@ public:
     void reset();
 
     // Number of active entities in the registry.
-    std::size_t Size() const;
+    std::size_t size() const;
 
     // Sets the callback that will be invoked whenever a component is added or
     // removed from an entity.
@@ -136,17 +136,19 @@ public:
 
     // Generates all active entities. This is fast, however adding and removing
     // entities while iterating results is undefined.
-    cppcoro::generator<Entity> Each();
+    cppcoro::generator<Entity> all();
 
     // Does a fast iteration over all entities with the given Comp. If any extra
     // component types are specified, only entities that have all of those types
     // will be yielded. This should only be used for modifying the components, not
     // adding/removing new ones.
-    template <typename Comp, typename... Rest> cppcoro::generator<Entity> View();
+    template <typename Comp, typename... Rest>
+    cppcoro::generator<Entity> View();
 
     // Returns the first entity satisfying the given predicate, or ECS::Null if
     // none is found. Can optionally provide components to filter on.
-    template <typename... Comps> Entity Find(const EntityPredicate& pred = [](Entity){ return true; });
+    template <typename... Comps>
+    Entity Find(const EntityPredicate& pred = [](Entity){ return true; });
 
     friend class Entity;
 };
@@ -175,7 +177,7 @@ template <typename... Comps>
 Entity Registry::Find(const EntityPredicate& pred)
 {
     if constexpr (sizeof...(Comps) == 0) {
-        for (auto entity : Each()) {
+        for (auto entity : all()) {
             if (pred(entity)) {
                 return entity;
             }

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -26,8 +26,8 @@ class Entity
     std::size_t d_index;
     guid::GUID  d_guid;
 
-    bool Has(std::size_t type) const;
-    void Remove(std::size_t type) const;
+    bool has(std::size_t type) const;
+    void remove(std::size_t type) const;
 
 public:
     // Construction of entities should not be done directly, instead they should
@@ -38,12 +38,12 @@ public:
     bool valid() const;
     void destroy();
 
-    template <typename Comp, typename... Args> Comp& Add(Args&&... args);
-    template <typename Comp> void Remove() const;
-    template <typename Comp> Comp& Get() const;
-    template <typename Comp> bool Has() const;
+    template <typename Comp, typename... Args> Comp& add(Args&&... args);
+    template <typename Comp> void remove() const;
+    template <typename Comp> Comp& get() const;
+    template <typename Comp> bool has() const;
 
-    guid::GUID Id() const;
+    guid::GUID id() const;
 
     bool operator==(Entity other) const;
     bool operator!=(Entity other) const;
@@ -166,7 +166,7 @@ cppcoro::generator<Entity> Registry::View()
 {
     for (auto& [index, comp] : d_comps[spkt::type_hash<Comp>].instances.Fast()) {
         Entity entity{this, index, d_entities[index]};
-        if ((entity.Has<Rest>() && ...)) {
+        if ((entity.has<Rest>() && ...)) {
             co_yield entity;
         }
     }
@@ -195,7 +195,7 @@ Entity Registry::Find(const EntityPredicate& pred)
 // ENTITY TEMPLATES
 
 template <typename Comp, typename... Args>
-Comp& Entity::Add(Args&&... args)
+Comp& Entity::add(Args&&... args)
 {
     assert(valid());
 
@@ -221,14 +221,14 @@ Comp& Entity::Add(Args&&... args)
 }
 
 template <typename Comp>
-void Entity::Remove() const
+void Entity::remove() const
 {
     assert(valid());
-    Remove(spkt::type_hash<Comp>);
+    remove(spkt::type_hash<Comp>);
 }
 
 template <typename Comp>
-Comp& Entity::Get() const
+Comp& Entity::get() const
 {
     assert(valid());
     auto& entry = d_registry->d_comps.at(spkt::type_hash<Comp>).instances[d_index];
@@ -236,10 +236,10 @@ Comp& Entity::Get() const
 }
 
 template <typename Comp>
-bool Entity::Has() const
+bool Entity::has() const
 {
     assert(valid());
-    return Has(spkt::type_hash<Comp>);
+    return has(spkt::type_hash<Comp>);
 }
 
 // We can push an entity into the Lua stack by calling the Lua equivalent of malloc
@@ -263,7 +263,7 @@ template <> struct hash<Sprocket::ecs::Entity>
 {
     std::size_t operator()(const Sprocket::ecs::Entity& entity) const noexcept
     {
-        return std::hash<Sprocket::guid::GUID>{}(entity.Id());
+        return std::hash<Sprocket::guid::GUID>{}(entity.id());
     };
 };
 

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -36,7 +36,7 @@ public:
     Entity();
 
     bool valid() const;
-    void Delete();
+    void destroy();
 
     template <typename Comp, typename... Args> Comp& Add(Args&&... args);
     template <typename Comp> void Remove() const;

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -71,8 +71,7 @@ public:
     using EntityPredicate = std::function<bool(Entity)>;
 
 private:
-    // Callback that is invoked whenever a component is added or removed
-    // from an entity.
+    // Callback that is invoked whenever a component is added or removed from an entity.
     std::function<void(ev::Event&)> d_callback = [](ev::Event&) {};
 
     // Generates GUIDs for new Entities 
@@ -148,7 +147,7 @@ public:
     // Returns the first entity satisfying the given predicate, or ECS::Null if
     // none is found. Can optionally provide components to filter on.
     template <typename... Comps>
-    Entity Find(const EntityPredicate& pred = [](Entity){ return true; });
+    Entity find(const EntityPredicate& pred = [](Entity){ return true; });
 
     friend class Entity;
 };
@@ -174,7 +173,7 @@ cppcoro::generator<Entity> Registry::view()
 }
 
 template <typename... Comps>
-Entity Registry::Find(const EntityPredicate& pred)
+Entity Registry::find(const EntityPredicate& pred)
 {
     if constexpr (sizeof...(Comps) == 0) {
         for (auto entity : all()) {

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -118,11 +118,11 @@ public:
 
     // Loops through all entities and deletes their components. This will trigger
     // the OnRemove functionality. Callbacks are not removed.
-    void DeleteAll();
+    void clear();
 
     // Resets all internal storage, removing all entities (without calling OnRemove)
     // and removes all OnAdd/OnRemove callbacks.
-    void Clear();
+    void reset();
 
     // Number of active entities in the registry.
     std::size_t Size() const;

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -143,7 +143,7 @@ public:
     // will be yielded. This should only be used for modifying the components, not
     // adding/removing new ones.
     template <typename Comp, typename... Rest>
-    cppcoro::generator<Entity> View();
+    cppcoro::generator<Entity> view();
 
     // Returns the first entity satisfying the given predicate, or ECS::Null if
     // none is found. Can optionally provide components to filter on.
@@ -163,7 +163,7 @@ static const Entity Null{};
 // REGISTRY TEMPLATES
 
 template <typename Comp, typename... Rest>
-cppcoro::generator<Entity> Registry::View()
+cppcoro::generator<Entity> Registry::view()
 {
     for (auto& [index, comp] : d_comps[spkt::type_hash<Comp>].instances.Fast()) {
         Entity entity{this, index, d_entities[index]};
@@ -184,7 +184,7 @@ Entity Registry::Find(const EntityPredicate& pred)
         }
     }
     else {
-        for (auto entity : View<Comps...>()) {
+        for (auto entity : view<Comps...>()) {
             if (pred(entity)) {
                 return entity;
             }

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -35,7 +35,7 @@ public:
     Entity(Registry* r, std::size_t i, guid::GUID g);
     Entity();
 
-    bool Valid() const;
+    bool valid() const;
     void Delete();
 
     template <typename Comp, typename... Args> Comp& Add(Args&&... args);
@@ -197,7 +197,7 @@ Entity Registry::Find(const EntityPredicate& pred)
 template <typename Comp, typename... Args>
 Comp& Entity::Add(Args&&... args)
 {
-    assert(Valid());
+    assert(valid());
 
     auto& data = d_registry->d_comps[spkt::type_hash<Comp>];
 
@@ -223,14 +223,14 @@ Comp& Entity::Add(Args&&... args)
 template <typename Comp>
 void Entity::Remove() const
 {
-    assert(Valid());
+    assert(valid());
     Remove(spkt::type_hash<Comp>);
 }
 
 template <typename Comp>
 Comp& Entity::Get() const
 {
-    assert(Valid());
+    assert(valid());
     auto& entry = d_registry->d_comps.at(spkt::type_hash<Comp>).instances[d_index];
     return std::any_cast<Comp&>(entry);
 }
@@ -238,7 +238,7 @@ Comp& Entity::Get() const
 template <typename Comp>
 bool Entity::Has() const
 {
-    assert(Valid());
+    assert(valid());
     return Has(spkt::type_hash<Comp>);
 }
 

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -145,9 +145,6 @@ public:
     template <typename Comp, typename... Rest>
     cppcoro::generator<Entity> view();
 
-    template <typename Comp>
-    cppcoro::generator<std::tuple<Entity, Comp&>> view_get();
-
     // Returns the first entity satisfying the given predicate, or ECS::Null if
     // none is found. Can optionally provide components to filter on.
     template <typename... Comps>
@@ -173,15 +170,6 @@ cppcoro::generator<Entity> Registry::view()
         if ((entity.has<Rest>() && ...)) {
             co_yield entity;
         }
-    }
-}
-
-template <typename Comp>
-cppcoro::generator<std::tuple<Entity, Comp&>> Registry::view_get()
-{
-    for (auto& [index, comp] : d_comps[spkt::type_info<Comp>].instances.Fast()) {
-        Entity entity{this, index, d_entities[index]};
-        co_yield std::make_tuple(entity, std::ref(comp));
     }
 }
 

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -23,13 +23,8 @@ public:
         // Called with every event so systems can consume them.
 
 private:
-    // EntitySystems can not be copied.
     EntitySystem(const EntitySystem&) = delete;
     EntitySystem& operator=(const EntitySystem&) = delete;
-
-    // EntitySystems can not be moved.
-    EntitySystem(EntitySystem&&) = delete;
-    EntitySystem& operator=(EntitySystem&&) = delete;
 };
 
 }

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -3,7 +3,7 @@
 namespace Sprocket {
 
 class Scene;
-namespace ev { class Event; }
+namespace ev { class Event; class Dispatcher; }
 namespace ecs { class Registry; }
 
 class EntitySystem
@@ -12,15 +12,12 @@ public:
     EntitySystem() = default;
     virtual ~EntitySystem() {};
 
-    virtual void on_startup(ecs::Registry& registry) {};
+    virtual void on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher) {};
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
     
-    virtual void on_update(ecs::Registry& registry, double dt) {};
+    virtual void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) {};
         // Called every tick of the game loop.
-
-    virtual void on_event(ecs::Registry& registry, ev::Event& event) {};
-        // Called with every event so systems can consume them.
 
 private:
     EntitySystem(const EntitySystem&) = delete;

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -12,14 +12,14 @@ public:
     EntitySystem() = default;
     virtual ~EntitySystem() {};
 
-    virtual void OnStartup(ecs::Registry& registry) {};
+    virtual void on_startup(ecs::Registry& registry) {};
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
     
-    virtual void OnUpdate(ecs::Registry& registry, double dt) {};
+    virtual void on_update(ecs::Registry& registry, double dt) {};
         // Called every tick of the game loop.
 
-    virtual void OnEvent(ecs::Registry& registry, ev::Event& event) {};
+    virtual void on_event(ecs::Registry& registry, ev::Event& event) {};
         // Called with every event so systems can consume them.
 
 private:

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -200,7 +200,7 @@ void Load(const std::string& file, ecs::Registry* reg)
 
     auto entities = data["Entities"];
     for (auto entity : entities) {
-        ecs::Entity e = reg->New(entity["@GUID"].as<guid::GUID>());
+        ecs::Entity e = reg->create(entity["@GUID"].as<guid::GUID>());
         if (auto spec = entity["TemporaryComponent"]) {
             TemporaryComponent c;
             e.add<TemporaryComponent>(c);
@@ -335,7 +335,7 @@ void Load(const std::string& file, ecs::Registry* reg)
 
 ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 {
-    ecs::Entity e = reg->New();
+    ecs::Entity e = reg->create();
     if (entity.has<TemporaryComponent>()) {
         e.add<TemporaryComponent>(entity.get<TemporaryComponent>());
     }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -19,45 +19,45 @@ void Save(const std::string& file, ecs::Registry* reg)
     out << YAML::BeginMap;
     out << YAML::Key << "Entities" << YAML::BeginSeq;
     for (auto entity : reg->Each()) {
-        if (entity.Has<TemporaryComponent>()) { return; }
+        if (entity.has<TemporaryComponent>()) { return; }
         out << YAML::BeginMap;
-        out << YAML::Key << "@GUID" << YAML::Value << entity.Id();
-        if (entity.Has<TemporaryComponent>()) {
-            const auto& c = entity.Get<TemporaryComponent>();
+        out << YAML::Key << "@GUID" << YAML::Value << entity.id();
+        if (entity.has<TemporaryComponent>()) {
+            const auto& c = entity.get<TemporaryComponent>();
             out << YAML::Key << "TemporaryComponent" << YAML::BeginMap;
             out << YAML::EndMap;
         }
-        if (entity.Has<NameComponent>()) {
-            const auto& c = entity.Get<NameComponent>();
+        if (entity.has<NameComponent>()) {
+            const auto& c = entity.get<NameComponent>();
             out << YAML::Key << "NameComponent" << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::EndMap;
         }
-        if (entity.Has<Transform2DComponent>()) {
-            const auto& c = entity.Get<Transform2DComponent>();
+        if (entity.has<Transform2DComponent>()) {
+            const auto& c = entity.get<Transform2DComponent>();
             out << YAML::Key << "Transform2DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "rotation" << YAML::Value << c.rotation;
             out << YAML::Key << "scale" << YAML::Value << c.scale;
             out << YAML::EndMap;
         }
-        if (entity.Has<Transform3DComponent>()) {
-            const auto& c = entity.Get<Transform3DComponent>();
+        if (entity.has<Transform3DComponent>()) {
+            const auto& c = entity.get<Transform3DComponent>();
             out << YAML::Key << "Transform3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
             out << YAML::Key << "scale" << YAML::Value << c.scale;
             out << YAML::EndMap;
         }
-        if (entity.Has<ModelComponent>()) {
-            const auto& c = entity.Get<ModelComponent>();
+        if (entity.has<ModelComponent>()) {
+            const auto& c = entity.get<ModelComponent>();
             out << YAML::Key << "ModelComponent" << YAML::BeginMap;
             out << YAML::Key << "mesh" << YAML::Value << c.mesh;
             out << YAML::Key << "material" << YAML::Value << c.material;
             out << YAML::EndMap;
         }
-        if (entity.Has<RigidBody3DComponent>()) {
-            const auto& c = entity.Get<RigidBody3DComponent>();
+        if (entity.has<RigidBody3DComponent>()) {
+            const auto& c = entity.get<RigidBody3DComponent>();
             out << YAML::Key << "RigidBody3DComponent" << YAML::BeginMap;
             out << YAML::Key << "velocity" << YAML::Value << c.velocity;
             out << YAML::Key << "gravity" << YAML::Value << c.gravity;
@@ -67,8 +67,8 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "rollingResistance" << YAML::Value << c.rollingResistance;
             out << YAML::EndMap;
         }
-        if (entity.Has<BoxCollider3DComponent>()) {
-            const auto& c = entity.Get<BoxCollider3DComponent>();
+        if (entity.has<BoxCollider3DComponent>()) {
+            const auto& c = entity.get<BoxCollider3DComponent>();
             out << YAML::Key << "BoxCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -77,8 +77,8 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "applyScale" << YAML::Value << c.applyScale;
             out << YAML::EndMap;
         }
-        if (entity.Has<SphereCollider3DComponent>()) {
-            const auto& c = entity.Get<SphereCollider3DComponent>();
+        if (entity.has<SphereCollider3DComponent>()) {
+            const auto& c = entity.get<SphereCollider3DComponent>();
             out << YAML::Key << "SphereCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -86,8 +86,8 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "radius" << YAML::Value << c.radius;
             out << YAML::EndMap;
         }
-        if (entity.Has<CapsuleCollider3DComponent>()) {
-            const auto& c = entity.Get<CapsuleCollider3DComponent>();
+        if (entity.has<CapsuleCollider3DComponent>()) {
+            const auto& c = entity.get<CapsuleCollider3DComponent>();
             out << YAML::Key << "CapsuleCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -96,47 +96,47 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "height" << YAML::Value << c.height;
             out << YAML::EndMap;
         }
-        if (entity.Has<ScriptComponent>()) {
-            const auto& c = entity.Get<ScriptComponent>();
+        if (entity.has<ScriptComponent>()) {
+            const auto& c = entity.get<ScriptComponent>();
             out << YAML::Key << "ScriptComponent" << YAML::BeginMap;
             out << YAML::Key << "script" << YAML::Value << c.script;
             out << YAML::Key << "active" << YAML::Value << c.active;
             out << YAML::EndMap;
         }
-        if (entity.Has<Camera3DComponent>()) {
-            const auto& c = entity.Get<Camera3DComponent>();
+        if (entity.has<Camera3DComponent>()) {
+            const auto& c = entity.get<Camera3DComponent>();
             out << YAML::Key << "Camera3DComponent" << YAML::BeginMap;
             out << YAML::Key << "fov" << YAML::Value << c.fov;
             out << YAML::Key << "pitch" << YAML::Value << c.pitch;
             out << YAML::EndMap;
         }
-        if (entity.Has<SelectComponent>()) {
-            const auto& c = entity.Get<SelectComponent>();
+        if (entity.has<SelectComponent>()) {
+            const auto& c = entity.get<SelectComponent>();
             out << YAML::Key << "SelectComponent" << YAML::BeginMap;
             out << YAML::EndMap;
         }
-        if (entity.Has<PathComponent>()) {
-            const auto& c = entity.Get<PathComponent>();
+        if (entity.has<PathComponent>()) {
+            const auto& c = entity.get<PathComponent>();
             out << YAML::Key << "PathComponent" << YAML::BeginMap;
             out << YAML::Key << "speed" << YAML::Value << c.speed;
             out << YAML::EndMap;
         }
-        if (entity.Has<GridComponent>()) {
-            const auto& c = entity.Get<GridComponent>();
+        if (entity.has<GridComponent>()) {
+            const auto& c = entity.get<GridComponent>();
             out << YAML::Key << "GridComponent" << YAML::BeginMap;
             out << YAML::Key << "x" << YAML::Value << c.x;
             out << YAML::Key << "z" << YAML::Value << c.z;
             out << YAML::EndMap;
         }
-        if (entity.Has<LightComponent>()) {
-            const auto& c = entity.Get<LightComponent>();
+        if (entity.has<LightComponent>()) {
+            const auto& c = entity.get<LightComponent>();
             out << YAML::Key << "LightComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
             out << YAML::EndMap;
         }
-        if (entity.Has<SunComponent>()) {
-            const auto& c = entity.Get<SunComponent>();
+        if (entity.has<SunComponent>()) {
+            const auto& c = entity.get<SunComponent>();
             out << YAML::Key << "SunComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
@@ -144,15 +144,15 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "shadows" << YAML::Value << c.shadows;
             out << YAML::EndMap;
         }
-        if (entity.Has<AmbienceComponent>()) {
-            const auto& c = entity.Get<AmbienceComponent>();
+        if (entity.has<AmbienceComponent>()) {
+            const auto& c = entity.get<AmbienceComponent>();
             out << YAML::Key << "AmbienceComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
             out << YAML::EndMap;
         }
-        if (entity.Has<ParticleComponent>()) {
-            const auto& c = entity.Get<ParticleComponent>();
+        if (entity.has<ParticleComponent>()) {
+            const auto& c = entity.get<ParticleComponent>();
             out << YAML::Key << "ParticleComponent" << YAML::BeginMap;
             out << YAML::Key << "interval" << YAML::Value << c.interval;
             out << YAML::Key << "velocity" << YAML::Value << c.velocity;
@@ -162,8 +162,8 @@ void Save(const std::string& file, ecs::Registry* reg)
             out << YAML::Key << "life" << YAML::Value << c.life;
             out << YAML::EndMap;
         }
-        if (entity.Has<MeshAnimationComponent>()) {
-            const auto& c = entity.Get<MeshAnimationComponent>();
+        if (entity.has<MeshAnimationComponent>()) {
+            const auto& c = entity.get<MeshAnimationComponent>();
             out << YAML::Key << "MeshAnimationComponent" << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::Key << "time" << YAML::Value << c.time;
@@ -184,7 +184,7 @@ void Load(const std::string& file, ecs::Registry* reg)
     // Must be a clean scene
     u32 count = 0;
     for (ecs::Entity e : reg->Each()) {
-        if (!e.Has<TemporaryComponent>()) ++count;
+        if (!e.has<TemporaryComponent>()) ++count;
     }
     assert(count == 0);
 
@@ -203,32 +203,32 @@ void Load(const std::string& file, ecs::Registry* reg)
         ecs::Entity e = reg->New(entity["@GUID"].as<guid::GUID>());
         if (auto spec = entity["TemporaryComponent"]) {
             TemporaryComponent c;
-            e.Add<TemporaryComponent>(c);
+            e.add<TemporaryComponent>(c);
         }
         if (auto spec = entity["NameComponent"]) {
             NameComponent c;
             c.name = spec["name"] ? spec["name"].as<std::string>() : "Entity";
-            e.Add<NameComponent>(c);
+            e.add<NameComponent>(c);
         }
         if (auto spec = entity["Transform2DComponent"]) {
             Transform2DComponent c;
             c.position = spec["position"] ? spec["position"].as<glm::vec2>() : glm::vec2{0.0f, 0.0f};
             c.rotation = spec["rotation"] ? spec["rotation"].as<float>() : 0.0f;
             c.scale = spec["scale"] ? spec["scale"].as<glm::vec2>() : glm::vec2{1.0f, 1.0f};
-            e.Add<Transform2DComponent>(c);
+            e.add<Transform2DComponent>(c);
         }
         if (auto spec = entity["Transform3DComponent"]) {
             Transform3DComponent c;
             c.position = spec["position"] ? spec["position"].as<glm::vec3>() : glm::vec3{0.0f, 0.0f, 0.0f};
             c.orientation = spec["orientation"] ? spec["orientation"].as<glm::quat>() : glm::quat{1.0f, 0.0f, 0.0f, 0.0f};
             c.scale = spec["scale"] ? spec["scale"].as<glm::vec3>() : glm::vec3{1.0f, 1.0f, 1.0f};
-            e.Add<Transform3DComponent>(c);
+            e.add<Transform3DComponent>(c);
         }
         if (auto spec = entity["ModelComponent"]) {
             ModelComponent c;
             c.mesh = spec["mesh"] ? spec["mesh"].as<std::string>() : "";
             c.material = spec["material"] ? spec["material"].as<std::string>() : "";
-            e.Add<ModelComponent>(c);
+            e.add<ModelComponent>(c);
         }
         if (auto spec = entity["RigidBody3DComponent"]) {
             RigidBody3DComponent c;
@@ -238,7 +238,7 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.bounciness = spec["bounciness"] ? spec["bounciness"].as<float>() : 0.5f;
             c.frictionCoefficient = spec["frictionCoefficient"] ? spec["frictionCoefficient"].as<float>() : 0.3f;
             c.rollingResistance = spec["rollingResistance"] ? spec["rollingResistance"].as<float>() : 0.0f;
-            e.Add<RigidBody3DComponent>(c);
+            e.add<RigidBody3DComponent>(c);
         }
         if (auto spec = entity["BoxCollider3DComponent"]) {
             BoxCollider3DComponent c;
@@ -247,7 +247,7 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.mass = spec["mass"] ? spec["mass"].as<float>() : 1.0f;
             c.halfExtents = spec["halfExtents"] ? spec["halfExtents"].as<glm::vec3>() : glm::vec3{0.0f, 0.0f, 0.0f};
             c.applyScale = spec["applyScale"] ? spec["applyScale"].as<bool>() : true;
-            e.Add<BoxCollider3DComponent>(c);
+            e.add<BoxCollider3DComponent>(c);
         }
         if (auto spec = entity["SphereCollider3DComponent"]) {
             SphereCollider3DComponent c;
@@ -255,7 +255,7 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.orientation = spec["orientation"] ? spec["orientation"].as<glm::quat>() : glm::quat{1.0f, 0.0f, 0.0f, 0.0f};
             c.mass = spec["mass"] ? spec["mass"].as<float>() : 1.0f;
             c.radius = spec["radius"] ? spec["radius"].as<float>() : 1.0f;
-            e.Add<SphereCollider3DComponent>(c);
+            e.add<SphereCollider3DComponent>(c);
         }
         if (auto spec = entity["CapsuleCollider3DComponent"]) {
             CapsuleCollider3DComponent c;
@@ -264,40 +264,40 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.mass = spec["mass"] ? spec["mass"].as<float>() : 1.0f;
             c.radius = spec["radius"] ? spec["radius"].as<float>() : 1.0f;
             c.height = spec["height"] ? spec["height"].as<float>() : 1.0f;
-            e.Add<CapsuleCollider3DComponent>(c);
+            e.add<CapsuleCollider3DComponent>(c);
         }
         if (auto spec = entity["ScriptComponent"]) {
             ScriptComponent c;
             c.script = spec["script"] ? spec["script"].as<std::string>() : "";
             c.active = spec["active"] ? spec["active"].as<bool>() : true;
-            e.Add<ScriptComponent>(c);
+            e.add<ScriptComponent>(c);
         }
         if (auto spec = entity["Camera3DComponent"]) {
             Camera3DComponent c;
             c.fov = spec["fov"] ? spec["fov"].as<float>() : 70.0f;
             c.pitch = spec["pitch"] ? spec["pitch"].as<float>() : 0.0f;
-            e.Add<Camera3DComponent>(c);
+            e.add<Camera3DComponent>(c);
         }
         if (auto spec = entity["SelectComponent"]) {
             SelectComponent c;
-            e.Add<SelectComponent>(c);
+            e.add<SelectComponent>(c);
         }
         if (auto spec = entity["PathComponent"]) {
             PathComponent c;
             c.speed = spec["speed"] ? spec["speed"].as<float>() : 0.0f;
-            e.Add<PathComponent>(c);
+            e.add<PathComponent>(c);
         }
         if (auto spec = entity["GridComponent"]) {
             GridComponent c;
             c.x = spec["x"] ? spec["x"].as<int>() : 0;
             c.z = spec["z"] ? spec["z"].as<int>() : 0;
-            e.Add<GridComponent>(c);
+            e.add<GridComponent>(c);
         }
         if (auto spec = entity["LightComponent"]) {
             LightComponent c;
             c.colour = spec["colour"] ? spec["colour"].as<glm::vec3>() : glm::vec3{1.0f, 1.0f, 1.0f};
             c.brightness = spec["brightness"] ? spec["brightness"].as<float>() : 1.0f;
-            e.Add<LightComponent>(c);
+            e.add<LightComponent>(c);
         }
         if (auto spec = entity["SunComponent"]) {
             SunComponent c;
@@ -305,13 +305,13 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.brightness = spec["brightness"] ? spec["brightness"].as<float>() : 1.0f;
             c.direction = spec["direction"] ? spec["direction"].as<glm::vec3>() : glm::vec3{0.0f, -1.0f, 0.0f};
             c.shadows = spec["shadows"] ? spec["shadows"].as<bool>() : false;
-            e.Add<SunComponent>(c);
+            e.add<SunComponent>(c);
         }
         if (auto spec = entity["AmbienceComponent"]) {
             AmbienceComponent c;
             c.colour = spec["colour"] ? spec["colour"].as<glm::vec3>() : glm::vec3{1.0f, 1.0f, 1.0f};
             c.brightness = spec["brightness"] ? spec["brightness"].as<float>() : 1.0f;
-            e.Add<AmbienceComponent>(c);
+            e.add<AmbienceComponent>(c);
         }
         if (auto spec = entity["ParticleComponent"]) {
             ParticleComponent c;
@@ -321,14 +321,14 @@ void Load(const std::string& file, ecs::Registry* reg)
             c.acceleration = spec["acceleration"] ? spec["acceleration"].as<glm::vec3>() : glm::vec3{0.0f, -9.81f, 0.0f};
             c.scale = spec["scale"] ? spec["scale"].as<glm::vec3>() : glm::vec3{1.0f, 1.0f, 1.0f};
             c.life = spec["life"] ? spec["life"].as<float>() : 1.0f;
-            e.Add<ParticleComponent>(c);
+            e.add<ParticleComponent>(c);
         }
         if (auto spec = entity["MeshAnimationComponent"]) {
             MeshAnimationComponent c;
             c.name = spec["name"] ? spec["name"].as<std::string>() : "";
             c.time = spec["time"] ? spec["time"].as<float>() : 0.0f;
             c.speed = spec["speed"] ? spec["speed"].as<float>() : 1.0f;
-            e.Add<MeshAnimationComponent>(c);
+            e.add<MeshAnimationComponent>(c);
         }
     }
 }
@@ -336,62 +336,62 @@ void Load(const std::string& file, ecs::Registry* reg)
 ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 {
     ecs::Entity e = reg->New();
-    if (entity.Has<TemporaryComponent>()) {
-        e.Add<TemporaryComponent>(entity.Get<TemporaryComponent>());
+    if (entity.has<TemporaryComponent>()) {
+        e.add<TemporaryComponent>(entity.get<TemporaryComponent>());
     }
-    if (entity.Has<NameComponent>()) {
-        e.Add<NameComponent>(entity.Get<NameComponent>());
+    if (entity.has<NameComponent>()) {
+        e.add<NameComponent>(entity.get<NameComponent>());
     }
-    if (entity.Has<Transform2DComponent>()) {
-        e.Add<Transform2DComponent>(entity.Get<Transform2DComponent>());
+    if (entity.has<Transform2DComponent>()) {
+        e.add<Transform2DComponent>(entity.get<Transform2DComponent>());
     }
-    if (entity.Has<Transform3DComponent>()) {
-        e.Add<Transform3DComponent>(entity.Get<Transform3DComponent>());
+    if (entity.has<Transform3DComponent>()) {
+        e.add<Transform3DComponent>(entity.get<Transform3DComponent>());
     }
-    if (entity.Has<ModelComponent>()) {
-        e.Add<ModelComponent>(entity.Get<ModelComponent>());
+    if (entity.has<ModelComponent>()) {
+        e.add<ModelComponent>(entity.get<ModelComponent>());
     }
-    if (entity.Has<RigidBody3DComponent>()) {
-        e.Add<RigidBody3DComponent>(entity.Get<RigidBody3DComponent>());
+    if (entity.has<RigidBody3DComponent>()) {
+        e.add<RigidBody3DComponent>(entity.get<RigidBody3DComponent>());
     }
-    if (entity.Has<BoxCollider3DComponent>()) {
-        e.Add<BoxCollider3DComponent>(entity.Get<BoxCollider3DComponent>());
+    if (entity.has<BoxCollider3DComponent>()) {
+        e.add<BoxCollider3DComponent>(entity.get<BoxCollider3DComponent>());
     }
-    if (entity.Has<SphereCollider3DComponent>()) {
-        e.Add<SphereCollider3DComponent>(entity.Get<SphereCollider3DComponent>());
+    if (entity.has<SphereCollider3DComponent>()) {
+        e.add<SphereCollider3DComponent>(entity.get<SphereCollider3DComponent>());
     }
-    if (entity.Has<CapsuleCollider3DComponent>()) {
-        e.Add<CapsuleCollider3DComponent>(entity.Get<CapsuleCollider3DComponent>());
+    if (entity.has<CapsuleCollider3DComponent>()) {
+        e.add<CapsuleCollider3DComponent>(entity.get<CapsuleCollider3DComponent>());
     }
-    if (entity.Has<ScriptComponent>()) {
-        e.Add<ScriptComponent>(entity.Get<ScriptComponent>());
+    if (entity.has<ScriptComponent>()) {
+        e.add<ScriptComponent>(entity.get<ScriptComponent>());
     }
-    if (entity.Has<Camera3DComponent>()) {
-        e.Add<Camera3DComponent>(entity.Get<Camera3DComponent>());
+    if (entity.has<Camera3DComponent>()) {
+        e.add<Camera3DComponent>(entity.get<Camera3DComponent>());
     }
-    if (entity.Has<SelectComponent>()) {
-        e.Add<SelectComponent>(entity.Get<SelectComponent>());
+    if (entity.has<SelectComponent>()) {
+        e.add<SelectComponent>(entity.get<SelectComponent>());
     }
-    if (entity.Has<PathComponent>()) {
-        e.Add<PathComponent>(entity.Get<PathComponent>());
+    if (entity.has<PathComponent>()) {
+        e.add<PathComponent>(entity.get<PathComponent>());
     }
-    if (entity.Has<GridComponent>()) {
-        e.Add<GridComponent>(entity.Get<GridComponent>());
+    if (entity.has<GridComponent>()) {
+        e.add<GridComponent>(entity.get<GridComponent>());
     }
-    if (entity.Has<LightComponent>()) {
-        e.Add<LightComponent>(entity.Get<LightComponent>());
+    if (entity.has<LightComponent>()) {
+        e.add<LightComponent>(entity.get<LightComponent>());
     }
-    if (entity.Has<SunComponent>()) {
-        e.Add<SunComponent>(entity.Get<SunComponent>());
+    if (entity.has<SunComponent>()) {
+        e.add<SunComponent>(entity.get<SunComponent>());
     }
-    if (entity.Has<AmbienceComponent>()) {
-        e.Add<AmbienceComponent>(entity.Get<AmbienceComponent>());
+    if (entity.has<AmbienceComponent>()) {
+        e.add<AmbienceComponent>(entity.get<AmbienceComponent>());
     }
-    if (entity.Has<ParticleComponent>()) {
-        e.Add<ParticleComponent>(entity.Get<ParticleComponent>());
+    if (entity.has<ParticleComponent>()) {
+        e.add<ParticleComponent>(entity.get<ParticleComponent>());
     }
-    if (entity.Has<MeshAnimationComponent>()) {
-        e.Add<MeshAnimationComponent>(entity.Get<MeshAnimationComponent>());
+    if (entity.has<MeshAnimationComponent>()) {
+        e.add<MeshAnimationComponent>(entity.get<MeshAnimationComponent>());
     }
     return e;
 }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -18,7 +18,7 @@ void Save(const std::string& file, ecs::Registry* reg)
     YAML::Emitter out;
     out << YAML::BeginMap;
     out << YAML::Key << "Entities" << YAML::BeginSeq;
-    for (auto entity : reg->Each()) {
+    for (auto entity : reg->all()) {
         if (entity.has<TemporaryComponent>()) { return; }
         out << YAML::BeginMap;
         out << YAML::Key << "@GUID" << YAML::Value << entity.id();
@@ -183,7 +183,7 @@ void Load(const std::string& file, ecs::Registry* reg)
 {
     // Must be a clean scene
     u32 count = 0;
-    for (ecs::Entity e : reg->Each()) {
+    for (ecs::Entity e : reg->all()) {
         if (!e.has<TemporaryComponent>()) ++count;
     }
     assert(count == 0);
@@ -398,7 +398,7 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 
 void Copy(ecs::Registry* source, ecs::Registry* target)
 {
-    for (auto entity : source->Each()) {
+    for (auto entity : source->all()) {
         Copy(target, entity);
     }
 }

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -18,12 +18,12 @@ void Save(const std::string& file, ecs::Registry* reg)
     out << YAML::BeginMap;
     out << YAML::Key << "Entities" << YAML::BeginSeq;
     for (auto entity : reg->Each()) {
-        if (entity.Has<TemporaryComponent>()) { return; }
+        if (entity.has<TemporaryComponent>()) { return; }
         out << YAML::BeginMap;
-        out << YAML::Key << "@GUID" << YAML::Value << entity.Id();
+        out << YAML::Key << "@GUID" << YAML::Value << entity.id();
 #ifdef DATAMATIC_BLOCK SAVABLE=true
-        if (entity.Has<{{Comp.Name}}>()) {
-            const auto& c = entity.Get<{{Comp.Name}}>();
+        if (entity.has<{{Comp.Name}}>()) {
+            const auto& c = entity.get<{{Comp.Name}}>();
             out << YAML::Key << "{{Comp.Name}}" << YAML::BeginMap;
             out << YAML::Key << "{{Attr.Name}}" << YAML::Value << c.{{Attr.Name}};
             out << YAML::EndMap;
@@ -59,12 +59,12 @@ void Load(const std::string& file, ecs::Registry* reg)
 
     auto entities = data["Entities"];
     for (auto entity : entities) {
-        ecs::Entity e = reg->New(entity["@GUID"].as<guid::GUID>());
+        ecs::Entity e = reg->create(entity["@GUID"].as<guid::GUID>());
 #ifdef DATAMATIC_BLOCK SAVABLE=true
         if (auto spec = entity["{{Comp.Name}}"]) {
             {{Comp.Name}} c;
             c.{{Attr.Name}} = spec["{{Attr.Name}}"] ? spec["{{Attr.Name}}"].as<{{Attr.Type}}>() : {{Attr.Default}};
-            e.Add<{{Comp.Name}}>(c);
+            e.add<{{Comp.Name}}>(c);
         }
 #endif
     }
@@ -72,10 +72,10 @@ void Load(const std::string& file, ecs::Registry* reg)
 
 ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 {
-    ecs::Entity e = reg->New();
+    ecs::Entity e = reg->create();
 #ifdef DATAMATIC_BLOCK
-    if (entity.Has<{{Comp.Name}}>()) {
-        e.Add<{{Comp.Name}}>(entity.Get<{{Comp.Name}}>());
+    if (entity.has<{{Comp.Name}}>()) {
+        e.add<{{Comp.Name}}>(entity.get<{{Comp.Name}}>());
     }
 #endif
     return e;

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -43,7 +43,7 @@ void Load(const std::string& file, ecs::Registry* reg)
     // Must be a clean scene
     u32 count = 0;
     for (ecs::Entity e : reg->Each()) {
-        if (!e.Has<TemporaryComponent>()) ++count;
+        if (!e.has<TemporaryComponent>()) ++count;
     }
     assert(count == 0);
 

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -17,7 +17,7 @@ void Save(const std::string& file, ecs::Registry* reg)
     YAML::Emitter out;
     out << YAML::BeginMap;
     out << YAML::Key << "Entities" << YAML::BeginSeq;
-    for (auto entity : reg->Each()) {
+    for (auto entity : reg->all()) {
         if (entity.has<TemporaryComponent>()) { return; }
         out << YAML::BeginMap;
         out << YAML::Key << "@GUID" << YAML::Value << entity.id();
@@ -42,7 +42,7 @@ void Load(const std::string& file, ecs::Registry* reg)
 {
     // Must be a clean scene
     u32 count = 0;
-    for (ecs::Entity e : reg->Each()) {
+    for (ecs::Entity e : reg->all()) {
         if (!e.has<TemporaryComponent>()) ++count;
     }
     assert(count == 0);
@@ -83,7 +83,7 @@ ecs::Entity Copy(ecs::Registry* reg, ecs::Entity entity)
 
 void Copy(ecs::Registry* source, ecs::Registry* target)
 {
-    for (auto entity : source->Each()) {
+    for (auto entity : source->all()) {
         Copy(target, entity);
     }
 }

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -32,7 +32,7 @@ void Scene::OnEvent(ev::Event& event)
 
 std::size_t Scene::Size() const
 {
-    return d_registry.Size();
+    return d_registry.size();
 }
 
 void Scene::Clear()

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -19,14 +19,14 @@ void Scene::Load(std::string_view file)
 void Scene::OnUpdate(double dt)
 {
     for (auto& system : d_systems) {
-        system->OnUpdate(d_registry, dt);
+        system->on_update(d_registry, dt);
     }
 }
 
 void Scene::OnEvent(ev::Event& event)
 {
     for (auto& system : d_systems) {
-        system->OnEvent(d_registry, event);
+        system->on_event(d_registry, event);
     }
 }
 

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -19,15 +19,13 @@ void Scene::Load(std::string_view file)
 void Scene::OnUpdate(double dt)
 {
     for (auto& system : d_systems) {
-        system->on_update(d_registry, dt);
+        system->on_update(d_registry, d_dispatcher, dt);
     }
 }
 
 void Scene::OnEvent(ev::Event& event)
 {
-    for (auto& system : d_systems) {
-        system->on_event(d_registry, event);
-    }
+    d_dispatcher.publish(event);
 }
 
 std::size_t Scene::Size() const

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -37,7 +37,7 @@ std::size_t Scene::Size() const
 
 void Scene::Clear()
 {
-    d_registry.Clear();
+    d_registry.reset();
     d_lookup.clear();
     d_systems.clear();
 }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -2,6 +2,7 @@
 #include "ECS.h"
 #include "EntitySystem.h"
 #include "Events.h"
+#include "TypeInfo.h"
 
 #include <memory>
 #include <vector>
@@ -12,7 +13,7 @@ namespace Sprocket {
     
 class Scene
 {
-    std::unordered_map<std::size_t, std::size_t> d_lookup;
+    std::unordered_map<spkt::type_info_t, std::size_t> d_lookup;
     std::vector<std::unique_ptr<EntitySystem>> d_systems;
 
     ecs::Registry d_registry;
@@ -42,21 +43,21 @@ template <typename T, typename... Args>
 T& Scene::Add(Args&&... args)
 {
     assert(d_registry.size() == 0);
-    assert(d_lookup.find(spkt::type_hash<T>) == d_lookup.end());
-    d_lookup[spkt::type_hash<T>] = d_systems.size();
+    assert(d_lookup.find(spkt::type_info<T>) == d_lookup.end());
+    d_lookup[spkt::type_info<T>] = d_systems.size();
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
-    d_systems.back()->OnStartup(d_registry);
+    d_systems.back()->on_startup(d_registry);
     return *static_cast<T*>(d_systems.back().get());
 }
 
 template <typename T> bool Scene::Has()
 {
-    return d_lookup.find(type_hash<T>) != d_lookup.end();
+    return d_lookup.find(spkt::type_info<T>) != d_lookup.end();
 }
 
 template <typename T> T& Scene::Get()
 {
-    auto it = d_lookup.find(spkt::type_hash<T>);
+    auto it = d_lookup.find(spkt::type_info<T>);
     assert(it != d_lookup.end());
     return *static_cast<T*>(d_systems[it->second].get());
 }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -18,6 +18,8 @@ class Scene
 
     ecs::Registry d_registry;
 
+    ev::Dispatcher d_dispatcher;
+
 public:
     Scene();
 
@@ -46,7 +48,7 @@ T& Scene::Add(Args&&... args)
     assert(d_lookup.find(spkt::type_info<T>) == d_lookup.end());
     d_lookup[spkt::type_info<T>] = d_systems.size();
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
-    d_systems.back()->on_startup(d_registry);
+    d_systems.back()->on_startup(d_registry, d_dispatcher);
     return *static_cast<T*>(d_systems.back().get());
 }
 

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -41,7 +41,7 @@ public:
 template <typename T, typename... Args>
 T& Scene::Add(Args&&... args)
 {
-    assert(d_registry.Size() == 0);
+    assert(d_registry.size() == 0);
     assert(d_lookup.find(spkt::type_hash<T>) == d_lookup.end());
     d_lookup[spkt::type_hash<T>] = d_systems.size();
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -7,7 +7,7 @@ namespace Sprocket {
 
 void AnimationSystem::OnUpdate(ecs::Registry& registry, double dt)
 {
-    for (auto entity : registry.View<MeshAnimationComponent>()) {
+    for (auto entity : registry.view<MeshAnimationComponent>()) {
         auto& ac = entity.get<MeshAnimationComponent>();
         ac.time += (float)dt * ac.speed;
     }

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void AnimationSystem::OnUpdate(ecs::Registry& registry, double dt)
+void AnimationSystem::on_update(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.view<MeshAnimationComponent>()) {
         auto& ac = entity.get<MeshAnimationComponent>();

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void AnimationSystem::on_update(ecs::Registry& registry, double dt)
+void AnimationSystem::on_update(ecs::Registry& registry, const ev::Dispatcher&, double dt)
 {
     for (auto entity : registry.view<MeshAnimationComponent>()) {
         auto& ac = entity.get<MeshAnimationComponent>();

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -8,7 +8,7 @@ namespace Sprocket {
 void AnimationSystem::OnUpdate(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.View<MeshAnimationComponent>()) {
-        auto& ac = entity.Get<MeshAnimationComponent>();
+        auto& ac = entity.get<MeshAnimationComponent>();
         ac.time += (float)dt * ac.speed;
     }
 }

--- a/Sprocket/Scene/Systems/AnimationSystem.h
+++ b/Sprocket/Scene/Systems/AnimationSystem.h
@@ -6,7 +6,7 @@ namespace Sprocket {
 class AnimationSystem : public EntitySystem
 {
 public:
-    void OnUpdate(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/AnimationSystem.h
+++ b/Sprocket/Scene/Systems/AnimationSystem.h
@@ -6,7 +6,7 @@ namespace Sprocket {
 class AnimationSystem : public EntitySystem
 {
 public:
-    void on_update(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -10,7 +10,7 @@ CameraSystem::CameraSystem(float aspectRatio)
     : d_aspectRatio(aspectRatio)
 {}
 
-void CameraSystem::OnEvent(ecs::Registry& registry, ev::Event& event)
+void CameraSystem::on_event(ecs::Registry& registry, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<Camera3DComponent>>()) {
         auto& camera = data->entity.get<Camera3DComponent>();

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -10,24 +10,28 @@ CameraSystem::CameraSystem(float aspectRatio)
     : d_aspectRatio(aspectRatio)
 {}
 
-void CameraSystem::on_event(ecs::Registry& registry, ev::Event& event)
+void CameraSystem::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
 {
-    if (auto data = event.get_if<ecs::ComponentAddedEvent<Camera3DComponent>>()) {
-        auto& camera = data->entity.get<Camera3DComponent>();
+    dispatcher.subscribe<ecs::ComponentAddedEvent<Camera3DComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::ComponentAddedEvent<Camera3DComponent>>();
+
+        auto& camera = data.entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(
             camera.fov, d_aspectRatio, 0.1f, 1000.0f
         );
-    }
-    else if (auto data = event.get_if<ev::WindowResize>()) {
-        d_aspectRatio = (float)data->width / data->height;
+    });
 
+    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event) {
+        auto data = event.get<ev::WindowResize>();
+
+        d_aspectRatio = (float)data.width / data.height;
         for (auto entity : registry.view<Camera3DComponent>()) {
             auto& camera = entity.get<Camera3DComponent>();
             camera.projection = glm::perspective(
                 camera.fov, d_aspectRatio, 0.1f, 1000.0f
             );
         }
-    }
+    });
 }
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -21,7 +21,7 @@ void CameraSystem::OnEvent(ecs::Registry& registry, ev::Event& event)
     else if (auto data = event.get_if<ev::WindowResize>()) {
         d_aspectRatio = (float)data->width / data->height;
 
-        for (auto entity : registry.View<Camera3DComponent>()) {
+        for (auto entity : registry.view<Camera3DComponent>()) {
             auto& camera = entity.get<Camera3DComponent>();
             camera.projection = glm::perspective(
                 camera.fov, d_aspectRatio, 0.1f, 1000.0f

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -12,18 +12,14 @@ CameraSystem::CameraSystem(float aspectRatio)
 
 void CameraSystem::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
 {
-    dispatcher.subscribe<ecs::Added<Camera3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<Camera3DComponent>>();
-
+    dispatcher.subscribe<ecs::Added<Camera3DComponent>>([&](ev::Event& event, auto&& data) {
         auto& camera = data.entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(
             camera.fov, d_aspectRatio, 0.1f, 1000.0f
         );
     });
 
-    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event) {
-        auto data = event.get<ev::WindowResize>();
-
+    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event, auto&& data) {
         d_aspectRatio = (float)data.width / data.height;
         for (auto entity : registry.view<Camera3DComponent>()) {
             auto& camera = entity.get<Camera3DComponent>();

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -12,8 +12,8 @@ CameraSystem::CameraSystem(float aspectRatio)
 
 void CameraSystem::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
 {
-    dispatcher.subscribe<ecs::ComponentAddedEvent<Camera3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::ComponentAddedEvent<Camera3DComponent>>();
+    dispatcher.subscribe<ecs::Added<Camera3DComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::Added<Camera3DComponent>>();
 
         auto& camera = data.entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -13,7 +13,7 @@ CameraSystem::CameraSystem(float aspectRatio)
 void CameraSystem::OnEvent(ecs::Registry& registry, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<Camera3DComponent>>()) {
-        auto& camera = data->entity.Get<Camera3DComponent>();
+        auto& camera = data->entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(
             camera.fov, d_aspectRatio, 0.1f, 1000.0f
         );
@@ -22,7 +22,7 @@ void CameraSystem::OnEvent(ecs::Registry& registry, ev::Event& event)
         d_aspectRatio = (float)data->width / data->height;
 
         for (auto entity : registry.View<Camera3DComponent>()) {
-            auto& camera = entity.Get<Camera3DComponent>();
+            auto& camera = entity.get<Camera3DComponent>();
             camera.projection = glm::perspective(
                 camera.fov, d_aspectRatio, 0.1f, 1000.0f
             );

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -9,7 +9,7 @@ class CameraSystem : public EntitySystem
 
 public:
     CameraSystem(float aspectRatio);
-    void on_event(ecs::Registry& registry, ev::Event& event) override;
+    void on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -9,7 +9,7 @@ class CameraSystem : public EntitySystem
 
 public:
     CameraSystem(float aspectRatio);
-    void OnEvent(ecs::Registry& registry, ev::Event& event) override;
+    void on_event(ecs::Registry& registry, ev::Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -46,8 +46,7 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
     auto& model2 = d_selectedSquare.add<ModelComponent>();
     model2.mesh = gridSquare;
 
-    dispatcher.subscribe<ecs::Added<GridComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<GridComponent>>();
+    dispatcher.subscribe<ecs::Added<GridComponent>>([&](ev::Event& event, auto&& data) {
         auto& transform = data.entity.get<Transform3DComponent>();
         const auto& gc = data.entity.get<GridComponent>();
 
@@ -58,8 +57,7 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
         d_gridEntities[{gc.x, gc.z}] = data.entity;
     });
 
-    dispatcher.subscribe<ecs::Removed<GridComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Removed<GridComponent>>();
+    dispatcher.subscribe<ecs::Removed<GridComponent>>([&](ev::Event& eventm, auto&& data) {
         auto& gc = data.entity.get<GridComponent>();
 
         auto it = d_gridEntities.find({gc.x, gc.z});
@@ -71,8 +69,7 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
         }
     });
 
-    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event) {
-        auto data = event.get<ev::MouseButtonPressed>();
+    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event, auto&& data) {
         if (data.button == Mouse::LEFT) {
             d_selected = d_hovered;
         } else {

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -28,7 +28,7 @@ void GameGrid::OnStartup(ecs::Registry& registry)
 {
     std::string gridSquare = "Resources/Models/Square.obj";
 
-    d_hoveredSquare = registry.New();
+    d_hoveredSquare = registry.create();
     auto& n1 = d_hoveredSquare.add<NameComponent>();
     d_hoveredSquare.add<TemporaryComponent>();
     n1.name = "Hovered Grid Highlighter";
@@ -37,7 +37,7 @@ void GameGrid::OnStartup(ecs::Registry& registry)
     auto& model1 = d_hoveredSquare.add<ModelComponent>();
     model1.mesh = gridSquare;
 
-    d_selectedSquare = registry.New();
+    d_selectedSquare = registry.create();
     auto& n2 = d_selectedSquare.add<NameComponent>();
     d_selectedSquare.add<TemporaryComponent>();
     n2.name = "Selected Grid Highlighter";

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -46,8 +46,8 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
     auto& model2 = d_selectedSquare.add<ModelComponent>();
     model2.mesh = gridSquare;
 
-    dispatcher.subscribe<ecs::ComponentAddedEvent<GridComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::ComponentAddedEvent<GridComponent>>();
+    dispatcher.subscribe<ecs::Added<GridComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::Added<GridComponent>>();
         auto& transform = data.entity.get<Transform3DComponent>();
         const auto& gc = data.entity.get<GridComponent>();
 
@@ -58,8 +58,8 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
         d_gridEntities[{gc.x, gc.z}] = data.entity;
     });
 
-    dispatcher.subscribe<ecs::ComponentRemovedEvent<GridComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::ComponentRemovedEvent<GridComponent>>();
+    dispatcher.subscribe<ecs::Removed<GridComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::Removed<GridComponent>>();
         auto& gc = data.entity.get<GridComponent>();
 
         auto it = d_gridEntities.find({gc.x, gc.z});
@@ -81,7 +81,7 @@ void GameGrid::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
     });
 }
 
-void GameGrid::on_update(ecs::Registry&, const ev::Dispatcher& d, double dt)
+void GameGrid::on_update(ecs::Registry&, const ev::Dispatcher&, double dt)
 {
     auto& camTr = d_camera.get<Transform3DComponent>();
 

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -24,7 +24,7 @@ GameGrid::GameGrid(Window* window)
 {
 }
 
-void GameGrid::OnStartup(ecs::Registry& registry)
+void GameGrid::on_startup(ecs::Registry& registry)
 {
     std::string gridSquare = "Resources/Models/Square.obj";
 
@@ -47,7 +47,7 @@ void GameGrid::OnStartup(ecs::Registry& registry)
     model2.mesh = gridSquare;
 }
 
-void GameGrid::OnUpdate(ecs::Registry&, double dt)
+void GameGrid::on_update(ecs::Registry&, double dt)
 {
     auto& camTr = d_camera.get<Transform3DComponent>();
 
@@ -72,7 +72,7 @@ void GameGrid::OnUpdate(ecs::Registry&, double dt)
     }
 }
 
-void GameGrid::OnEvent(ecs::Registry&, ev::Event& event)
+void GameGrid::on_event(ecs::Registry&, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<GridComponent>>()) {
         auto& transform = data->entity.get<Transform3DComponent>();

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -11,8 +11,8 @@
 namespace Sprocket {
 
 std::string Name(const ecs::Entity& e) {
-    if (e.Has<NameComponent>()) {
-        return e.Get<NameComponent>().name;
+    if (e.has<NameComponent>()) {
+        return e.get<NameComponent>().name;
     }
     return "Entity";
 }
@@ -29,27 +29,27 @@ void GameGrid::OnStartup(ecs::Registry& registry)
     std::string gridSquare = "Resources/Models/Square.obj";
 
     d_hoveredSquare = registry.New();
-    auto& n1 = d_hoveredSquare.Add<NameComponent>();
-    d_hoveredSquare.Add<TemporaryComponent>();
+    auto& n1 = d_hoveredSquare.add<NameComponent>();
+    d_hoveredSquare.add<TemporaryComponent>();
     n1.name = "Hovered Grid Highlighter";
-    auto& tr1 = d_hoveredSquare.Add<Transform3DComponent>();
+    auto& tr1 = d_hoveredSquare.add<Transform3DComponent>();
     tr1.scale = {0.3f, 0.3f, 0.3f};
-    auto& model1 = d_hoveredSquare.Add<ModelComponent>();
+    auto& model1 = d_hoveredSquare.add<ModelComponent>();
     model1.mesh = gridSquare;
 
     d_selectedSquare = registry.New();
-    auto& n2 = d_selectedSquare.Add<NameComponent>();
-    d_selectedSquare.Add<TemporaryComponent>();
+    auto& n2 = d_selectedSquare.add<NameComponent>();
+    d_selectedSquare.add<TemporaryComponent>();
     n2.name = "Selected Grid Highlighter";
-    auto& tr2 = d_selectedSquare.Add<Transform3DComponent>();
+    auto& tr2 = d_selectedSquare.add<Transform3DComponent>();
     tr2.scale = {0.5f, 0.5f, 0.5f};
-    auto& model2 = d_selectedSquare.Add<ModelComponent>();
+    auto& model2 = d_selectedSquare.add<ModelComponent>();
     model2.mesh = gridSquare;
 }
 
 void GameGrid::OnUpdate(ecs::Registry&, double dt)
 {
-    auto& camTr = d_camera.Get<Transform3DComponent>();
+    auto& camTr = d_camera.get<Transform3DComponent>();
 
     glm::vec3 cameraPos = camTr.position;
     glm::vec3 direction = Maths::GetMouseRay(
@@ -64,19 +64,19 @@ void GameGrid::OnUpdate(ecs::Registry&, double dt)
     glm::vec3 mousePos = cameraPos + lambda * direction;
     d_hovered = {(int)std::floor(mousePos.x), (int)std::floor(mousePos.z)};
 
-    d_hoveredSquare.Get<Transform3DComponent>().position = { d_hovered.x + 0.5f, 0.05f, d_hovered.y + 0.5f };
+    d_hoveredSquare.get<Transform3DComponent>().position = { d_hovered.x + 0.5f, 0.05f, d_hovered.y + 0.5f };
     if (d_selected.has_value()) {
-        d_selectedSquare.Get<Transform3DComponent>().position = { d_selected.value().x + 0.5f, 0.05f, d_selected.value().y + 0.5f };
+        d_selectedSquare.get<Transform3DComponent>().position = { d_selected.value().x + 0.5f, 0.05f, d_selected.value().y + 0.5f };
     } else {
-        d_selectedSquare.Get<Transform3DComponent>().position = { 0.5f, -1.0f, 0.5f };
+        d_selectedSquare.get<Transform3DComponent>().position = { 0.5f, -1.0f, 0.5f };
     }
 }
 
 void GameGrid::OnEvent(ecs::Registry&, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<GridComponent>>()) {
-        auto& transform = data->entity.Get<Transform3DComponent>();
-        const auto& gc = data->entity.Get<GridComponent>();
+        auto& transform = data->entity.get<Transform3DComponent>();
+        const auto& gc = data->entity.get<GridComponent>();
 
         assert(!d_gridEntities.contains({gc.x, gc.z}));
     
@@ -86,7 +86,7 @@ void GameGrid::OnEvent(ecs::Registry&, ev::Event& event)
     }
 
     else if (auto data = event.get_if<ecs::ComponentAddedEvent<GridComponent>>()) {
-        auto& gc = data->entity.Get<GridComponent>();
+        auto& gc = data->entity.get<GridComponent>();
 
         auto it = d_gridEntities.find({gc.x, gc.z});
         if (it == d_gridEntities.end()) {

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -34,9 +34,9 @@ private:
 public:
     GameGrid(Window* window);
 
-    void OnStartup(ecs::Registry& registry) override;
-    void OnUpdate(ecs::Registry& registry, double dt) override;
-    void OnEvent(ecs::Registry& registry, ev::Event& event) override;
+    void on_startup(ecs::Registry& registry) override;
+    void on_update(ecs::Registry& registry, double dt) override;
+    void on_event(ecs::Registry& registry, ev::Event& event) override;
 
     ecs::Entity At(const glm::ivec2& pos) const;
 

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -34,9 +34,8 @@ private:
 public:
     GameGrid(Window* window);
 
-    void on_startup(ecs::Registry& registry) override;
-    void on_update(ecs::Registry& registry, double dt) override;
-    void on_event(ecs::Registry& registry, ev::Event& event) override;
+    void on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 
     ecs::Entity At(const glm::ivec2& pos) const;
 

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -12,7 +12,7 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 
 void ParticleSystem::OnUpdate(ecs::Registry& registry, double dt)
 {
-    for (auto entity : registry.View<ParticleComponent>()) {
+    for (auto entity : registry.view<ParticleComponent>()) {
         auto& tc = entity.get<Transform3DComponent>();
         auto& pc = entity.get<ParticleComponent>();
 

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -13,8 +13,8 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 void ParticleSystem::OnUpdate(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.View<ParticleComponent>()) {
-        auto& tc = entity.Get<Transform3DComponent>();
-        auto& pc = entity.Get<ParticleComponent>();
+        auto& tc = entity.get<Transform3DComponent>();
+        auto& pc = entity.get<ParticleComponent>();
 
         pc.accumulator += dt;
         while (pc.accumulator > pc.interval) {

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -10,7 +10,7 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 {
 }
 
-void ParticleSystem::OnUpdate(ecs::Registry& registry, double dt)
+void ParticleSystem::on_update(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.view<ParticleComponent>()) {
         auto& tc = entity.get<Transform3DComponent>();

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -10,7 +10,7 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 {
 }
 
-void ParticleSystem::on_update(ecs::Registry& registry, double dt)
+void ParticleSystem::on_update(ecs::Registry& registry, const ev::Dispatcher&, double dt)
 {
     for (auto entity : registry.view<ParticleComponent>()) {
         auto& tc = entity.get<Transform3DComponent>();

--- a/Sprocket/Scene/Systems/ParticleSystem.h
+++ b/Sprocket/Scene/Systems/ParticleSystem.h
@@ -12,7 +12,7 @@ class ParticleSystem : public EntitySystem
 public:
     ParticleSystem(ParticleManager* manager);
     
-    void OnUpdate(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/ParticleSystem.h
+++ b/Sprocket/Scene/Systems/ParticleSystem.h
@@ -12,7 +12,7 @@ class ParticleSystem : public EntitySystem
 public:
     ParticleSystem(ParticleManager* manager);
     
-    void on_update(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -7,7 +7,7 @@ namespace Sprocket {
 
 void PathFollower::OnUpdate(ecs::Registry& registry, double dt)
 {
-    for (auto entity : registry.View<PathComponent>()) {
+    for (auto entity : registry.view<PathComponent>()) {
         auto& transform = entity.get<Transform3DComponent>();
         auto& path = entity.get<PathComponent>();
         if (path.markers.empty()) { return; }

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -8,8 +8,8 @@ namespace Sprocket {
 void PathFollower::OnUpdate(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.View<PathComponent>()) {
-        auto& transform = entity.Get<Transform3DComponent>();
-        auto& path = entity.Get<PathComponent>();
+        auto& transform = entity.get<Transform3DComponent>();
+        auto& path = entity.get<PathComponent>();
         if (path.markers.empty()) { return; }
         
         glm::vec3 direction = glm::normalize(path.markers.front() - transform.position);

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void PathFollower::on_update(ecs::Registry& registry, double dt)
+void PathFollower::on_update(ecs::Registry& registry, const ev::Dispatcher&, double dt)
 {
     for (auto entity : registry.view<PathComponent>()) {
         auto& transform = entity.get<Transform3DComponent>();

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void PathFollower::OnUpdate(ecs::Registry& registry, double dt)
+void PathFollower::on_update(ecs::Registry& registry, double dt)
 {
     for (auto entity : registry.view<PathComponent>()) {
         auto& transform = entity.get<Transform3DComponent>();

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class PathFollower : public EntitySystem
 {
 public:
-    void OnUpdate(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, double dt) override;
         // Called once per entity per frame and before the system updates.
 };
 

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class PathFollower : public EntitySystem
 {
 public:
-    void on_update(ecs::Registry& registry, double dt) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
         // Called once per entity per frame and before the system updates.
 };
 

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -180,9 +180,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
 {
     dispatcher.subscribe<ecs::Added<RigidBody3DComponent>>([&](ev::Event& event, auto&& data) {
         assert(data.entity.has<Transform3DComponent>());
-
         auto& tc = data.entity.get<Transform3DComponent>();
-        auto& rc = data.entity.get<RigidBody3DComponent>();
 
         auto& entry = d_impl->entityData[data.entity];
         entry.entity = data.entity;

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -97,10 +97,10 @@ public:
     void onContact(const rp3d::CollisionCallback::CallbackData& data) override
     {
         const auto name = [](const ecs::Entity& e) {
-            if (e.Has<NameComponent>()) {
-                return e.Get<NameComponent>().name;
+            if (e.has<NameComponent>()) {
+                return e.get<NameComponent>().name;
             }
-            return guid::Stringify(e.Id());
+            return guid::Stringify(e.id());
         };
 
         for (u32 p = 0; p != data.getNbContactPairs(); ++p) {
@@ -187,9 +187,9 @@ PhysicsEngine3D::PhysicsEngine3D(const glm::vec3& gravity)
 void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<RigidBody3DComponent>>()) {
-        assert(data->entity.Has<Transform3DComponent>());
-        auto& tc = data->entity.Get<Transform3DComponent>();
-        auto& rc = data->entity.Get<RigidBody3DComponent>();
+        assert(data->entity.has<Transform3DComponent>());
+        auto& tc = data->entity.get<Transform3DComponent>();
+        auto& rc = data->entity.get<RigidBody3DComponent>();
 
         auto& entry = d_impl->entityData[data->entity];
         entry.entity = data->entity;
@@ -198,9 +198,9 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
     }
 
     else if (auto data = event.get_if<ecs::ComponentRemovedEvent<RigidBody3DComponent>>()) {
-        data->entity.Remove<BoxCollider3DComponent>();
-        data->entity.Remove<SphereCollider3DComponent>();
-        data->entity.Remove<CapsuleCollider3DComponent>();
+        data->entity.remove<BoxCollider3DComponent>();
+        data->entity.remove<SphereCollider3DComponent>();
+        data->entity.remove<CapsuleCollider3DComponent>();
 
         auto rigidBodyIt = d_impl->entityData.find(data->entity);
         d_impl->world->destroyRigidBody(rigidBodyIt->second.body);
@@ -208,11 +208,11 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
     }
 
     else if (auto data = event.get_if<ecs::ComponentAddedEvent<BoxCollider3DComponent>>()) {
-        assert(data->entity.Has<Transform3DComponent>());
-        assert(data->entity.Has<RigidBody3DComponent>());
+        assert(data->entity.has<Transform3DComponent>());
+        assert(data->entity.has<RigidBody3DComponent>());
 
-        auto& tc = data->entity.Get<Transform3DComponent>();
-        auto& bc = data->entity.Get<BoxCollider3DComponent>();
+        auto& tc = data->entity.get<Transform3DComponent>();
+        auto& bc = data->entity.get<BoxCollider3DComponent>();
         auto& entry = d_impl->entityData[data->entity];
 
         glm::vec3 dimensions = bc.halfExtents;
@@ -221,7 +221,7 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
         rp3d::Transform transform = Convert(bc.position, bc.orientation);
 
         entry.boxCollider = entry.body->addCollider(shape, transform);
-        SetMaterial(entry.boxCollider, data->entity.Get<RigidBody3DComponent>());
+        SetMaterial(entry.boxCollider, data->entity.get<RigidBody3DComponent>());
     }
 
     else if (auto data = event.get_if<ecs::ComponentRemovedEvent<BoxCollider3DComponent>>()) {
@@ -230,18 +230,18 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
     }
 
     else if (auto data = event.get_if<ecs::ComponentAddedEvent<SphereCollider3DComponent>>()) {
-        assert(data->entity.Has<Transform3DComponent>());
-        assert(data->entity.Has<RigidBody3DComponent>());
+        assert(data->entity.has<Transform3DComponent>());
+        assert(data->entity.has<RigidBody3DComponent>());
 
-        auto& tc = data->entity.Get<Transform3DComponent>();
-        auto& sc = data->entity.Get<SphereCollider3DComponent>();
+        auto& tc = data->entity.get<Transform3DComponent>();
+        auto& sc = data->entity.get<SphereCollider3DComponent>();
         auto& entry = d_impl->entityData[data->entity];
         
         rp3d::SphereShape* shape = d_impl->pc.createSphereShape(sc.radius);
         rp3d::Transform transform = Convert(sc.position, sc.orientation);
 
         entry.sphereCollider = entry.body->addCollider(shape, transform);
-        SetMaterial(entry.sphereCollider, data->entity.Get<RigidBody3DComponent>());   
+        SetMaterial(entry.sphereCollider, data->entity.get<RigidBody3DComponent>());   
     }
 
     else if (auto data = event.get_if<ecs::ComponentRemovedEvent<SphereCollider3DComponent>>()) {
@@ -250,18 +250,18 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
     }
 
     else if (auto data = event.get_if<ecs::ComponentAddedEvent<CapsuleCollider3DComponent>>()) {
-        assert(data->entity.Has<Transform3DComponent>());
-        assert(data->entity.Has<RigidBody3DComponent>());
+        assert(data->entity.has<Transform3DComponent>());
+        assert(data->entity.has<RigidBody3DComponent>());
 
-        auto& tc = data->entity.Get<Transform3DComponent>();
-        auto& cc = data->entity.Get<CapsuleCollider3DComponent>();
+        auto& tc = data->entity.get<Transform3DComponent>();
+        auto& cc = data->entity.get<CapsuleCollider3DComponent>();
         auto& entry = d_impl->entityData[data->entity];
         
         rp3d::CapsuleShape* shape = d_impl->pc.createCapsuleShape(cc.radius, cc.height);
         rp3d::Transform transform = Convert(cc.position, cc.orientation);
 
         entry.capsuleCollider = entry.body->addCollider(shape, transform);
-        SetMaterial(entry.capsuleCollider, data->entity.Get<RigidBody3DComponent>()); 
+        SetMaterial(entry.capsuleCollider, data->entity.get<RigidBody3DComponent>()); 
     }
 
     else if (auto data = event.get_if<ecs::ComponentRemovedEvent<CapsuleCollider3DComponent>>()) {
@@ -282,8 +282,8 @@ void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
     // Do this even if not running so that the physics engine stays up
     // to date with the scene.
     for (auto entity : registry.View<RigidBody3DComponent>()) {
-        const auto& tc = entity.Get<Transform3DComponent>();
-        const auto& physics = entity.Get<RigidBody3DComponent>();
+        const auto& tc = entity.get<Transform3DComponent>();
+        const auto& physics = entity.get<RigidBody3DComponent>();
 
         auto& entry = d_impl->entityData[entity];
         rp3d::RigidBody* body = entry.body;
@@ -300,9 +300,9 @@ void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
 
             // TODO: Move to RigidBody3DComponent
             float mass = 0;
-            if (entity.Has<BoxCollider3DComponent>()) { mass += entity.Get<BoxCollider3DComponent>().mass; }
-            if (entity.Has<SphereCollider3DComponent>()) { mass += entity.Get<SphereCollider3DComponent>().mass; }
-            if (entity.Has<CapsuleCollider3DComponent>()) { mass += entity.Get<CapsuleCollider3DComponent>().mass; }
+            if (entity.has<BoxCollider3DComponent>()) { mass += entity.get<BoxCollider3DComponent>().mass; }
+            if (entity.has<SphereCollider3DComponent>()) { mass += entity.get<SphereCollider3DComponent>().mass; }
+            if (entity.has<CapsuleCollider3DComponent>()) { mass += entity.get<CapsuleCollider3DComponent>().mass; }
             body->setMass(mass);
         }
 
@@ -327,8 +327,8 @@ void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
 
     // Post Update
     for (auto entity : registry.View<RigidBody3DComponent>()) {
-        auto& tc = entity.Get<Transform3DComponent>();
-        auto& rc = entity.Get<RigidBody3DComponent>();
+        auto& tc = entity.get<Transform3DComponent>();
+        auto& rc = entity.get<RigidBody3DComponent>();
         const rp3d::RigidBody* body = d_impl->entityData[entity].body;
 
         tc.position = Convert(body->getTransform().getPosition());

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -179,9 +179,10 @@ PhysicsEngine3D::PhysicsEngine3D(const glm::vec3& gravity)
 void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
 {
     dispatcher.subscribe<ecs::Added<RigidBody3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<RigidBody3DComponent>>();
+        const auto& data = event.get<ecs::Added<RigidBody3DComponent>>();
 
-        assert(data->entity.has<Transform3DComponent>());
+        assert(data.entity.has<Transform3DComponent>());
+
         auto& tc = data.entity.get<Transform3DComponent>();
         auto& rc = data.entity.get<RigidBody3DComponent>();
 
@@ -191,8 +192,8 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         entry.body->setUserData(static_cast<void*>(&entry.entity));
     });
 
-    dispatcher.subscribe<ecs::Added<RigidBody3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<RigidBody3DComponent>>();
+    dispatcher.subscribe<ecs::Removed<RigidBody3DComponent>>([&](ev::Event& event) {
+        const auto& data = event.get<ecs::Removed<RigidBody3DComponent>>();
 
         data.entity.remove<BoxCollider3DComponent>();
         data.entity.remove<SphereCollider3DComponent>();
@@ -204,14 +205,17 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
     });
 
     dispatcher.subscribe<ecs::Added<BoxCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<BoxCollider3DComponent>>();
+        const auto& data = event.get<ecs::Added<BoxCollider3DComponent>>();
 
-        assert(data->entity.has<Transform3DComponent>());
-        assert(data->entity.has<RigidBody3DComponent>());
+        assert(data.entity.has<Transform3DComponent>());
+        assert(data.entity.has<RigidBody3DComponent>());
 
         auto& tc = data.entity.get<Transform3DComponent>();
         auto& bc = data.entity.get<BoxCollider3DComponent>();
-        auto& entry = d_impl->entityData[data.entity];
+
+        auto it = d_impl->entityData.find(data.entity);
+        assert(it != d_impl->entityData.end());
+        auto& entry = it->second;
 
         glm::vec3 dimensions = bc.halfExtents;
         if (bc.applyScale) { dimensions *= tc.scale; }
@@ -223,17 +227,17 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
     });
 
     dispatcher.subscribe<ecs::Removed<BoxCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Removed<BoxCollider3DComponent>>();
+        const auto& data = event.get<ecs::Removed<BoxCollider3DComponent>>();
 
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.boxCollider);
     });
 
     dispatcher.subscribe<ecs::Added<SphereCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<SphereCollider3DComponent>>();
+        const auto& data = event.get<ecs::Added<SphereCollider3DComponent>>();
 
-        assert(data->entity.has<Transform3DComponent>());
-        assert(data->entity.has<RigidBody3DComponent>());
+        assert(data.entity.has<Transform3DComponent>());
+        assert(data.entity.has<RigidBody3DComponent>());
 
         auto& tc = data.entity.get<Transform3DComponent>();
         auto& sc = data.entity.get<SphereCollider3DComponent>();
@@ -247,14 +251,14 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
     });
 
     dispatcher.subscribe<ecs::Removed<SphereCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Removed<SphereCollider3DComponent>>();
+        const auto& data = event.get<ecs::Removed<SphereCollider3DComponent>>();
 
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.sphereCollider);
     });
 
     dispatcher.subscribe<ecs::Added<CapsuleCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<CapsuleCollider3DComponent>>();
+        const auto& data = event.get<ecs::Added<CapsuleCollider3DComponent>>();
 
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
@@ -271,7 +275,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
     });
 
     dispatcher.subscribe<ecs::Removed<CapsuleCollider3DComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Removed<CapsuleCollider3DComponent>>();
+        const auto& data = event.get<ecs::Removed<CapsuleCollider3DComponent>>();
 
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.capsuleCollider);

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -184,7 +184,7 @@ PhysicsEngine3D::PhysicsEngine3D(const glm::vec3& gravity)
 {
 }
 
-void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
+void PhysicsEngine3D::on_event(ecs::Registry& registry, ev::Event& event)
 {
     if (auto data = event.get_if<ecs::ComponentAddedEvent<RigidBody3DComponent>>()) {
         assert(data->entity.has<Transform3DComponent>());
@@ -270,13 +270,13 @@ void PhysicsEngine3D::OnEvent(ecs::Registry& registry, ev::Event& event)
     }
 }
 
-void PhysicsEngine3D::OnStartup(ecs::Registry& registry)
+void PhysicsEngine3D::on_startup(ecs::Registry& registry)
 {
     d_impl->listener = std::make_unique<EventListener>(&registry);
     d_impl->world->setEventListener(d_impl->listener.get());
 }
 
-void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
+void PhysicsEngine3D::on_update(ecs::Registry& registry, double dt)
 {
     // Pre Update
     // Do this even if not running so that the physics engine stays up

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -281,7 +281,7 @@ void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
     // Pre Update
     // Do this even if not running so that the physics engine stays up
     // to date with the scene.
-    for (auto entity : registry.View<RigidBody3DComponent>()) {
+    for (auto entity : registry.view<RigidBody3DComponent>()) {
         const auto& tc = entity.get<Transform3DComponent>();
         const auto& physics = entity.get<RigidBody3DComponent>();
 
@@ -326,7 +326,7 @@ void PhysicsEngine3D::OnUpdate(ecs::Registry& registry, double dt)
     }
 
     // Post Update
-    for (auto entity : registry.View<RigidBody3DComponent>()) {
+    for (auto entity : registry.view<RigidBody3DComponent>()) {
         auto& tc = entity.get<Transform3DComponent>();
         auto& rc = entity.get<RigidBody3DComponent>();
         const rp3d::RigidBody* body = d_impl->entityData[entity].body;

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -178,9 +178,7 @@ PhysicsEngine3D::PhysicsEngine3D(const glm::vec3& gravity)
 
 void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher)
 {
-    dispatcher.subscribe<ecs::Added<RigidBody3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Added<RigidBody3DComponent>>();
-
+    dispatcher.subscribe<ecs::Added<RigidBody3DComponent>>([&](ev::Event& event, auto&& data) {
         assert(data.entity.has<Transform3DComponent>());
 
         auto& tc = data.entity.get<Transform3DComponent>();
@@ -192,9 +190,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         entry.body->setUserData(static_cast<void*>(&entry.entity));
     });
 
-    dispatcher.subscribe<ecs::Removed<RigidBody3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Removed<RigidBody3DComponent>>();
-
+    dispatcher.subscribe<ecs::Removed<RigidBody3DComponent>>([&](ev::Event& event, auto&& data) {
         data.entity.remove<BoxCollider3DComponent>();
         data.entity.remove<SphereCollider3DComponent>();
         data.entity.remove<CapsuleCollider3DComponent>();
@@ -204,9 +200,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         d_impl->entityData.erase(rigidBodyIt);
     });
 
-    dispatcher.subscribe<ecs::Added<BoxCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Added<BoxCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Added<BoxCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
 
@@ -226,12 +220,12 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.boxCollider, data.entity.get<RigidBody3DComponent>());
     });
 
-    dispatcher.subscribe<ecs::Removed<BoxCollider3DComponent>>([&](ev::Event& event, const auto& data) {
+    dispatcher.subscribe<ecs::Removed<BoxCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.boxCollider);
     });
 
-    dispatcher.subscribe<ecs::Added<SphereCollider3DComponent>>([&](ev::Event& event, const auto& data) {
+    dispatcher.subscribe<ecs::Added<SphereCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
 
@@ -246,12 +240,12 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.sphereCollider, data.entity.get<RigidBody3DComponent>());   
     });
 
-    dispatcher.subscribe<ecs::Removed<SphereCollider3DComponent>>([&](ev::Event& event, const auto& data) {
+    dispatcher.subscribe<ecs::Removed<SphereCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.sphereCollider);
     });
 
-    dispatcher.subscribe<ecs::Added<CapsuleCollider3DComponent>>([&](ev::Event& event, const auto& data) {
+    dispatcher.subscribe<ecs::Added<CapsuleCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
 
@@ -266,7 +260,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.capsuleCollider, data.entity.get<RigidBody3DComponent>()); 
     });
 
-    dispatcher.subscribe<ecs::Removed<CapsuleCollider3DComponent>>([&](ev::Event& event, const auto& data) {
+    dispatcher.subscribe<ecs::Removed<CapsuleCollider3DComponent>>([&](ev::Event& event, auto&& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.capsuleCollider);
     });

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -226,16 +226,12 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.boxCollider, data.entity.get<RigidBody3DComponent>());
     });
 
-    dispatcher.subscribe<ecs::Removed<BoxCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Removed<BoxCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Removed<BoxCollider3DComponent>>([&](ev::Event& event, const auto& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.boxCollider);
     });
 
-    dispatcher.subscribe<ecs::Added<SphereCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Added<SphereCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Added<SphereCollider3DComponent>>([&](ev::Event& event, const auto& data) {
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
 
@@ -250,16 +246,12 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.sphereCollider, data.entity.get<RigidBody3DComponent>());   
     });
 
-    dispatcher.subscribe<ecs::Removed<SphereCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Removed<SphereCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Removed<SphereCollider3DComponent>>([&](ev::Event& event, const auto& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.sphereCollider);
     });
 
-    dispatcher.subscribe<ecs::Added<CapsuleCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Added<CapsuleCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Added<CapsuleCollider3DComponent>>([&](ev::Event& event, const auto& data) {
         assert(data.entity.has<Transform3DComponent>());
         assert(data.entity.has<RigidBody3DComponent>());
 
@@ -274,9 +266,7 @@ void PhysicsEngine3D::on_startup(ecs::Registry& registry, ev::Dispatcher& dispat
         SetMaterial(entry.capsuleCollider, data.entity.get<RigidBody3DComponent>()); 
     });
 
-    dispatcher.subscribe<ecs::Removed<CapsuleCollider3DComponent>>([&](ev::Event& event) {
-        const auto& data = event.get<ecs::Removed<CapsuleCollider3DComponent>>();
-
+    dispatcher.subscribe<ecs::Removed<CapsuleCollider3DComponent>>([&](ev::Event& event, const auto& data) {
         auto& entry = d_impl->entityData[data.entity];
         entry.body->removeCollider(entry.capsuleCollider);
     });

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -27,9 +27,8 @@ public:
     PhysicsEngine3D(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
     ~PhysicsEngine3D() = default;
 
-    void on_startup(ecs::Registry& registry) override;
-    void on_event(ecs::Registry& registry, ev::Event& event) override;
-    void on_update(ecs::Registry& registry, double dt) override;
+    void on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 
     ecs::Entity Raycast(const glm::vec3& base, const glm::vec3& direction);
         // Given a position in the world and a direction from that point,

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -27,9 +27,9 @@ public:
     PhysicsEngine3D(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
     ~PhysicsEngine3D() = default;
 
-    void OnStartup(ecs::Registry& registry) override;
-    void OnEvent(ecs::Registry& registry, ev::Event& event) override;
-    void OnUpdate(ecs::Registry& registry, double dt) override;
+    void on_startup(ecs::Registry& registry) override;
+    void on_event(ecs::Registry& registry, ev::Event& event) override;
+    void on_update(ecs::Registry& registry, double dt) override;
 
     ecs::Entity Raycast(const glm::vec3& base, const glm::vec3& direction);
         // Given a position in the world and a direction from that point,

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -16,7 +16,7 @@ ScriptRunner::ScriptRunner(Window* window)
 {
 }
 
-void ScriptRunner::OnUpdate(ecs::Registry&, double dt)
+void ScriptRunner::on_update(ecs::Registry&, double dt)
 {
     // We delete scripts here rather then with OnRemove otherwise we would segfault if
     // a script tries to delete its own entity, which is functionality that we want to
@@ -36,7 +36,7 @@ void ScriptRunner::OnUpdate(ecs::Registry&, double dt)
     }
 }
 
-void ScriptRunner::OnEvent(ecs::Registry& registry, ev::Event& event)
+void ScriptRunner::on_event(ecs::Registry& registry, ev::Event& event)
 {
     d_input.on_event(event);
 

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -51,8 +51,8 @@ void ScriptRunner::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatche
 {
     d_input.on_startup(dispatcher);
 
-    dispatcher.subscribe<ecs::ComponentAddedEvent<ScriptComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::ComponentAddedEvent<ScriptComponent>>();
+    dispatcher.subscribe<ecs::Added<ScriptComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::Added<ScriptComponent>>();
 
         lua::Script script(data.entity.get<ScriptComponent>().script);
         lua::load_registry_functions(script, registry);
@@ -67,8 +67,8 @@ void ScriptRunner::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatche
         d_engines.emplace(data.entity, std::make_pair(std::move(script), true));
     });
 
-    dispatcher.subscribe<ecs::ComponentRemovedEvent<ScriptComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::ComponentRemovedEvent<ScriptComponent>>();
+    dispatcher.subscribe<ecs::Removed<ScriptComponent>>([&](ev::Event& event) {
+        auto data = event.get<ecs::Removed<ScriptComponent>>();
 
         auto it = d_engines.find(data.entity);
         if (it != d_engines.end()) {

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -51,9 +51,7 @@ void ScriptRunner::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatche
 {
     d_input.on_startup(dispatcher);
 
-    dispatcher.subscribe<ecs::Added<ScriptComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Added<ScriptComponent>>();
-
+    dispatcher.subscribe<ecs::Added<ScriptComponent>>([&](ev::Event& event, auto&& data) {
         lua::Script script(data.entity.get<ScriptComponent>().script);
         lua::load_registry_functions(script, registry);
         lua::load_input_functions(script, d_input);
@@ -67,54 +65,35 @@ void ScriptRunner::on_startup(ecs::Registry& registry, ev::Dispatcher& dispatche
         d_engines.emplace(data.entity, std::make_pair(std::move(script), true));
     });
 
-    dispatcher.subscribe<ecs::Removed<ScriptComponent>>([&](ev::Event& event) {
-        auto data = event.get<ecs::Removed<ScriptComponent>>();
-
+    dispatcher.subscribe<ecs::Removed<ScriptComponent>>([&](ev::Event& event, auto&& data) {
         auto it = d_engines.find(data.entity);
         if (it != d_engines.end()) {
             it->second.second = false; // alive = false
         }
     });
 
-
-    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event) {
-        auto data = event.get<ev::WindowResize>();
+    const auto handler = [&](ev::Event& event, const char* f, auto&&... args) {
         for (auto& script : active_scripts()) {
-            const char* f = "OnWindowResizeEvent";
-            if (script.has_function(f) && script.call_function<bool>(f, data.width, data.height)) {
+            if (script.has_function(f) && script.call_function<bool>(f, std::forward<decltype(args)>(args)...)) {
                 event.consume();
             }
         }
+    };
+
+    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event, auto&& data) {
+        handler(event, "OnWindowResizeEvent", data.width, data.height);
     });
 
-    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event) {
-        auto data = event.get<ev::MouseButtonPressed>();
-        for (auto& script : active_scripts()) {
-            const char* f = "OnMouseButtonPressedEvent";
-            if (script.has_function(f) && script.call_function<bool>(f, data.button, data.action, data.mods)) {
-                event.consume();
-            }
-        }
+    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event, auto&& data) {
+        handler(event, "OnMouseButtonPressedEvent", data.button, data.action, data.mods);
     });
 
-    dispatcher.subscribe<ev::MouseScrolled>([&](ev::Event& event) {
-        auto data = event.get<ev::MouseScrolled>();
-        for (auto& script : active_scripts()) {
-            const char* f = "OnMouseScrolledEvent";
-            if (script.has_function(f) && script.call_function<bool>(f, data.x_offset, data.y_offset)) {
-                event.consume();
-            }
-        }
+    dispatcher.subscribe<ev::MouseScrolled>([&](ev::Event& event, auto&& data) {
+        handler(event, "OnMouseScrolledEvent", data.x_offset, data.y_offset);
     });
 
-    dispatcher.subscribe<CollisionEvent>([&](ev::Event& event) {
-        auto data = event.get<CollisionEvent>();
-        for (auto& script : active_scripts()) {
-            const char* f = "OnCollisionEvent";
-            if (script.has_function(f) && script.call_function<bool>(f, data.entity1, data.entity2)) {
-                event.consume();
-            }
-        }
+    dispatcher.subscribe<CollisionEvent>([&](ev::Event& event, auto&& data) {
+        handler(event, "OnCollisionEvent", data.entity1, data.entity2);
     });
 }
 

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -26,7 +26,7 @@ void ScriptRunner::OnUpdate(ecs::Registry&, double dt)
         auto& [script, alive] = it->second;
 
         if (alive) {
-            if (entity.Get<ScriptComponent>().active) {
+            if (entity.get<ScriptComponent>().active) {
                 script.call_function<void>("OnUpdate", entity, dt);
             }
             ++it;
@@ -41,7 +41,7 @@ void ScriptRunner::OnEvent(ecs::Registry& registry, ev::Event& event)
     d_input.on_event(event);
 
     if (auto data = event.get_if<ecs::ComponentAddedEvent<ScriptComponent>>()) {
-        lua::Script script(data->entity.Get<ScriptComponent>().script);
+        lua::Script script(data->entity.get<ScriptComponent>().script);
         lua::load_registry_functions(script, registry);
         lua::load_input_functions(script, d_input);
         lua::load_window_functions(script, *d_window);
@@ -75,7 +75,7 @@ void ScriptRunner::OnEvent(ecs::Registry& registry, ev::Event& event)
 
     for (auto& [entity, pair] : d_engines) {
         auto& [script, alive] = pair;
-        if (!(alive && entity.Get<ScriptComponent>().active)) {
+        if (!(alive && entity.get<ScriptComponent>().active)) {
             continue;
         }
 

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -19,8 +19,8 @@ class ScriptRunner : public EntitySystem
 public:
     ScriptRunner(Window* window);
 
-    void OnUpdate(ecs::Registry& registry, double dt) override;
-    void OnEvent(ecs::Registry& registry, ev::Event& event) override;
+    void on_update(ecs::Registry& registry, double dt) override;
+    void on_event(ecs::Registry& registry, ev::Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -6,6 +6,7 @@
 #include "Window.h"
 
 #include <unordered_map>
+#include <cppcoro/generator.hpp>
 
 namespace Sprocket {
 
@@ -16,11 +17,13 @@ class ScriptRunner : public EntitySystem
 
     std::unordered_map<ecs::Entity, std::pair<lua::Script, bool>> d_engines;
 
+    cppcoro::generator<lua::Script&> active_scripts();
+
 public:
     ScriptRunner(Window* window);
 
-    void on_update(ecs::Registry& registry, double dt) override;
-    void on_event(ecs::Registry& registry, ev::Event& event) override;
+    void on_startup(ecs::Registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_update(ecs::Registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 };
 
 }

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -97,7 +97,7 @@ void load_registry_functions(lua::Script& script, ecs::Registry& registry)
 
     lua_register(L, "_Each_New", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto gen = new Generator(get_pointer<ecs::Registry>(L, "__registry__")->Each());
+        auto gen = new Generator(get_pointer<ecs::Registry>(L, "__registry__")->all());
         lua_pushlightuserdata(L, static_cast<void*>(gen));
         return 1;
     });

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -84,7 +84,7 @@ void load_registry_functions(lua::Script& script, ecs::Registry& registry)
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         auto luaEntity = static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        luaEntity->Delete();
+        luaEntity->destroy();
         return 0;
     });
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -77,7 +77,7 @@ void load_registry_functions(lua::Script& script, ecs::Registry& registry)
     lua_register(L, "NewEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         auto luaEntity = static_cast<ecs::Entity*>(lua_newuserdata(L, sizeof(ecs::Entity)));
-        *luaEntity = get_pointer<ecs::Registry>(L, "__registry__")->New();
+        *luaEntity = get_pointer<ecs::Registry>(L, "__registry__")->create();
         return 1;
     });
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -62,7 +62,7 @@ template <typename T> int _has_impl(lua_State* L)
 {
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    lua_pushboolean(L, entity.Has<T>());
+    lua_pushboolean(L, entity.has<T>());
     return 1;
 }
 
@@ -248,7 +248,7 @@ void load_entity_transformation_functions(lua::Script& script)
         float ty = (float)lua_tonumber(L, 6);
         float tz = (float)lua_tonumber(L, 7);
 
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         tr.position = glm::vec3(px, py, pz);
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, {tx, ty, tz}, {0.0, 1.0, 0.0})));
         return 0;
@@ -264,7 +264,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); };
 
         ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
 
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
@@ -275,11 +275,11 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
         ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         auto o = tr.orientation;
 
-        if (entity.Has<Camera3DComponent>()) {
-            auto pitch = entity.Get<Camera3DComponent>().pitch;
+        if (entity.has<Camera3DComponent>()) {
+            auto pitch = entity.get<Camera3DComponent>().pitch;
             o = glm::rotate(o, pitch, {1, 0, 0});
         }
 
@@ -297,7 +297,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         int ptr = 1;
         ecs::Entity entity = Converter<ecs::Entity>::read(L, ptr);
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         return Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
     });
 
@@ -312,7 +312,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
         int ptr = 1;
         ecs::Entity entity = Converter<ecs::Entity>::read(L, ptr);
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         float yaw = Converter<float>::read(L, ptr);
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
@@ -347,10 +347,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<NameComponent>());
+        assert(e.has<NameComponent>());
 
         int count = 0;
-        const auto& c = e.Get<NameComponent>();
+        const auto& c = e.get<NameComponent>();
         count += Converter<std::string>::push(L, c.name);
         assert(count == NameComponent_dimension);
         return count;
@@ -368,7 +368,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<NameComponent>();
+        auto& c = e.get<NameComponent>();
         c.name = Converter<std::string>::read(L, ptr);
         assert(ptr == NameComponent_dimension + 2);
         return 0;
@@ -385,11 +385,11 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<NameComponent>());
+        assert(!e.has<NameComponent>());
 
         NameComponent c;
         c.name = Converter<std::string>::read(L, ptr);
-        e.Add<NameComponent>(c);
+        e.add<NameComponent>(c);
         assert(ptr == NameComponent_dimension + 2);
         return 0;
     });
@@ -420,10 +420,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<Transform2DComponent>());
+        assert(e.has<Transform2DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<Transform2DComponent>();
+        const auto& c = e.get<Transform2DComponent>();
         count += Converter<glm::vec2>::push(L, c.position);
         count += Converter<float>::push(L, c.rotation);
         count += Converter<glm::vec2>::push(L, c.scale);
@@ -443,7 +443,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<Transform2DComponent>();
+        auto& c = e.get<Transform2DComponent>();
         c.position = Converter<glm::vec2>::read(L, ptr);
         c.rotation = Converter<float>::read(L, ptr);
         c.scale = Converter<glm::vec2>::read(L, ptr);
@@ -462,13 +462,13 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<Transform2DComponent>());
+        assert(!e.has<Transform2DComponent>());
 
         Transform2DComponent c;
         c.position = Converter<glm::vec2>::read(L, ptr);
         c.rotation = Converter<float>::read(L, ptr);
         c.scale = Converter<glm::vec2>::read(L, ptr);
-        e.Add<Transform2DComponent>(c);
+        e.add<Transform2DComponent>(c);
         assert(ptr == Transform2DComponent_dimension + 2);
         return 0;
     });
@@ -498,10 +498,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<Transform3DComponent>());
+        assert(e.has<Transform3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<Transform3DComponent>();
+        const auto& c = e.get<Transform3DComponent>();
         count += Converter<glm::vec3>::push(L, c.position);
         count += Converter<glm::vec3>::push(L, c.scale);
         assert(count == Transform3DComponent_dimension);
@@ -520,7 +520,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<Transform3DComponent>();
+        auto& c = e.get<Transform3DComponent>();
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.scale = Converter<glm::vec3>::read(L, ptr);
         assert(ptr == Transform3DComponent_dimension + 2);
@@ -538,12 +538,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<Transform3DComponent>());
+        assert(!e.has<Transform3DComponent>());
 
         Transform3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.scale = Converter<glm::vec3>::read(L, ptr);
-        e.Add<Transform3DComponent>(c);
+        e.add<Transform3DComponent>(c);
         assert(ptr == Transform3DComponent_dimension + 2);
         return 0;
     });
@@ -573,10 +573,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<ModelComponent>());
+        assert(e.has<ModelComponent>());
 
         int count = 0;
-        const auto& c = e.Get<ModelComponent>();
+        const auto& c = e.get<ModelComponent>();
         count += Converter<std::string>::push(L, c.mesh);
         count += Converter<std::string>::push(L, c.material);
         assert(count == ModelComponent_dimension);
@@ -595,7 +595,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<ModelComponent>();
+        auto& c = e.get<ModelComponent>();
         c.mesh = Converter<std::string>::read(L, ptr);
         c.material = Converter<std::string>::read(L, ptr);
         assert(ptr == ModelComponent_dimension + 2);
@@ -613,12 +613,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<ModelComponent>());
+        assert(!e.has<ModelComponent>());
 
         ModelComponent c;
         c.mesh = Converter<std::string>::read(L, ptr);
         c.material = Converter<std::string>::read(L, ptr);
-        e.Add<ModelComponent>(c);
+        e.add<ModelComponent>(c);
         assert(ptr == ModelComponent_dimension + 2);
         return 0;
     });
@@ -654,10 +654,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<RigidBody3DComponent>());
+        assert(e.has<RigidBody3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<RigidBody3DComponent>();
+        const auto& c = e.get<RigidBody3DComponent>();
         count += Converter<glm::vec3>::push(L, c.velocity);
         count += Converter<bool>::push(L, c.gravity);
         count += Converter<bool>::push(L, c.frozen);
@@ -682,7 +682,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<RigidBody3DComponent>();
+        auto& c = e.get<RigidBody3DComponent>();
         c.velocity = Converter<glm::vec3>::read(L, ptr);
         c.gravity = Converter<bool>::read(L, ptr);
         c.frozen = Converter<bool>::read(L, ptr);
@@ -706,7 +706,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<RigidBody3DComponent>());
+        assert(!e.has<RigidBody3DComponent>());
 
         RigidBody3DComponent c;
         c.velocity = Converter<glm::vec3>::read(L, ptr);
@@ -717,7 +717,7 @@ void load_entity_component_functions(lua::Script& script)
         c.rollingResistance = Converter<float>::read(L, ptr);
         c.force = Converter<glm::vec3>::read(L, ptr);
         c.onFloor = Converter<bool>::read(L, ptr);
-        e.Add<RigidBody3DComponent>(c);
+        e.add<RigidBody3DComponent>(c);
         assert(ptr == RigidBody3DComponent_dimension + 2);
         return 0;
     });
@@ -749,10 +749,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<BoxCollider3DComponent>());
+        assert(e.has<BoxCollider3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<BoxCollider3DComponent>();
+        const auto& c = e.get<BoxCollider3DComponent>();
         count += Converter<glm::vec3>::push(L, c.position);
         count += Converter<float>::push(L, c.mass);
         count += Converter<glm::vec3>::push(L, c.halfExtents);
@@ -773,7 +773,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<BoxCollider3DComponent>();
+        auto& c = e.get<BoxCollider3DComponent>();
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.halfExtents = Converter<glm::vec3>::read(L, ptr);
@@ -793,14 +793,14 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<BoxCollider3DComponent>());
+        assert(!e.has<BoxCollider3DComponent>());
 
         BoxCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.halfExtents = Converter<glm::vec3>::read(L, ptr);
         c.applyScale = Converter<bool>::read(L, ptr);
-        e.Add<BoxCollider3DComponent>(c);
+        e.add<BoxCollider3DComponent>(c);
         assert(ptr == BoxCollider3DComponent_dimension + 2);
         return 0;
     });
@@ -831,10 +831,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<SphereCollider3DComponent>());
+        assert(e.has<SphereCollider3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<SphereCollider3DComponent>();
+        const auto& c = e.get<SphereCollider3DComponent>();
         count += Converter<glm::vec3>::push(L, c.position);
         count += Converter<float>::push(L, c.mass);
         count += Converter<float>::push(L, c.radius);
@@ -854,7 +854,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<SphereCollider3DComponent>();
+        auto& c = e.get<SphereCollider3DComponent>();
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.radius = Converter<float>::read(L, ptr);
@@ -873,13 +873,13 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<SphereCollider3DComponent>());
+        assert(!e.has<SphereCollider3DComponent>());
 
         SphereCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.radius = Converter<float>::read(L, ptr);
-        e.Add<SphereCollider3DComponent>(c);
+        e.add<SphereCollider3DComponent>(c);
         assert(ptr == SphereCollider3DComponent_dimension + 2);
         return 0;
     });
@@ -911,10 +911,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<CapsuleCollider3DComponent>());
+        assert(e.has<CapsuleCollider3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<CapsuleCollider3DComponent>();
+        const auto& c = e.get<CapsuleCollider3DComponent>();
         count += Converter<glm::vec3>::push(L, c.position);
         count += Converter<float>::push(L, c.mass);
         count += Converter<float>::push(L, c.radius);
@@ -935,7 +935,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<CapsuleCollider3DComponent>();
+        auto& c = e.get<CapsuleCollider3DComponent>();
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.radius = Converter<float>::read(L, ptr);
@@ -955,14 +955,14 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<CapsuleCollider3DComponent>());
+        assert(!e.has<CapsuleCollider3DComponent>());
 
         CapsuleCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ptr);
         c.mass = Converter<float>::read(L, ptr);
         c.radius = Converter<float>::read(L, ptr);
         c.height = Converter<float>::read(L, ptr);
-        e.Add<CapsuleCollider3DComponent>(c);
+        e.add<CapsuleCollider3DComponent>(c);
         assert(ptr == CapsuleCollider3DComponent_dimension + 2);
         return 0;
     });
@@ -992,10 +992,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<ScriptComponent>());
+        assert(e.has<ScriptComponent>());
 
         int count = 0;
-        const auto& c = e.Get<ScriptComponent>();
+        const auto& c = e.get<ScriptComponent>();
         count += Converter<std::string>::push(L, c.script);
         count += Converter<bool>::push(L, c.active);
         assert(count == ScriptComponent_dimension);
@@ -1014,7 +1014,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<ScriptComponent>();
+        auto& c = e.get<ScriptComponent>();
         c.script = Converter<std::string>::read(L, ptr);
         c.active = Converter<bool>::read(L, ptr);
         assert(ptr == ScriptComponent_dimension + 2);
@@ -1032,12 +1032,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<ScriptComponent>());
+        assert(!e.has<ScriptComponent>());
 
         ScriptComponent c;
         c.script = Converter<std::string>::read(L, ptr);
         c.active = Converter<bool>::read(L, ptr);
-        e.Add<ScriptComponent>(c);
+        e.add<ScriptComponent>(c);
         assert(ptr == ScriptComponent_dimension + 2);
         return 0;
     });
@@ -1067,10 +1067,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<Camera3DComponent>());
+        assert(e.has<Camera3DComponent>());
 
         int count = 0;
-        const auto& c = e.Get<Camera3DComponent>();
+        const auto& c = e.get<Camera3DComponent>();
         count += Converter<float>::push(L, c.fov);
         count += Converter<float>::push(L, c.pitch);
         assert(count == Camera3DComponent_dimension);
@@ -1089,7 +1089,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<Camera3DComponent>();
+        auto& c = e.get<Camera3DComponent>();
         c.fov = Converter<float>::read(L, ptr);
         c.pitch = Converter<float>::read(L, ptr);
         assert(ptr == Camera3DComponent_dimension + 2);
@@ -1107,12 +1107,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<Camera3DComponent>());
+        assert(!e.has<Camera3DComponent>());
 
         Camera3DComponent c;
         c.fov = Converter<float>::read(L, ptr);
         c.pitch = Converter<float>::read(L, ptr);
-        e.Add<Camera3DComponent>(c);
+        e.add<Camera3DComponent>(c);
         assert(ptr == Camera3DComponent_dimension + 2);
         return 0;
     });
@@ -1142,10 +1142,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<SelectComponent>());
+        assert(e.has<SelectComponent>());
 
         int count = 0;
-        const auto& c = e.Get<SelectComponent>();
+        const auto& c = e.get<SelectComponent>();
         count += Converter<bool>::push(L, c.selected);
         count += Converter<bool>::push(L, c.hovered);
         assert(count == SelectComponent_dimension);
@@ -1164,7 +1164,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<SelectComponent>();
+        auto& c = e.get<SelectComponent>();
         c.selected = Converter<bool>::read(L, ptr);
         c.hovered = Converter<bool>::read(L, ptr);
         assert(ptr == SelectComponent_dimension + 2);
@@ -1182,12 +1182,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<SelectComponent>());
+        assert(!e.has<SelectComponent>());
 
         SelectComponent c;
         c.selected = Converter<bool>::read(L, ptr);
         c.hovered = Converter<bool>::read(L, ptr);
-        e.Add<SelectComponent>(c);
+        e.add<SelectComponent>(c);
         assert(ptr == SelectComponent_dimension + 2);
         return 0;
     });
@@ -1216,10 +1216,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<PathComponent>());
+        assert(e.has<PathComponent>());
 
         int count = 0;
-        const auto& c = e.Get<PathComponent>();
+        const auto& c = e.get<PathComponent>();
         count += Converter<float>::push(L, c.speed);
         assert(count == PathComponent_dimension);
         return count;
@@ -1237,7 +1237,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<PathComponent>();
+        auto& c = e.get<PathComponent>();
         c.speed = Converter<float>::read(L, ptr);
         assert(ptr == PathComponent_dimension + 2);
         return 0;
@@ -1254,11 +1254,11 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<PathComponent>());
+        assert(!e.has<PathComponent>());
 
         PathComponent c;
         c.speed = Converter<float>::read(L, ptr);
-        e.Add<PathComponent>(c);
+        e.add<PathComponent>(c);
         assert(ptr == PathComponent_dimension + 2);
         return 0;
     });
@@ -1288,10 +1288,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<GridComponent>());
+        assert(e.has<GridComponent>());
 
         int count = 0;
-        const auto& c = e.Get<GridComponent>();
+        const auto& c = e.get<GridComponent>();
         count += Converter<int>::push(L, c.x);
         count += Converter<int>::push(L, c.z);
         assert(count == GridComponent_dimension);
@@ -1310,7 +1310,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<GridComponent>();
+        auto& c = e.get<GridComponent>();
         c.x = Converter<int>::read(L, ptr);
         c.z = Converter<int>::read(L, ptr);
         assert(ptr == GridComponent_dimension + 2);
@@ -1328,12 +1328,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<GridComponent>());
+        assert(!e.has<GridComponent>());
 
         GridComponent c;
         c.x = Converter<int>::read(L, ptr);
         c.z = Converter<int>::read(L, ptr);
-        e.Add<GridComponent>(c);
+        e.add<GridComponent>(c);
         assert(ptr == GridComponent_dimension + 2);
         return 0;
     });
@@ -1363,10 +1363,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<LightComponent>());
+        assert(e.has<LightComponent>());
 
         int count = 0;
-        const auto& c = e.Get<LightComponent>();
+        const auto& c = e.get<LightComponent>();
         count += Converter<glm::vec3>::push(L, c.colour);
         count += Converter<float>::push(L, c.brightness);
         assert(count == LightComponent_dimension);
@@ -1385,7 +1385,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<LightComponent>();
+        auto& c = e.get<LightComponent>();
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
         assert(ptr == LightComponent_dimension + 2);
@@ -1403,12 +1403,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<LightComponent>());
+        assert(!e.has<LightComponent>());
 
         LightComponent c;
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
-        e.Add<LightComponent>(c);
+        e.add<LightComponent>(c);
         assert(ptr == LightComponent_dimension + 2);
         return 0;
     });
@@ -1440,10 +1440,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<SunComponent>());
+        assert(e.has<SunComponent>());
 
         int count = 0;
-        const auto& c = e.Get<SunComponent>();
+        const auto& c = e.get<SunComponent>();
         count += Converter<glm::vec3>::push(L, c.colour);
         count += Converter<float>::push(L, c.brightness);
         count += Converter<glm::vec3>::push(L, c.direction);
@@ -1464,7 +1464,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<SunComponent>();
+        auto& c = e.get<SunComponent>();
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
         c.direction = Converter<glm::vec3>::read(L, ptr);
@@ -1484,14 +1484,14 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<SunComponent>());
+        assert(!e.has<SunComponent>());
 
         SunComponent c;
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
         c.direction = Converter<glm::vec3>::read(L, ptr);
         c.shadows = Converter<bool>::read(L, ptr);
-        e.Add<SunComponent>(c);
+        e.add<SunComponent>(c);
         assert(ptr == SunComponent_dimension + 2);
         return 0;
     });
@@ -1521,10 +1521,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<AmbienceComponent>());
+        assert(e.has<AmbienceComponent>());
 
         int count = 0;
-        const auto& c = e.Get<AmbienceComponent>();
+        const auto& c = e.get<AmbienceComponent>();
         count += Converter<glm::vec3>::push(L, c.colour);
         count += Converter<float>::push(L, c.brightness);
         assert(count == AmbienceComponent_dimension);
@@ -1543,7 +1543,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<AmbienceComponent>();
+        auto& c = e.get<AmbienceComponent>();
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
         assert(ptr == AmbienceComponent_dimension + 2);
@@ -1561,12 +1561,12 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<AmbienceComponent>());
+        assert(!e.has<AmbienceComponent>());
 
         AmbienceComponent c;
         c.colour = Converter<glm::vec3>::read(L, ptr);
         c.brightness = Converter<float>::read(L, ptr);
-        e.Add<AmbienceComponent>(c);
+        e.add<AmbienceComponent>(c);
         assert(ptr == AmbienceComponent_dimension + 2);
         return 0;
     });
@@ -1600,10 +1600,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<ParticleComponent>());
+        assert(e.has<ParticleComponent>());
 
         int count = 0;
-        const auto& c = e.Get<ParticleComponent>();
+        const auto& c = e.get<ParticleComponent>();
         count += Converter<float>::push(L, c.interval);
         count += Converter<glm::vec3>::push(L, c.velocity);
         count += Converter<float>::push(L, c.velocityNoise);
@@ -1626,7 +1626,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<ParticleComponent>();
+        auto& c = e.get<ParticleComponent>();
         c.interval = Converter<float>::read(L, ptr);
         c.velocity = Converter<glm::vec3>::read(L, ptr);
         c.velocityNoise = Converter<float>::read(L, ptr);
@@ -1648,7 +1648,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<ParticleComponent>());
+        assert(!e.has<ParticleComponent>());
 
         ParticleComponent c;
         c.interval = Converter<float>::read(L, ptr);
@@ -1657,7 +1657,7 @@ void load_entity_component_functions(lua::Script& script)
         c.acceleration = Converter<glm::vec3>::read(L, ptr);
         c.scale = Converter<glm::vec3>::read(L, ptr);
         c.life = Converter<float>::read(L, ptr);
-        e.Add<ParticleComponent>(c);
+        e.add<ParticleComponent>(c);
         assert(ptr == ParticleComponent_dimension + 2);
         return 0;
     });
@@ -1688,10 +1688,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<MeshAnimationComponent>());
+        assert(e.has<MeshAnimationComponent>());
 
         int count = 0;
-        const auto& c = e.Get<MeshAnimationComponent>();
+        const auto& c = e.get<MeshAnimationComponent>();
         count += Converter<std::string>::push(L, c.name);
         count += Converter<float>::push(L, c.time);
         count += Converter<float>::push(L, c.speed);
@@ -1711,7 +1711,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<MeshAnimationComponent>();
+        auto& c = e.get<MeshAnimationComponent>();
         c.name = Converter<std::string>::read(L, ptr);
         c.time = Converter<float>::read(L, ptr);
         c.speed = Converter<float>::read(L, ptr);
@@ -1730,13 +1730,13 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<MeshAnimationComponent>());
+        assert(!e.has<MeshAnimationComponent>());
 
         MeshAnimationComponent c;
         c.name = Converter<std::string>::read(L, ptr);
         c.time = Converter<float>::read(L, ptr);
         c.speed = Converter<float>::read(L, ptr);
-        e.Add<MeshAnimationComponent>(c);
+        e.add<MeshAnimationComponent>(c);
         assert(ptr == MeshAnimationComponent_dimension + 2);
         return 0;
     });

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -61,7 +61,7 @@ template <typename T> int _has_impl(lua_State* L)
 {
     if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
     ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-    lua_pushboolean(L, entity.Has<T>());
+    lua_pushboolean(L, entity.has<T>());
     return 1;
 }
 
@@ -76,14 +76,14 @@ void load_registry_functions(lua::Script& script, ecs::Registry& registry)
     lua_register(L, "NewEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         auto luaEntity = static_cast<ecs::Entity*>(lua_newuserdata(L, sizeof(ecs::Entity)));
-        *luaEntity = get_pointer<ecs::Registry>(L, "__registry__")->New();
+        *luaEntity = get_pointer<ecs::Registry>(L, "__registry__")->create();
         return 1;
     });
 
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         auto luaEntity = static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        luaEntity->Delete();
+        luaEntity->destroy();
         return 0;
     });
 
@@ -247,7 +247,7 @@ void load_entity_transformation_functions(lua::Script& script)
         float ty = (float)lua_tonumber(L, 6);
         float tz = (float)lua_tonumber(L, 7);
 
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         tr.position = glm::vec3(px, py, pz);
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, {tx, ty, tz}, {0.0, 1.0, 0.0})));
         return 0;
@@ -263,7 +263,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); };
 
         ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
 
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
@@ -274,11 +274,11 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
         ecs::Entity entity = *static_cast<ecs::Entity*>(lua_touserdata(L, 1));
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         auto o = tr.orientation;
         
-        if (entity.Has<Camera3DComponent>()) {
-            auto pitch = entity.Get<Camera3DComponent>().pitch;
+        if (entity.has<Camera3DComponent>()) {
+            auto pitch = entity.get<Camera3DComponent>().pitch;
             o = glm::rotate(o, pitch, {1, 0, 0});
         }
 
@@ -296,7 +296,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         int ptr = 1;
         ecs::Entity entity = Converter<ecs::Entity>::read(L, ptr);
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         return Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
     });
 
@@ -311,7 +311,7 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
         int ptr = 1;
         ecs::Entity entity = Converter<ecs::Entity>::read(L, ptr);
-        auto& tr = entity.Get<Transform3DComponent>();
+        auto& tr = entity.get<Transform3DComponent>();
         float yaw = Converter<float>::read(L, ptr);
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
@@ -347,10 +347,10 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(e.Has<{{Comp.Name}}>());
+        assert(e.has<{{Comp.Name}}>());
 
         int count = 0;
-        const auto& c = e.Get<{{Comp.Name}}>();
+        const auto& c = e.get<{{Comp.Name}}>();
         count += Converter<{{Attr.Type}}>::push(L, c.{{Attr.Name}});
         assert(count == {{Comp.Name}}_dimension);
         return count;
@@ -365,7 +365,7 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        auto& c = e.Get<{{Comp.Name}}>();
+        auto& c = e.get<{{Comp.Name}}>();
         c.{{Attr.Name}} = Converter<{{Attr.Type}}>::read(L, ptr);
         assert(ptr == {{Comp.Name}}_dimension + 2);
         return 0;
@@ -380,11 +380,11 @@ void load_entity_component_functions(lua::Script& script)
 
         int ptr = 1;
         ecs::Entity e = Converter<ecs::Entity>::read(L, ptr);
-        assert(!e.Has<{{Comp.Name}}>());
+        assert(!e.has<{{Comp.Name}}>());
 
         {{Comp.Name}} c;
         c.{{Attr.Name}} = Converter<{{Attr.Type}}>::read(L, ptr);
-        e.Add<{{Comp.Name}}>(c);
+        e.add<{{Comp.Name}}>(c);
         assert(ptr == {{Comp.Name}}_dimension + 2);
         return 0;
     });

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -96,7 +96,7 @@ void load_registry_functions(lua::Script& script, ecs::Registry& registry)
     
     lua_register(L, "_Each_New", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto gen = new Generator(get_pointer<ecs::Registry>(L, "__registry__")->Each());
+        auto gen = new Generator(get_pointer<ecs::Registry>(L, "__registry__")->all());
         lua_pushlightuserdata(L, static_cast<void*>(gen));
         return 1;
     });

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -47,6 +47,7 @@
 #include "Utility/SparseSet.h"
 #include "Utility/MouseCodes.h"
 #include "Utility/Stopwatch.h"
+#include "Utility/TypeInfo.h"
 #include "Utility/Types.h"
 #include "Utility/Yaml.h"
 

--- a/Sprocket/Utility/Hashing.h
+++ b/Sprocket/Utility/Hashing.h
@@ -15,22 +15,4 @@ struct hash_pair
     } 
 };
 
-template <typename T>
-constexpr std::size_t sdbm_type_hash()
-{
-    std::size_t hash = 0;
-    for (const auto& c : std::string_view{__FUNCSIG__}) {
-        hash = c + 65599 * hash;
-    }
-    return hash;
-};
-
-template <typename T>
-constexpr std::size_t type_hash = sdbm_type_hash<T>();
-
-// Check that it is actually calcualated at compile time
-// Will fail if the function_name source doesnt give unique
-// values on this platform
-static_assert(type_hash<int> != type_hash<float>);
-
 }

--- a/Sprocket/Utility/Hashing.h
+++ b/Sprocket/Utility/Hashing.h
@@ -28,6 +28,9 @@ constexpr std::size_t sdbm_type_hash()
 template <typename T>
 constexpr std::size_t type_hash = sdbm_type_hash<T>();
 
-static_assert(type_hash<int> != 0); // Check that it is actually calcualated at compile time
+// Check that it is actually calcualated at compile time
+// Will fail if the function_name source doesnt give unique
+// values on this platform
+static_assert(type_hash<int> != type_hash<float>);
 
 }

--- a/Sprocket/Utility/InputProxy.cpp
+++ b/Sprocket/Utility/InputProxy.cpp
@@ -10,7 +10,28 @@ InputProxy::InputProxy()
     d_keyboard.fill(false);
     d_mouse.fill(false);
 }
-    
+
+void InputProxy::on_startup(ev::Dispatcher& dispatcher)
+{
+    dispatcher.subscribe<ev::KeyboardButtonPressed>([&](ev::Event& event) {
+        if (event.is_consumed()) { return; }
+        d_keyboard[event.get<ev::KeyboardButtonPressed>().key] = true;
+    });
+
+    dispatcher.subscribe<ev::KeyboardButtonReleased>([&](ev::Event& event) {
+        d_keyboard[event.get<ev::KeyboardButtonReleased>().key] = false;
+    });
+
+    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event) {
+        if (event.is_consumed()) { return; }
+        d_mouse[event.get<ev::MouseButtonPressed>().button] = true;
+    });
+
+    dispatcher.subscribe<ev::MouseButtonReleased>([&](ev::Event& event) {
+        d_mouse[event.get<ev::MouseButtonReleased>().button] = false;
+    });
+}
+  
 void InputProxy::on_event(ev::Event& event)
 {
     if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {

--- a/Sprocket/Utility/InputProxy.h
+++ b/Sprocket/Utility/InputProxy.h
@@ -2,7 +2,7 @@
 #include <array>
 
 namespace Sprocket {
-namespace ev { class Event; }
+namespace ev { class Event; class Dispatcher; }
 
 class InputProxy
 {
@@ -16,6 +16,7 @@ private:
 public:
     InputProxy();
 
+    void on_startup(ev::Dispatcher& dispatcher);
     void on_event(ev::Event& event);
 
     bool is_mouse_down(int button) const;

--- a/Sprocket/Utility/TypeInfo.h
+++ b/Sprocket/Utility/TypeInfo.h
@@ -1,8 +1,8 @@
-#include <Sprocket.h>
+#pragma once
+#include <string_view>
+#include <cstddef>
 
-#include "Game.h"
-
-using namespace Sprocket;
+namespace spkt {
 
 template <typename T>
 constexpr std::string_view type_name_raw() {
@@ -38,41 +38,32 @@ constexpr std::size_t sdbm_type_hash()
     return hash;
 };
 
-struct type_index
+struct type_info_t
 {
     const std::string_view name;
     const std::size_t      hash;
 
-    type_index(std::string_view name, std::size_t hash)
+    type_info_t(std::string_view name, std::size_t hash)
         : name(name)
         , hash(hash)
     {}
-};
 
-struct foo
-{
-    const char* x;
-    std::size_t y;
+    bool operator==(const type_info_t& other) const
+    {
+        return name == other.name && hash == other.hash;
+    }
 };
 
 template <typename T>
-type_index get_type_index()
-{
-    return {type_name<T>(), sdbm_type_hash<T>()};
+inline const type_info_t type_info = type_info_t(type_name<T>(), sdbm_type_hash<T>());
+
 }
 
-using XX = int;
-
-int main()
+template <>
+struct std::hash<spkt::type_info_t>
 {
-    //Sprocket::Window window("Game");
-    //WorldLayer game(&window);
-    //Sprocket::RunOptions options;
-    //options.showFramerate = true;
-    //return Sprocket::Run(game, window, options);
-    
-    auto index = get_type_index<Sprocket::ecs::Registry>();
-    log::info("{}", index.name);
-    log::info("{}", index.hash);
-    log::info("{}", sizeof(foo));
-}
+    std::size_t operator()(const spkt::type_info_t& info) const noexcept
+    {
+        return info.hash;
+    };
+};

--- a/Sprocket/Utility/TypeInfo.h
+++ b/Sprocket/Utility/TypeInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string_view>
 #include <cstddef>
+#include <memory>
 
 namespace spkt {
 
@@ -43,9 +44,10 @@ struct type_info_t
     const std::string_view name;
     const std::size_t      hash;
 
-    type_info_t(std::string_view name, std::size_t hash)
-        : name(name)
-        , hash(hash)
+    template <typename T>
+    explicit type_info_t(std::in_place_type_t<T>)
+        : name(type_name<T>())
+        , hash(sdbm_type_hash<T>())
     {}
 
     bool operator==(const type_info_t& other) const
@@ -55,7 +57,7 @@ struct type_info_t
 };
 
 template <typename T>
-inline const type_info_t type_info = type_info_t(type_name<T>(), sdbm_type_hash<T>());
+inline const type_info_t type_info = type_info_t(std::in_place_type<T>);
 
 }
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -80,7 +80,7 @@ Collapsed=1
 
 [Window][Viewport]
 Pos=0,21
-Size=1609,1059
+Size=1609,996
 Collapsed=0
 DockId=0x00000004,0
 
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=1611,609
-Size=309,370
+Pos=1611,574
+Size=309,348
 Collapsed=0
 DockId=0x00000005,0
 
@@ -132,7 +132,7 @@ Collapsed=0
 
 [Window][Explorer]
 Pos=1611,21
-Size=309,586
+Size=309,551
 Collapsed=0
 DockId=0x00000003,0
 
@@ -143,7 +143,7 @@ Collapsed=0
 
 [Window][DockSpaceViewport_11111111]
 Pos=0,21
-Size=1920,1059
+Size=1920,996
 Collapsed=0
 
 [Window][Colour Scheme Picker]
@@ -157,14 +157,14 @@ Size=277,422
 Collapsed=0
 
 [Window][Options]
-Pos=1611,981
-Size=309,99
+Pos=1611,924
+Size=309,93
 Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1920,1059 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=969,699 CentralNode=1 Selected=0x995B0CF8
+DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1920,996 Split=X Selected=0x995B0CF8
+  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=1609,699 CentralNode=1 Selected=0x995B0CF8
   DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=309,699 Split=Y Selected=0x1E89CEB8
     DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0x1E89CEB8
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=309,386 Selected=0x1E89CEB8


### PR DESCRIPTION
- Added `ev::Dispatcher` which offers two functions, `subscribe<Event>(<callback>)` and `publish<Event>`. The intention here is that several objects can subscribe to certain events and then the dispatcher is responsible for forwards events to them. This is preferred to those objects implementing `on_event` because then they only get given the events they want.
- `ev::Dispatcher::subscribe` can take two kinds of callable, `std::function<void(ev::Event&)>` and `std::function<void(ev::Event&, const T&)>`, the latter also providing the data in the event so that a call to `event.get` isn't needed.
- Added `TypeInfo.h`, expanding the type hashing from an earlier commit. This implements a compile-time `type_info` which can also be used as a hash key. This also keep a pretty type name.
- Removed `on_event` from scene systems. All systems now receive a dispatcher in their `on_startup` and `on_update` functions. They can subscribe in the `on_startup` functions and publish events in the `on_update` functions.
- `Scene` hooks up the `ecs::Registry` to publish component added/removed events to the systems.
- `ScriptRunner` currently only forwards a small amount of events to script, it will need to be updated whenever new events are needed.
- `ecs` is now snake_case formatted.