### PR TITLE
Remove Event Dispatcher

### DIFF
--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -199,7 +199,9 @@ void WorldLayer::OnEvent(Sprocket::ev::Event& event)
         }
     }
 
-    d_scene.OnEvent(event);
+    if (!event.is_consumed()) {
+        d_scene.OnEvent(event);
+    }
 }
 
 void WorldLayer::OnUpdate(double dt)
@@ -283,32 +285,32 @@ void WorldLayer::OnRender()
                 
             auto pos = grid.SelectedPosition().value();
             if (d_hoveredEntityUI.Button("+Tree", {0, 0, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
                 AddTree(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Rock", {0, 60, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
                 AddRock(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Iron", {0, 120, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
                 AddIron(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Tin", {0, 180, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
                 AddTin(pos);
             }
 
             if (d_hoveredEntityUI.Button("+Mithril", {0, 240, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
                 AddMithril(pos);
             }
 
             if (d_hoveredEntityUI.Button("Clear", {0, 300, width, 50})) {
-                selected.destroy();
+                if (selected.valid()) { selected.destroy(); }
             }
 
             d_hoveredEntityUI.EndPanel();

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -40,48 +40,6 @@ Event make_event(Args&&... args)
 	return Event(std::in_place_type<T>, std::forward<Args>(args)...);
 }
 
-class Dispatcher
-{
-public:
-	using EventHandler = std::function<void(ev::Event&)>;
-
-	template <typename T>
-	using EventHandlerTyped = std::function<void(ev::Event&, const T&)>;
-
-private:
-	std::unordered_map<std::type_index, std::vector<EventHandler>> d_handlers;
-
-public:
-	
-	template <typename T>
-	void subscribe(const EventHandler& handler)
-	{
-		d_handlers[typeid(T)].push_back(handler);
-	}
-
-	template <typename T>
-	void subscribe(const EventHandlerTyped<T>& handler)
-	{
-		d_handlers[typeid(T)].push_back([handler](ev::Event& event) {
-			handler(event, event.get<T>());
-		});
-	}
-
-	void desubscribe_all()
-	{
-		d_handlers.clear();
-	}
-
-	void publish(ev::Event& event) const
-	{
-		if (auto it = d_handlers.find(event.type_info()); it != d_handlers.end()) {
-			for (auto& handler : it->second) {
-				handler(event);
-			}
-		}
-	}
-};
-
 // KEYBOARD EVENTS 
 struct KeyboardButtonPressed {
 	int key;

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -27,7 +27,6 @@ int Run(App& app, Window& window, const RunOptions& options = {})
         window.Clear();
         
         double dt = watch.OnUpdate();
-        window.OnUpdate();
         app.OnUpdate(dt);
         app.OnRender();
 
@@ -35,6 +34,7 @@ int Run(App& app, Window& window, const RunOptions& options = {})
             window.SetWindowName(std::format("{} [FPS: {}]", name, watch.Framerate()));
         }
 
+        window.OnUpdate();
     }
 
     return 0;

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -27,6 +27,7 @@ int Run(App& app, Window& window, const RunOptions& options = {})
         window.Clear();
         
         double dt = watch.OnUpdate();
+        window.OnUpdate();
         app.OnUpdate(dt);
         app.OnRender();
 
@@ -34,7 +35,6 @@ int Run(App& app, Window& window, const RunOptions& options = {})
             window.SetWindowName(std::format("{} [FPS: {}]", name, watch.Framerate()));
         }
 
-        window.OnUpdate();
     }
 
     return 0;

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -2,7 +2,7 @@
 #include "ECS.h"
 
 namespace Sprocket {
-namespace ev { class Event; class Dispatcher; }
+namespace ev { class Event; }
 
 class EntitySystem
 {
@@ -10,13 +10,13 @@ public:
     EntitySystem() = default;
     virtual ~EntitySystem() {};
 
-    virtual void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) {};
+    virtual void on_startup(spkt::registry& registry) {};
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
 
     virtual void on_event(spkt::registry& registry, ev::Event& event) {};
     
-    virtual void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) {};
+    virtual void on_update(spkt::registry& registry, double dt) {};
         // Called every tick of the game loop.
 
 private:

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -13,6 +13,8 @@ public:
     virtual void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) {};
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
+
+    virtual void on_event(spkt::registry& registry, ev::Event& event) {};
     
     virtual void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) {};
         // Called every tick of the game loop.

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -34,7 +34,7 @@ void Scene::Load(std::string_view file)
 void Scene::OnUpdate(double dt)
 {
     for (auto& system : d_systems) {
-        system->on_update(d_registry, d_dispatcher, dt);
+        system->on_update(d_registry, dt);
     }
 }
 

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -40,7 +40,9 @@ void Scene::OnUpdate(double dt)
 
 void Scene::OnEvent(ev::Event& event)
 {
-    d_dispatcher.publish(event);
+    for (auto& system : d_systems) {
+        system->on_event(d_registry, event);
+    }
 }
 
 std::size_t Scene::Size() const

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -19,8 +19,6 @@ class Scene
 
     spkt::registry d_registry;
 
-    ev::Dispatcher d_dispatcher;
-
 public:
     Scene();
     ~Scene();
@@ -56,7 +54,7 @@ T& Scene::Add(Args&&... args)
     assert(d_lookup.find(spkt::type_info<T>) == d_lookup.end());
     d_lookup[spkt::type_info<T>] = d_systems.size();
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
-    d_systems.back()->on_startup(d_registry, d_dispatcher);
+    d_systems.back()->on_startup(d_registry);
     return *static_cast<T*>(d_systems.back().get());
 }
 

