### PR TITLE
Reflect Datamatic Update

### DIFF
--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -16,14 +16,14 @@ void Inspector::Show(Anvil& editor)
 
     if (!editor.Selected().valid()) {
         if (ImGui::Button("New Entity")) {
-            auto e = editor.GetScene()->Entities().create();
+            auto e = apx::create_from(editor.GetScene()->Entities());
             editor.SetSelected(e);
         }
         return;
     }
     int count = 0;
 
-    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity.id());
+    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity.entity());
 
 #ifdef DATAMATIC_BLOCK
     if (entity.has<{{Comp.Name}}>()) {

--- a/Anvil/Panels/Inspector.dm.cpp
+++ b/Anvil/Panels/Inspector.dm.cpp
@@ -26,13 +26,13 @@ void Inspector::Show(Anvil& editor)
     ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity.entity());
 
 #ifdef DATAMATIC_BLOCK
-    if (entity.has<{{Comp.Name}}>()) {
-        auto& c = entity.get<{{Comp.Name}}>();
-        if (ImGui::CollapsingHeader("{{Comp.DisplayName}}")) {
+    if (entity.has<{{Comp.name}}>()) {
+        auto& c = entity.get<{{Comp.name}}>();
+        if (ImGui::CollapsingHeader("{{Comp.display_name}}")) {
             ImGui::PushID(count++);
             {{Attr.Inspector.Display}};
             {{Comp.Inspector.GuizmoSettings}}
-            if (ImGui::Button("Delete")) { entity.remove<{{Comp.Name}}>(); }
+            if (ImGui::Button("Delete")) { entity.remove<{{Comp.name}}>(); }
             ImGui::PopID();
         }
     }
@@ -46,9 +46,9 @@ void Inspector::Show(Anvil& editor)
 
     if (ImGui::BeginPopup("missing_components_list")) {
 #ifdef DATAMATIC_BLOCK
-        if (!entity.has<{{Comp.Name}}>() && ImGui::Selectable("{{Comp.DisplayName}}")) {
-            {{Comp.Name}} c;
-            entity.add<{{Comp.Name}}>(c);
+        if (!entity.has<{{Comp.name}}>() && ImGui::Selectable("{{Comp.display_name}}")) {
+            {{Comp.name}} c;
+            entity.add<{{Comp.name}}>(c);
         }
 #endif
         ImGui::EndMenu();

--- a/Anvil/Panels/Inspector.dmx.py
+++ b/Anvil/Panels/Inspector.dmx.py
@@ -4,13 +4,13 @@ from Datamatic import Types
 class Inspector(Plugin):
 
     @compmethod
-    def GuizmoSettings(comp, flags):
+    def GuizmoSettings(comp):
         if comp["Name"] == "Transform3DComponent":
             return "ImGuiXtra::GuizmoSettings(d_operation, d_mode, d_useSnap, d_snap);"
         return ""
 
     @attrmethod
-    def Display(attr, flags):
+    def Display(attr):
         name = attr["Name"]
         display = attr["DisplayName"]
         cpp_type = attr["Type"]

--- a/Anvil/Panels/Inspector.dmx.py
+++ b/Anvil/Panels/Inspector.dmx.py
@@ -4,13 +4,13 @@ from Datamatic import Types
 class Inspector(Plugin):
 
     @compmethod
-    def GuizmoSettings(comp):
+    def GuizmoSettings(cls, comp):
         if comp["Name"] == "Transform3DComponent":
             return "ImGuiXtra::GuizmoSettings(d_operation, d_mode, d_useSnap, d_snap);"
         return ""
 
     @attrmethod
-    def Display(attr):
+    def Display(cls, attr):
         name = attr["Name"]
         display = attr["DisplayName"]
         cpp_type = attr["Type"]

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -7,9 +7,9 @@ namespace Sprocket{
 
 // Components
 #ifdef DATAMATIC_BLOCK
-struct {{Comp.Name}}
+struct {{Comp.name}}
 {
-    {{Attr.Type}} {{Attr.Name}} = {{Attr.Default}};
+    {{Attr.type}} {{Attr.name}} = {{Attr.default}};
 };
 
 #endif

--- a/Sprocket/Scene/ECS.dm.h
+++ b/Sprocket/Scene/ECS.dm.h
@@ -11,7 +11,7 @@ namespace spkt {
 // it would know if the current component is the last one.
 using registry = apx::registry<
 #ifdef DATAMATIC_BLOCK
-    Sprocket::{{Comp.Name}},
+    Sprocket::{{Comp.Name}}{{Comp.format.comma}}
 #endif
 >;
 

--- a/Sprocket/Scene/ECS.dm.h
+++ b/Sprocket/Scene/ECS.dm.h
@@ -11,7 +11,7 @@ namespace spkt {
 // it would know if the current component is the last one.
 using registry = apx::registry<
 #ifdef DATAMATIC_BLOCK
-    Sprocket::{{Comp.Name}}{{Comp.conditional.if_not_last|,}}
+    Sprocket::{{Comp.name}}{{Comp.if_not_last|,}}
 #endif
 >;
 

--- a/Sprocket/Scene/ECS.dm.h
+++ b/Sprocket/Scene/ECS.dm.h
@@ -11,7 +11,7 @@ namespace spkt {
 // it would know if the current component is the last one.
 using registry = apx::registry<
 #ifdef DATAMATIC_BLOCK
-    Sprocket::{{Comp.Name}}{{Comp.format.comma}}
+    Sprocket::{{Comp.Name}}{{Comp.conditional.if_not_last|,}}
 #endif
 >;
 

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -439,7 +439,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
         if (src.has<TemporaryComponent>()) {
             const TemporaryComponent& source_comp = src.get<TemporaryComponent>();
             TemporaryComponent target_comp;
-            dst.add(target_comp);
+            dst.add<TemporaryComponent>(target_comp);
         }
         if (src.has<NameComponent>()) {
             const NameComponent& source_comp = src.get<NameComponent>();

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -23,10 +23,10 @@ void Save(const std::string& file, spkt::registry* reg)
         out << YAML::BeginMap;
         out << YAML::Key << "ID#" << YAML::Value << id;
 #ifdef DATAMATIC_BLOCK SAVABLE=true
-        if (entity.has<{{Comp.Name}}>()) {
-            const auto& c = entity.get<{{Comp.Name}}>();
-            out << YAML::Key << "{{Comp.Name}}" << YAML::BeginMap;
-            out << YAML::Key << "{{Attr.Name}}" << YAML::Value << c.{{Attr.Name}};
+        if (entity.has<{{Comp.name}}>()) {
+            const auto& c = entity.get<{{Comp.name}}>();
+            out << YAML::Key << "{{Comp.name}}" << YAML::BeginMap;
+            out << YAML::Key << "{{Attr.name}}" << YAML::Value << c.{{Attr.name}};
             out << YAML::EndMap;
         }
 #endif
@@ -81,10 +81,10 @@ void Load(const std::string& file, spkt::registry* reg)
         spkt::identifier old_id = entity["ID#"].as<spkt::identifier>();
         spkt::entity e{*reg, id_remapper[old_id]};
 #ifdef DATAMATIC_BLOCK SAVABLE=true
-        if (auto spec = entity["{{Comp.Name}}"]) {
-            {{Comp.Name}} c;
-            c.{{Attr.Name}} = transform(spec["{{Attr.Name}}"].as<{{Attr.Type}}>());
-            e.add<{{Comp.Name}}>(c);
+        if (auto spec = entity["{{Comp.name}}"]) {
+            {{Comp.name}} c;
+            c.{{Attr.name}} = transform(spec["{{Attr.name}}"].as<{{Attr.type}}>());
+            e.add<{{Comp.name}}>(c);
         }
 #endif
     }
@@ -94,8 +94,8 @@ spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
 {
     spkt::entity e = apx::create_from(*reg);
 #ifdef DATAMATIC_BLOCK
-    if (entity.has<{{Comp.Name}}>()) {
-        e.add<{{Comp.Name}}>(entity.get<{{Comp.Name}}>());
+    if (entity.has<{{Comp.name}}>()) {
+        e.add<{{Comp.name}}>(entity.get<{{Comp.name}}>());
     }
 #endif
     return e;
@@ -122,11 +122,11 @@ void Copy(spkt::registry* source, spkt::registry* target)
         spkt::entity src{*source, id};
         spkt::entity dst{*target, id_remapper[id]};
 #ifdef DATAMATIC_BLOCK
-        if (src.has<{{Comp.Name}}>()) {
-            const {{Comp.Name}}& source_comp = src.get<{{Comp.Name}}>();
-            {{Comp.Name}} target_comp;
-            target_comp.{{Attr.Name}} = transform(source_comp.{{Attr.Name}});
-            dst.add<{{Comp.Name}}>(target_comp);
+        if (src.has<{{Comp.name}}>()) {
+            const {{Comp.name}}& source_comp = src.get<{{Comp.name}}>();
+            {{Comp.name}} target_comp;
+            target_comp.{{Attr.name}} = transform(source_comp.{{Attr.name}});
+            dst.add<{{Comp.name}}>(target_comp);
         }
 #endif
     }

--- a/Sprocket/Scripting/Lua.dmx.py
+++ b/Sprocket/Scripting/Lua.dmx.py
@@ -12,7 +12,7 @@ def from_attr(attr):
 class Lua(Plugin):
 
     @compmethod
-    def dimension(comp):
+    def dimension(cls, comp):
         count = 0
         for attr in comp['Attributes']:
             if attr["Flags"]["SCRIPTABLE"]:
@@ -20,11 +20,11 @@ class Lua(Plugin):
         return str(count)
     
     @compmethod
-    def Sig(comp):
+    def Sig(cls, comp):
         return ", ".join(attr['Name'] for attr in comp['Attributes'] if attr["Flags"]["SCRIPTABLE"])
 
-    @staticmethod
-    def get_attr_count_and_sig(comp):
+    @classmethod
+    def get_attr_count_and_sig(cls, comp):
         num_attrs = 0
         constructor_sig = []
         for attr in comp["Attributes"]:
@@ -45,9 +45,9 @@ class Lua(Plugin):
         return num_attrs, constructor_sig
 
     @compmethod
-    def Getter(comp):
+    def Getter(cls, comp):
         out = ""
-        num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
+        num_attrs, constructor_sig = cls.get_attr_count_and_sig(comp)
         name = comp["Name"]
         indent = " " * 8 # We indent extra to make the generated C++ file look nicer
 
@@ -59,9 +59,9 @@ class Lua(Plugin):
         return out
 
     @compmethod
-    def Setter(comp):
+    def Setter(cls, comp):
         out = ""
-        num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
+        num_attrs, constructor_sig = cls.get_attr_count_and_sig(comp)
         name = comp["Name"]
         indent = " " * 8 # We indent extra to make the generated C++ file look nicer
 
@@ -82,9 +82,9 @@ class Lua(Plugin):
         return out
 
     @compmethod
-    def Adder(comp):
+    def Adder(cls, comp):
         out = ""
-        num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
+        num_attrs, constructor_sig = cls.get_attr_count_and_sig(comp)
         name = comp["Name"]
         indent = " " * 8 # We indent extra to make the generated C++ file look nicer
 

--- a/Sprocket/Scripting/Lua.dmx.py
+++ b/Sprocket/Scripting/Lua.dmx.py
@@ -12,7 +12,7 @@ def from_attr(attr):
 class Lua(Plugin):
 
     @compmethod
-    def dimension(comp, flags):
+    def dimension(comp):
         count = 0
         for attr in comp['Attributes']:
             if attr["Flags"]["SCRIPTABLE"]:
@@ -20,7 +20,7 @@ class Lua(Plugin):
         return str(count)
     
     @compmethod
-    def Sig(comp, flags):
+    def Sig(comp):
         return ", ".join(attr['Name'] for attr in comp['Attributes'] if attr["Flags"]["SCRIPTABLE"])
 
     @staticmethod
@@ -45,7 +45,7 @@ class Lua(Plugin):
         return num_attrs, constructor_sig
 
     @compmethod
-    def Getter(comp, flags):
+    def Getter(comp):
         out = ""
         num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
         name = comp["Name"]
@@ -59,7 +59,7 @@ class Lua(Plugin):
         return out
 
     @compmethod
-    def Setter(comp, flags):
+    def Setter(comp):
         out = ""
         num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
         name = comp["Name"]
@@ -82,7 +82,7 @@ class Lua(Plugin):
         return out
 
     @compmethod
-    def Adder(comp, flags):
+    def Adder(comp):
         out = ""
         num_attrs, constructor_sig = Lua.get_attr_count_and_sig(comp)
         name = comp["Name"]

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -336,27 +336,27 @@ void load_entity_component_functions(lua::Script& script)
     lua_State* L = script.native_handle();
 
 #ifdef DATAMATIC_BLOCK SCRIPTABLE=true
-    // Functions for {{Comp.Name}} =====================================================
+    // Functions for {{Comp.name}} =====================================================
 
-    constexpr int {{Comp.Name}}_dimension = {{Comp.Lua.dimension}};
+    constexpr int {{Comp.name}}_dimension = {{Comp.Lua.dimension}};
 
     luaL_dostring(L, R"lua(
-        {{Comp.Name}} = Class(function(self, {{Comp.Lua.Sig}})
-            self.{{Attr.Name}} = {{Attr.Name}}
+        {{Comp.name}} = Class(function(self, {{Comp.Lua.Sig}})
+            self.{{Attr.name}} = {{Attr.name}}
         end)
     )lua");
 
-    lua_register(L, "_Get{{Comp.Name}}", [](lua_State* L) {
+    lua_register(L, "_Get{{Comp.name}}", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
 
         int ptr = 1;
         spkt::entity e = Converter<spkt::entity>::read(L, ptr);
-        assert(e.has<{{Comp.Name}}>());
+        assert(e.has<{{Comp.name}}>());
 
         int count = 0;
-        const auto& c = e.get<{{Comp.Name}}>();
-        count += Converter<{{Attr.Type}}>::push(L, c.{{Attr.Name}});
-        assert(count == {{Comp.Name}}_dimension);
+        const auto& c = e.get<{{Comp.name}}>();
+        count += Converter<{{Attr.type}}>::push(L, c.{{Attr.name}});
+        assert(count == {{Comp.name}}_dimension);
         return count;
     });
 
@@ -364,14 +364,14 @@ void load_entity_component_functions(lua::Script& script)
         {{Comp.Lua.Getter}}
     )lua");
 
-    lua_register(L, "_Set{{Comp.Name}}", [](lua_State* L) {
-        if (!CheckArgCount(L, {{Comp.Name}}_dimension + 1)) { return luaL_error(L, "Bad number of args"); }
+    lua_register(L, "_Set{{Comp.name}}", [](lua_State* L) {
+        if (!CheckArgCount(L, {{Comp.name}}_dimension + 1)) { return luaL_error(L, "Bad number of args"); }
 
         int ptr = 1;
         spkt::entity e = Converter<spkt::entity>::read(L, ptr);
-        auto& c = e.get<{{Comp.Name}}>();
-        c.{{Attr.Name}} = Converter<{{Attr.Type}}>::read(L, ptr);
-        assert(ptr == {{Comp.Name}}_dimension + 2);
+        auto& c = e.get<{{Comp.name}}>();
+        c.{{Attr.name}} = Converter<{{Attr.type}}>::read(L, ptr);
+        assert(ptr == {{Comp.name}}_dimension + 2);
         return 0;
     });
 
@@ -379,17 +379,17 @@ void load_entity_component_functions(lua::Script& script)
         {{Comp.Lua.Setter}}
     )lua");
 
-    lua_register(L, "_Add{{Comp.Name}}", [](lua_State* L) {
-        if (!CheckArgCount(L, {{Comp.Name}}_dimension + 1)) { return luaL_error(L, "Bad number of args"); }
+    lua_register(L, "_Add{{Comp.name}}", [](lua_State* L) {
+        if (!CheckArgCount(L, {{Comp.name}}_dimension + 1)) { return luaL_error(L, "Bad number of args"); }
 
         int ptr = 1;
         spkt::entity e = Converter<spkt::entity>::read(L, ptr);
-        assert(!e.has<{{Comp.Name}}>());
+        assert(!e.has<{{Comp.name}}>());
 
-        {{Comp.Name}} c;
-        c.{{Attr.Name}} = Converter<{{Attr.Type}}>::read(L, ptr);
-        e.add<{{Comp.Name}}>(c);
-        assert(ptr == {{Comp.Name}}_dimension + 2);
+        {{Comp.name}} c;
+        c.{{Attr.name}} = Converter<{{Attr.type}}>::read(L, ptr);
+        e.add<{{Comp.name}}>(c);
+        assert(ptr == {{Comp.name}}_dimension + 2);
         return 0;
     });
 
@@ -397,7 +397,7 @@ void load_entity_component_functions(lua::Script& script)
         {{Comp.Lua.Adder}}
     )lua");
 
-    lua_register(L, "Has{{Comp.Name}}", &_has_impl<{{Comp.Name}}>);
+    lua_register(L, "Has{{Comp.name}}", &_has_impl<{{Comp.name}}>);
 
 
 #endif


### PR DESCRIPTION
* Fix generated code that was still broken from previous commit.
* Update datamatic templates to make use of newer version. This is essentially renaming the accessor tokens to be snake case, and making use of `builtin.if_not_last` when generating the `Scene` typedef.