### PR TITLE
Simplify the Lua Converter

### DIFF
--- a/Sprocket/Scripting/LuaConverter.cpp
+++ b/Sprocket/Scripting/LuaConverter.cpp
@@ -7,17 +7,9 @@
 namespace Sprocket {
 namespace lua {
 
-int Converter<int>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<int>::push(lua_State* L, const int& value)
+void Converter<int>::push(lua_State* L, const int& value)
 {
     lua_pushinteger(L, value);
-    return 1;
 }
 
 int Converter<int>::read(lua_State* L, int index)
@@ -26,18 +18,9 @@ int Converter<int>::read(lua_State* L, int index)
     return static_cast<int>(lua_tointeger(L, index));
 }
 
-
-u32 Converter<u32>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<u32>::push(lua_State* L, const u32& value)
+void Converter<u32>::push(lua_State* L, const u32& value)
 {
     lua_pushinteger(L, value);
-    return 1;
 }
 
 u32 Converter<u32>::read(lua_State* L, int index)
@@ -46,18 +29,9 @@ u32 Converter<u32>::read(lua_State* L, int index)
     return static_cast<u32>(lua_tointeger(L, index));
 }
 
-
-bool Converter<bool>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<bool>::push(lua_State* L, const bool& value)
+void Converter<bool>::push(lua_State* L, const bool& value)
 {
     lua_pushboolean(L, value);
-    return 1;
 }
 
 bool Converter<bool>::read(lua_State* L, int index)
@@ -66,18 +40,9 @@ bool Converter<bool>::read(lua_State* L, int index)
     return static_cast<bool>(lua_toboolean(L, index));
 }
 
-
-float Converter<float>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<float>::push(lua_State* L, const float& value)
+void Converter<float>::push(lua_State* L, const float& value)
 {
     lua_pushnumber(L, value);
-    return 1;
 }
 
 float Converter<float>::read(lua_State* L, int index)
@@ -86,18 +51,9 @@ float Converter<float>::read(lua_State* L, int index)
     return static_cast<float>(lua_tonumber(L, index));
 }
 
-
-double Converter<double>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<double>::push(lua_State* L, const double& value)
+void Converter<double>::push(lua_State* L, const double& value)
 {
     lua_pushnumber(L, value);
-    return 1;
 }
 
 double Converter<double>::read(lua_State* L, int index)
@@ -106,18 +62,9 @@ double Converter<double>::read(lua_State* L, int index)
     return static_cast<double>(lua_tonumber(L, index));
 }
 
-
-const char* Converter<const char*>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<const char*>::push(lua_State* L, const char* value)
+void Converter<const char*>::push(lua_State* L, const char* value)
 {
     lua_pushstring(L, value);
-    return 1;
 }
 
 const char* Converter<const char*>::read(lua_State* L, int index)
@@ -126,18 +73,9 @@ const char* Converter<const char*>::read(lua_State* L, int index)
     return lua_tostring(L, index);
 }
 
-
-std::string Converter<std::string>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<std::string>::push(lua_State* L, const std::string& value)
+void Converter<std::string>::push(lua_State* L, const std::string& value)
 {
     lua_pushstring(L, value.c_str());
-    return 1;
 }
 
 std::string Converter<std::string>::read(lua_State* L, int index)
@@ -146,18 +84,9 @@ std::string Converter<std::string>::read(lua_State* L, int index)
     return lua_tostring(L, index);
 }
 
-
-void* Converter<void*>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<void*>::push(lua_State* L, void* value)
+void Converter<void*>::push(lua_State* L, void* value)
 {
     lua_pushlightuserdata(L, value);
-    return 1;
 }
 
 void* Converter<void*>::read(lua_State* L, int index)
@@ -166,19 +95,10 @@ void* Converter<void*>::read(lua_State* L, int index)
     return lua_touserdata(L, index);
 }
 
-
-spkt::entity Converter<spkt::entity>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<spkt::entity>::push(lua_State* L, const spkt::entity& value)
+void Converter<spkt::entity>::push(lua_State* L, const spkt::entity& value)
 {
     spkt::entity* handle = static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
     *handle = value;
-    return 1;
 }
 
 spkt::entity Converter<spkt::entity>::read(lua_State* L, int index)
@@ -187,19 +107,10 @@ spkt::entity Converter<spkt::entity>::read(lua_State* L, int index)
     return *static_cast<spkt::entity*>(lua_touserdata(L, index));
 }
 
