### PR TITLE
Use Datamatic Parametrised and Templatised Type Parsers

### DIFF
--- a/Sprocket/Utility/Maths.dmx.py
+++ b/Sprocket/Utility/Maths.dmx.py
@@ -3,27 +3,13 @@ A module for loading in the Maths types to Datamatic.
 """
 from Datamatic.Types import parse
 
-@parse.register("glm::vec2")
-def _(typename, obj) -> str:
+@parse.register("glm::vec2", length=2)
+@parse.register("glm::vec3", length=3)
+@parse.register("glm::vec4", length=4)
+@parse.register("glm::quat", length=4)
+def _(typename, obj, length) -> str:
     assert isinstance(obj, list)
-    assert len(obj) == 2
-    rep = ", ".join(parse("float", val) for val in obj)
-    return f"{typename}{{{rep}}}"
-
-
-@parse.register("glm::vec3")
-def _(typename, obj) -> str:
-    assert isinstance(obj, list)
-    assert len(obj) == 3
-    rep = ", ".join(parse("float", val) for val in obj)
-    return f"{typename}{{{rep}}}"
-
-
-@parse.register("glm::vec4")
-@parse.register("glm::quat")
-def _(typename, obj) -> str:
-    assert isinstance(obj, list)
-    assert len(obj) == 4
+    assert len(obj) == length
     rep = ", ".join(parse("float", val) for val in obj)
     return f"{typename}{{{rep}}}"
 
@@ -42,3 +28,6 @@ def _(typename, obj) -> str:
 @parse.register("std::queue<glm::vec3>") # TODO: Implement
 def _(typename, obj) -> str:
     return f"{typename}{{}}"
+
+@parse.template_register("std::queue<{}>")
+def _(typename, template_typename, obj):

--- a/Sprocket/Utility/Maths.dmx.py
+++ b/Sprocket/Utility/Maths.dmx.py
@@ -28,6 +28,3 @@ def _(typename, obj) -> str:
 @parse.register("std::queue<glm::vec3>") # TODO: Implement
 def _(typename, obj) -> str:
     return f"{typename}{{}}"
-
-@parse.template_register("std::queue<{}>")
-def _(typename, template_typename, obj):

--- a/Sprocket/Utility/Maths.dmx.py
+++ b/Sprocket/Utility/Maths.dmx.py
@@ -23,8 +23,3 @@ def _(typename, obj) -> str:
 @parse.register("glm::mat4") # TODO: Implement
 def _(typename, obj) -> str:
     return f"{typename}{{1.0}}"
-
-
-@parse.register("std::queue<glm::vec3>") # TODO: Implement
-def _(typename, obj) -> str:
-    return f"{typename}{{}}"

--- a/Sprocket/Utility/Maths.dmx.py
+++ b/Sprocket/Utility/Maths.dmx.py
@@ -3,6 +3,7 @@ A module for loading in the Maths types to Datamatic.
 """
 from Datamatic.Types import parse
 
+
 @parse.register("glm::vec2", length=2)
 @parse.register("glm::vec3", length=3)
 @parse.register("glm::vec4", length=4)


### PR DESCRIPTION
* Combine all `glm` parser definitions into one via a parametrised parser.
* Remove the parser for `std::queue<glm::vec3>` since datamatic now has a templatised parser for `std::queue<T>` so only a parser for `glm::vec3` is needed.