--- a/Sprocket/Scene/Systems/AnimationSystem.cpp
+++ b/Sprocket/Scene/Systems/AnimationSystem.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void AnimationSystem::on_update(spkt::registry& registry, const ev::Dispatcher&, double dt)
+void AnimationSystem::on_update(spkt::registry& registry, double dt)
 {
     for (auto id : registry.view<MeshAnimationComponent>()) {
         auto& ac = registry.get<MeshAnimationComponent>(id);

--- a/Sprocket/Scene/Systems/AnimationSystem.h
+++ b/Sprocket/Scene/Systems/AnimationSystem.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class AnimationSystem : public EntitySystem
 {
 public:
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -10,25 +10,24 @@ CameraSystem::CameraSystem(float aspectRatio)
     : d_aspectRatio(aspectRatio)
 {}
 
-void CameraSystem::on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher)
+void CameraSystem::on_event(spkt::registry& registry, ev::Event& event)
 {
-    dispatcher.subscribe<spkt::added<Camera3DComponent>>([&](ev::Event& event, auto&& data) {
-        spkt::entity entity = data.entity;
+    if (auto e = event.get_if<spkt::added<Camera3DComponent>>()) {
+        spkt::entity entity = e->entity;
         auto& camera = entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(
             camera.fov, d_aspectRatio, 0.1f, 1000.0f
         );
-    });
-
-    dispatcher.subscribe<ev::WindowResize>([&](ev::Event& event, auto&& data) {
-        d_aspectRatio = (float)data.width / data.height;
+    }
+    else if (auto e = event.get_if<ev::WindowResize>()) {
+        d_aspectRatio = (float)e->width / e->height;
         for (auto entity : registry.view<Camera3DComponent>()) {
             auto& camera = registry.get<Camera3DComponent>(entity);
             camera.projection = glm::perspective(
                 camera.fov, d_aspectRatio, 0.1f, 1000.0f
             );
         }
-    });
+    }
 }
 
 }

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -10,7 +10,7 @@ class CameraSystem : public EntitySystem
 
 public:
     CameraSystem(float aspectRatio);
-    void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_event(spkt::registry& registry, ev::Event& event) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -24,7 +24,7 @@ GameGrid::GameGrid(Window* window)
 {
 }
 
-void GameGrid::on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher)
+void GameGrid::on_startup(spkt::registry& registry)
 {
     std::string gridSquare = "Resources/Models/Square.obj";
 
@@ -79,7 +79,7 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
     }
 }
 