-
-spkt::identifier Converter<spkt::identifier>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<spkt::identifier>::push(lua_State* L, const spkt::identifier& value)
+void Converter<spkt::identifier>::push(lua_State* L, const spkt::identifier& value)
 {
     spkt::identifier* handle = static_cast<spkt::identifier*>(lua_newuserdata(L, sizeof(spkt::identifier)));
     *handle = value;
-    return 1;
 }
 
 spkt::identifier Converter<spkt::identifier>::read(lua_State* L, int index)
@@ -208,20 +119,11 @@ spkt::identifier Converter<spkt::identifier>::read(lua_State* L, int index)
     return *static_cast<spkt::identifier*>(lua_touserdata(L, index));
 }
 
-
-glm::vec2 Converter<glm::vec2>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<glm::vec2>::push(lua_State* L, const glm::vec2& value)
+void Converter<glm::vec2>::push(lua_State* L, const glm::vec2& value)
 {
     glm::vec2* vec = (glm::vec2*)lua_newuserdata(L, sizeof(glm::vec2));
     *vec = value;
     luaL_setmetatable(L, "vec2");
-    return 1;
 }
 
 glm::vec2 Converter<glm::vec2>::read(lua_State* L, int index)
@@ -229,20 +131,11 @@ glm::vec2 Converter<glm::vec2>::read(lua_State* L, int index)
     return *(glm::vec2*)luaL_checkudata(L, index, "vec2");
 }
 
-
-glm::vec3 Converter<glm::vec3>::pop(lua_State* L)
-{
-    auto ret = read(L, -1);
-    lua_pop(L, 1);
-    return ret;
-}
-
-int Converter<glm::vec3>::push(lua_State* L, const glm::vec3& value)
+void Converter<glm::vec3>::push(lua_State* L, const glm::vec3& value)
 {
     glm::vec3* vec = (glm::vec3*)lua_newuserdata(L, sizeof(glm::vec3));
     *vec = value;
     luaL_setmetatable(L, "vec3");
-    return 1;
 }
 
 glm::vec3 Converter<glm::vec3>::read(lua_State* L, int index)

--- a/Sprocket/Scripting/LuaConverter.h
+++ b/Sprocket/Scripting/LuaConverter.h
@@ -14,79 +14,64 @@ namespace lua {
 
 template <typename T> struct Converter
 {
-    // Pops from the top of the Lua stack.
-    static T pop(lua_State* L) { static_assert(false); }
-
-    // Pushes to the top of the Lua stack. Returns the dimension.
-    static int push(lua_State* L, const T& value) { static_assert(false); }
+    // Pushes to the top of the Lua stack.
+    static void push(lua_State* L, const T& value) { static_assert(false); }
     
-    // Reads at the given position in the Lua stack, advancing the pointer
-    // to the position after the last element used by this type.
+    // Reads the value at the given index in the Lua stack.
     static T read(lua_State* L, int index) { static_assert(false); }
 };
 
 template <> struct Converter<int>
 {
-    static int pop(lua_State* L);
-    static int push(lua_State* L, const int& value);
+    static void push(lua_State* L, const int& value);
     static int read(lua_State* L, int index);
 };
 
 template <> struct Converter<u32>
 {
-    static u32 pop(lua_State* L);
-    static int push(lua_State* L, const u32& value);
+    static void push(lua_State* L, const u32& value);
     static u32 read(lua_State* L, int index);
 };
 
 template <> struct Converter<bool>
 {
-    static bool pop(lua_State* L);
-    static int push(lua_State* L, const bool& value);
+    static void push(lua_State* L, const bool& value);
     static bool read(lua_State* L, int index);
 };
 
 template <> struct Converter<float>
 {
-    static float pop(lua_State* L);
-    static int push(lua_State* L, const float& value);
+    static void push(lua_State* L, const float& value);
     static float read(lua_State* L, int index);
 };
 
 template <> struct Converter<double>
 {
-    static double pop(lua_State* L);
-    static int push(lua_State* L, const double& value);
+    static void push(lua_State* L, const double& value);
     static double read(lua_State* L, int index);
 };
 
 template <> struct Converter<const char*>
 {
-    static const char* pop(lua_State* L);
-    static int push(lua_State* L, const char* value);
+    static void push(lua_State* L, const char* value);
     static const char* read(lua_State* L, int index);
 };
 
 template <> struct Converter<std::string>
 {
-    static std::string pop(lua_State* L);
-    static int push(lua_State* L, const std::string& value);
+    static void push(lua_State* L, const std::string& value);
     static std::string read(lua_State* L, int index);
 };
 
 template <> struct Converter<void*>
 {
-    static void* pop(lua_State* L);
-    static int push(lua_State* L, void* value);
+    static void push(lua_State* L, void* value);
     static void* read(lua_State* L, int index);
 };
 
 template <typename T> struct Converter<T*>
 {
-    static T* pop(lua_State* L) {
-        return (T*)Converter<void*>::pop(L);
-    }
-    static int push(lua_State* L, T* value) {
+    static void push(lua_State* L, T* value) {
         return Converter<void*>::push(L, (void*)value);
     }
     static T* read(lua_State* L, int index) {
@@ -96,29 +81,25 @@ template <typename T> struct Converter<T*>
 
 template <> struct Converter<spkt::entity>
 {
-    static spkt::entity pop(lua_State* L);
-    static int push(lua_State* L, const spkt::entity& value);
+    static void push(lua_State* L, const spkt::entity& value);
     static spkt::entity read(lua_State* L, int index);
 };
 
 template <> struct Converter<spkt::identifier>
 {
-    static spkt::identifier pop(lua_State* L);
-    static int push(lua_State* L, const spkt::identifier& value);
+    static void push(lua_State* L, const spkt::identifier& value);
     static spkt::identifier read(lua_State* L, int index);
 };
 
 template <> struct Converter<glm::vec2>
 {
-    static glm::vec2 pop(lua_State* L);
-    static int push(lua_State* L, const glm::vec2& value);
+    static void push(lua_State* L, const glm::vec2& value);
     static glm::vec2 read(lua_State* L, int index);
 };
 
 template <> struct Converter<glm::vec3>
 {
-    static glm::vec3 pop(lua_State* L);
-    static int push(lua_State* L, const glm::vec3& value);
+    static void push(lua_State* L, const glm::vec3& value);
     static glm::vec3 read(lua_State* L, int index);
 };
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -241,11 +241,9 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
         if (!CheckArgCount(L, 7)) { return luaL_error(L, "Bad number of args"); }
-
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);
-
         auto& tr = entity.get<Transform3DComponent>();
         tr.position = p;
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, t, {0.0, 1.0, 0.0})));
@@ -254,10 +252,8 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "RotateY", [](lua_State* L) {
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); };
-
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
         auto& tr = entity.get<Transform3DComponent>();
-
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
         return 0;
@@ -265,7 +261,6 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetForwardsDir", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
         auto& tr = entity.get<Transform3DComponent>();
         auto o = tr.orientation;
@@ -275,14 +270,16 @@ void load_entity_transformation_functions(lua::Script& script)
             o = glm::rotate(o, pitch, {1, 0, 0});
         }
 
-        return Converter<glm::vec3>::push(L, Maths::Forwards(o));
+        Converter<glm::vec3>::push(L, Maths::Forwards(o));
+        return 1;
     });
 
     lua_register(L, "GetRightDir", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         auto& tr = entity.get<Transform3DComponent>();
-        return Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
+        Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
+        return 1;
     });
 
     lua_register(L, "MakeUpright", [](lua_State* L) {
@@ -298,7 +295,8 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity1 = Converter<spkt::entity>::read(L, 1);
         spkt::entity entity2 = Converter<spkt::entity>::read(L, 2);
-        return Converter<bool>::push(L, entity1 == entity2);
+        Converter<bool>::push(L, entity1 == entity2);
+        return 1;
     });
 }
 
@@ -317,11 +315,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetNameComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<NameComponent>());
-
         const auto& c = e.get<NameComponent>();
         Converter<std::string>::push(L, c.name);
         return 1;
@@ -336,7 +331,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetNameComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<NameComponent>();
@@ -352,11 +346,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddNameComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<NameComponent>());
-
         NameComponent c;
         c.name = Converter<std::string>::read(L, ++ptr);
         e.add<NameComponent>(c);
@@ -384,11 +376,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetTransform2DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<Transform2DComponent>());
-
         const auto& c = e.get<Transform2DComponent>();
         Converter<glm::vec2>::push(L, c.position);
         Converter<float>::push(L, c.rotation);