-void GameGrid::on_update(spkt::registry&, const ev::Dispatcher&, double dt)
+void GameGrid::on_update(spkt::registry&, double dt)
 {
     auto& camTr = d_camera.get<Transform3DComponent>();
 

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -34,9 +34,9 @@ private:
 public:
     GameGrid(Window* window);
 
-    void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_startup(spkt::registry& registry) override;
     void on_event(spkt::registry& registry, ev::Event& event) override;
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
 
     spkt::entity At(const glm::ivec2& pos) const;
 

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -35,6 +35,7 @@ public:
     GameGrid(Window* window);
 
     void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 
     spkt::entity At(const glm::ivec2& pos) const;

--- a/Sprocket/Scene/Systems/ParticleSystem.cpp
+++ b/Sprocket/Scene/Systems/ParticleSystem.cpp
@@ -10,7 +10,7 @@ ParticleSystem::ParticleSystem(ParticleManager* manager)
 {
 }
 
-void ParticleSystem::on_update(spkt::registry& registry, const ev::Dispatcher&, double dt)
+void ParticleSystem::on_update(spkt::registry& registry, double dt)
 {
     for (auto entity : registry.view<ParticleComponent>()) {
         auto& tc = registry.get<Transform3DComponent>(entity);

--- a/Sprocket/Scene/Systems/ParticleSystem.h
+++ b/Sprocket/Scene/Systems/ParticleSystem.h
@@ -12,7 +12,7 @@ class ParticleSystem : public EntitySystem
 public:
     ParticleSystem(ParticleManager* manager);
     
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/PathFollower.cpp
+++ b/Sprocket/Scene/Systems/PathFollower.cpp
@@ -5,7 +5,7 @@
 
 namespace Sprocket {
 
-void PathFollower::on_update(spkt::registry& registry, const ev::Dispatcher&, double dt)
+void PathFollower::on_update(spkt::registry& registry, double dt)
 {
     for (auto entity : registry.view<PathComponent>()) {
         auto& transform = registry.get<Transform3DComponent>(entity);

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -7,7 +7,7 @@ namespace Sprocket {
 class PathFollower : public EntitySystem
 {
 public:
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
         // Called once per entity per frame and before the system updates.
 };
 

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -255,7 +255,7 @@ void PhysicsEngine3D::on_event(spkt::registry& registry, ev::Event& event)
     }
 }
 
-void PhysicsEngine3D::on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt)
+void PhysicsEngine3D::on_update(spkt::registry& registry, double dt)
 {
     // Pre Update
     for (auto id : registry.view<RigidBody3DComponent>()) {
@@ -319,9 +319,9 @@ void PhysicsEngine3D::on_update(spkt::registry& registry, const ev::Dispatcher& 
     }
 
     // Publish all generated events
-    for (auto& event : d_impl->listener.events()) {
-        dispatcher.publish(event);
-    }
+    //for (auto& event : d_impl->listener.events()) {
+    //    dispatcher.publish(event);
+    //}
     d_impl->listener.events().clear();
 }
 

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -28,7 +28,7 @@ public:
     ~PhysicsEngine3D() = default;
 
     void on_event(spkt::registry& registry, ev::Event& event) override;
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
 
     spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);
         // Given a position in the world and a direction from that point,

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -27,7 +27,7 @@ public:
     PhysicsEngine3D(const glm::vec3& gravity = {0.0f, -9.81f, 0.0f});
     ~PhysicsEngine3D() = default;
 
-    void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 
     spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -17,7 +17,7 @@ ScriptRunner::ScriptRunner(Window* window)
 {
 }
 
-void ScriptRunner::on_update(spkt::registry&, const ev::Dispatcher&, double dt)
+void ScriptRunner::on_update(spkt::registry&, double dt)
 {
     // We delete scripts here rather then with OnRemove otherwise we would segfault if
     // a script tries to delete its own entity, which is functionality that we want to
@@ -47,14 +47,10 @@ apx::generator<lua::Script&> ScriptRunner::active_scripts()
     }
 }
 
-// TODO: Add more event handlers
-void ScriptRunner::on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher)
-{
-    d_input.on_startup(dispatcher);
-}
-
 void ScriptRunner::on_event(spkt::registry& registry, ev::Event& event)
 {
+    d_input.on_event(event);
+
     if (auto e = event.get_if<spkt::added<ScriptComponent>>()) {
         lua::Script script(e->entity.get<ScriptComponent>().script);
         lua::load_vec3_functions(script);

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -23,6 +23,7 @@ public:
     ScriptRunner(Window* window);
 
     void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
+    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
 };
 

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -22,9 +22,8 @@ class ScriptRunner : public EntitySystem
 public:
     ScriptRunner(Window* window);
 
-    void on_startup(spkt::registry& registry, ev::Dispatcher& dispatcher) override;
     void on_event(spkt::registry& registry, ev::Event& event) override;
-    void on_update(spkt::registry& registry, const ev::Dispatcher& dispatcher, double dt) override;
+    void on_update(spkt::registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -216,7 +216,7 @@ void load_entity_transformation_functions(lua::Script& script)
     lua_State* L = script.native_handle();
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
-        if (!CheckArgCount(L, 7)) { return luaL_error(L, "Bad number of args"); }
+        if (!CheckArgCount(L, 3)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -216,7 +216,7 @@ void load_entity_transformation_functions(lua::Script& script)
     lua_State* L = script.native_handle();
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
-        if (!CheckArgCount(L, 7)) { return luaL_error(L, "Bad number of args"); }
+        if (!CheckArgCount(L, 3)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);

--- a/Sprocket/Utility/InputProxy.cpp
+++ b/Sprocket/Utility/InputProxy.cpp
@@ -10,27 +10,6 @@ InputProxy::InputProxy()
     d_keyboard.fill(false);
     d_mouse.fill(false);
 }
-
-void InputProxy::on_startup(ev::Dispatcher& dispatcher)
-{
-    dispatcher.subscribe<ev::KeyboardButtonPressed>([&](ev::Event& event) {
-        if (event.is_consumed()) { return; }
-        d_keyboard[event.get<ev::KeyboardButtonPressed>().key] = true;
-    });
-
-    dispatcher.subscribe<ev::KeyboardButtonReleased>([&](ev::Event& event) {
-        d_keyboard[event.get<ev::KeyboardButtonReleased>().key] = false;
-    });
-
-    dispatcher.subscribe<ev::MouseButtonPressed>([&](ev::Event& event) {
-        if (event.is_consumed()) { return; }
-        d_mouse[event.get<ev::MouseButtonPressed>().button] = true;
-    });
-
-    dispatcher.subscribe<ev::MouseButtonReleased>([&](ev::Event& event) {
-        d_mouse[event.get<ev::MouseButtonReleased>().button] = false;
-    });
-}
   
 void InputProxy::on_event(ev::Event& event)
 {

--- a/Sprocket/Utility/InputProxy.h
+++ b/Sprocket/Utility/InputProxy.h
@@ -2,7 +2,7 @@
 #include <array>
 
 namespace Sprocket {
-namespace ev { class Event; class Dispatcher; }
+namespace ev { class Event; }
 
 class InputProxy
 {
@@ -16,7 +16,6 @@ private:
 public:
     InputProxy();
 
-    void on_startup(ev::Dispatcher& dispatcher);
     void on_event(ev::Event& event);
 
     bool is_mouse_down(int button) const;


### PR DESCRIPTION
* This was overly complicated and the wrong abstraction, so `ev::Dispatcher` has been removed.
* This does mean systems can no longer emit other events, but this will be fixed via singleton components.
* Given systems an `on_event` function for the time being, but that can eventually be removed again when we have a singleton `InputComponent`.