@@ -405,7 +394,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetTransform2DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<Transform2DComponent>();
@@ -423,11 +411,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddTransform2DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<Transform2DComponent>());
-
         Transform2DComponent c;
         c.position = Converter<glm::vec2>::read(L, ++ptr);
         c.rotation = Converter<float>::read(L, ++ptr);
@@ -456,11 +442,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetTransform3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<Transform3DComponent>());
-
         const auto& c = e.get<Transform3DComponent>();
         Converter<glm::vec3>::push(L, c.position);
         Converter<glm::vec3>::push(L, c.scale);
@@ -476,7 +459,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetTransform3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<Transform3DComponent>();
@@ -493,11 +475,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddTransform3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<Transform3DComponent>());
-
         Transform3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ++ptr);
         c.scale = Converter<glm::vec3>::read(L, ++ptr);
@@ -525,11 +505,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetModelComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<ModelComponent>());
-
         const auto& c = e.get<ModelComponent>();
         Converter<std::string>::push(L, c.mesh);
         Converter<std::string>::push(L, c.material);
@@ -545,7 +522,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetModelComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<ModelComponent>();
@@ -562,11 +538,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddModelComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<ModelComponent>());
-
         ModelComponent c;
         c.mesh = Converter<std::string>::read(L, ++ptr);
         c.material = Converter<std::string>::read(L, ++ptr);
@@ -600,11 +574,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetRigidBody3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<RigidBody3DComponent>());
-
         const auto& c = e.get<RigidBody3DComponent>();
         Converter<glm::vec3>::push(L, c.velocity);
         Converter<bool>::push(L, c.gravity);
@@ -626,7 +597,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetRigidBody3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 8 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<RigidBody3DComponent>();
@@ -649,11 +619,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddRigidBody3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 8 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<RigidBody3DComponent>());
-
         RigidBody3DComponent c;
         c.velocity = Converter<glm::vec3>::read(L, ++ptr);
         c.gravity = Converter<bool>::read(L, ++ptr);
@@ -689,11 +657,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetBoxCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<BoxCollider3DComponent>());
-
         const auto& c = e.get<BoxCollider3DComponent>();
         Converter<glm::vec3>::push(L, c.position);
         Converter<float>::push(L, c.mass);
@@ -711,7 +676,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetBoxCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<BoxCollider3DComponent>();
@@ -730,11 +694,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddBoxCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<BoxCollider3DComponent>());
-
         BoxCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ++ptr);
         c.mass = Converter<float>::read(L, ++ptr);
@@ -765,11 +727,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetSphereCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<SphereCollider3DComponent>());
-
         const auto& c = e.get<SphereCollider3DComponent>();
         Converter<glm::vec3>::push(L, c.position);
         Converter<float>::push(L, c.mass);
@@ -786,7 +745,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetSphereCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<SphereCollider3DComponent>();
@@ -804,11 +762,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddSphereCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<SphereCollider3DComponent>());
-
         SphereCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ++ptr);
         c.mass = Converter<float>::read(L, ++ptr);
@@ -839,11 +795,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetCapsuleCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<CapsuleCollider3DComponent>());
-
         const auto& c = e.get<CapsuleCollider3DComponent>();
         Converter<glm::vec3>::push(L, c.position);
         Converter<float>::push(L, c.mass);
@@ -861,7 +814,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetCapsuleCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<CapsuleCollider3DComponent>();
@@ -880,11 +832,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddCapsuleCollider3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<CapsuleCollider3DComponent>());
-
         CapsuleCollider3DComponent c;
         c.position = Converter<glm::vec3>::read(L, ++ptr);
         c.mass = Converter<float>::read(L, ++ptr);
@@ -914,11 +864,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetScriptComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<ScriptComponent>());
-
         const auto& c = e.get<ScriptComponent>();
         Converter<std::string>::push(L, c.script);
         Converter<bool>::push(L, c.active);
@@ -934,7 +881,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetScriptComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<ScriptComponent>();
@@ -951,11 +897,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddScriptComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<ScriptComponent>());
-
         ScriptComponent c;
         c.script = Converter<std::string>::read(L, ++ptr);
         c.active = Converter<bool>::read(L, ++ptr);
@@ -983,11 +927,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetCamera3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<Camera3DComponent>());
-
         const auto& c = e.get<Camera3DComponent>();
         Converter<float>::push(L, c.fov);
         Converter<float>::push(L, c.pitch);
@@ -1003,7 +944,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetCamera3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<Camera3DComponent>();
@@ -1020,11 +960,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddCamera3DComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<Camera3DComponent>());
-
         Camera3DComponent c;
         c.fov = Converter<float>::read(L, ++ptr);
         c.pitch = Converter<float>::read(L, ++ptr);
@@ -1052,11 +990,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetSelectComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<SelectComponent>());
-
         const auto& c = e.get<SelectComponent>();
         Converter<bool>::push(L, c.selected);
         Converter<bool>::push(L, c.hovered);
@@ -1072,7 +1007,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetSelectComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<SelectComponent>();
@@ -1089,11 +1023,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddSelectComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<SelectComponent>());
-
         SelectComponent c;
         c.selected = Converter<bool>::read(L, ++ptr);
         c.hovered = Converter<bool>::read(L, ++ptr);
@@ -1120,11 +1052,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetPathComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<PathComponent>());
-
         const auto& c = e.get<PathComponent>();
         Converter<float>::push(L, c.speed);
         return 1;
@@ -1139,7 +1068,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetPathComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<PathComponent>();
@@ -1155,11 +1083,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddPathComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<PathComponent>());
-
         PathComponent c;
         c.speed = Converter<float>::read(L, ++ptr);
         e.add<PathComponent>(c);
@@ -1186,11 +1112,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetGridComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<GridComponent>());
-
         const auto& c = e.get<GridComponent>();
         Converter<int>::push(L, c.x);
         Converter<int>::push(L, c.z);
@@ -1206,7 +1129,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetGridComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<GridComponent>();
@@ -1223,11 +1145,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddGridComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<GridComponent>());
-
         GridComponent c;
         c.x = Converter<int>::read(L, ++ptr);
         c.z = Converter<int>::read(L, ++ptr);
@@ -1255,11 +1175,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetLightComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<LightComponent>());
-
         const auto& c = e.get<LightComponent>();
         Converter<glm::vec3>::push(L, c.colour);
         Converter<float>::push(L, c.brightness);
@@ -1275,7 +1192,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetLightComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<LightComponent>();
@@ -1292,11 +1208,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddLightComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<LightComponent>());
-
         LightComponent c;
         c.colour = Converter<glm::vec3>::read(L, ++ptr);
         c.brightness = Converter<float>::read(L, ++ptr);
@@ -1326,11 +1240,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetSunComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<SunComponent>());
-
         const auto& c = e.get<SunComponent>();
         Converter<glm::vec3>::push(L, c.colour);
         Converter<float>::push(L, c.brightness);
@@ -1348,7 +1259,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetSunComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<SunComponent>();
@@ -1367,11 +1277,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddSunComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<SunComponent>());
-
         SunComponent c;
         c.colour = Converter<glm::vec3>::read(L, ++ptr);
         c.brightness = Converter<float>::read(L, ++ptr);
@@ -1401,11 +1309,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetAmbienceComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<AmbienceComponent>());
-
         const auto& c = e.get<AmbienceComponent>();
         Converter<glm::vec3>::push(L, c.colour);
         Converter<float>::push(L, c.brightness);
@@ -1421,7 +1326,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetAmbienceComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<AmbienceComponent>();
@@ -1438,11 +1342,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddAmbienceComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<AmbienceComponent>());
-
         AmbienceComponent c;
         c.colour = Converter<glm::vec3>::read(L, ++ptr);
         c.brightness = Converter<float>::read(L, ++ptr);
@@ -1474,11 +1376,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetParticleComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<ParticleComponent>());
-
         const auto& c = e.get<ParticleComponent>();
         Converter<float>::push(L, c.interval);
         Converter<glm::vec3>::push(L, c.velocity);
@@ -1498,7 +1397,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetParticleComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 6 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<ParticleComponent>();
@@ -1519,11 +1417,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddParticleComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 6 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<ParticleComponent>());
-
         ParticleComponent c;
         c.interval = Converter<float>::read(L, ++ptr);
         c.velocity = Converter<glm::vec3>::read(L, ++ptr);
@@ -1556,11 +1452,8 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_GetMeshAnimationComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<MeshAnimationComponent>());
-
         const auto& c = e.get<MeshAnimationComponent>();
         Converter<std::string>::push(L, c.name);
         Converter<float>::push(L, c.time);
@@ -1577,7 +1470,6 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_SetMeshAnimationComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<MeshAnimationComponent>();
@@ -1595,11 +1487,9 @@ void load_entity_component_functions(lua::Script& script)
 
     lua_register(L, "_AddMeshAnimationComponent", [](lua_State* L) {
         if (!CheckArgCount(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<MeshAnimationComponent>());
-
         MeshAnimationComponent c;
         c.name = Converter<std::string>::read(L, ++ptr);
         c.time = Converter<float>::read(L, ++ptr);

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -241,11 +241,9 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
         if (!CheckArgCount(L, 7)) { return luaL_error(L, "Bad number of args"); }
-
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);
-
         auto& tr = entity.get<Transform3DComponent>();
         tr.position = p;
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, t, {0.0, 1.0, 0.0})));
@@ -254,10 +252,8 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "RotateY", [](lua_State* L) {
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); };
-
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
         auto& tr = entity.get<Transform3DComponent>();
-
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
         return 0;
@@ -265,7 +261,6 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetForwardsDir", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
         auto& tr = entity.get<Transform3DComponent>();
         auto o = tr.orientation;
@@ -275,14 +270,16 @@ void load_entity_transformation_functions(lua::Script& script)
             o = glm::rotate(o, pitch, {1, 0, 0});
         }
 
-        return Converter<glm::vec3>::push(L, Maths::Forwards(o));
+        Converter<glm::vec3>::push(L, Maths::Forwards(o));
+        return 1;
     });
 
     lua_register(L, "GetRightDir", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         auto& tr = entity.get<Transform3DComponent>();
-        return Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
+        Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
+        return 1;
     });
 
     lua_register(L, "MakeUpright", [](lua_State* L) {
@@ -298,7 +295,8 @@ void load_entity_transformation_functions(lua::Script& script)
         if (!CheckArgCount(L, 2)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity1 = Converter<spkt::entity>::read(L, 1);
         spkt::entity entity2 = Converter<spkt::entity>::read(L, 2);
-        return Converter<bool>::push(L, entity1 == entity2);
+        Converter<bool>::push(L, entity1 == entity2);
+        return 1;
     });
 }
 
@@ -318,11 +316,8 @@ DATAMATIC_BEGIN SCRIPTABLE=true
 
     lua_register(L, "_Get{{Comp::name}}", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
         assert(e.has<{{Comp::name}}>());
-
         const auto& c = e.get<{{Comp::name}}>();
         Converter<{{Attr::type}}>::push(L, c.{{Attr::name}});
         return {{Comp::attr_count}};
@@ -337,7 +332,6 @@ DATAMATIC_BEGIN SCRIPTABLE=true
 
     lua_register(L, "_Set{{Comp::name}}", [](lua_State* L) {
         if (!CheckArgCount(L, {{Comp::attr_count}} + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         auto& c = e.get<{{Comp::name}}>();
@@ -353,11 +347,9 @@ DATAMATIC_BEGIN SCRIPTABLE=true
 
     lua_register(L, "_Add{{Comp::name}}", [](lua_State* L) {
         if (!CheckArgCount(L, {{Comp::attr_count}} + 1)) { return luaL_error(L, "Bad number of args"); }
-
         int ptr = 0;
         spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
         assert(!e.has<{{Comp::name}}>());
-
         {{Comp::name}} c;
         c.{{Attr::name}} = Converter<{{Attr::type}}>::read(L, ++ptr);
         e.add<{{Comp::name}}>(c);

--- a/Sprocket/Scripting/LuaScript.h
+++ b/Sprocket/Scripting/LuaScript.h
@@ -55,7 +55,9 @@ Return Script::call_function(const std::string& function, Args&&... args)
         if (rc != LUA_OK) {
             return {};
         }
-        return lua::Converter<Return>::pop(L);
+        Return ret_val = lua::Converter<Return>::read(L, -1);
+        lua_pop(L, 1);
+        return ret_val;
     }
 }
 


### PR DESCRIPTION
* Remove `Converter<T>::pop` as it was only used in one place which now calls `Converter<T>::read` and pops manually.
* `Converter<T>::push` now returns `void` as the previous change made it always return `1`.
* Condense the generated code in `LuaLibrary.cpp`. `int ptr = 0` can be removed in the `_Get` functions since it only pulls one value now.