### PR TITLE
Singleton Entity

### DIFF
--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -65,11 +65,6 @@ public:
     void on_update(double dt);
     void on_render();
 
-    // Remove these
-    void OnEvent(ev::Event& event) { on_event(event); }
-    void OnUpdate(double dt) { on_update(dt); }
-    void OnRender() { on_render(); }
-
     spkt::entity selected() { return d_selected; }
     void set_selected(spkt::entity e) { d_selected = e; }
     void clear_selected() { d_selected = spkt::null; }

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -275,6 +275,16 @@ void Inspector::Show(Anvil& editor)
         }
     }
 
+    if (entity.has<Singleton>()) {
+        auto& c = entity.get<Singleton>();
+        if (ImGui::CollapsingHeader("Singleton")) {
+            ImGui::PushID(count++);
+            
+            if (ImGui::Button("Delete")) { entity.remove<Singleton>(); }
+            ImGui::PopID();
+        }
+    }
+
     ImGui::Separator();
 
     if (ImGui::Button("Add Component")) {
@@ -357,6 +367,10 @@ void Inspector::Show(Anvil& editor)
         if (!entity.has<MeshAnimationComponent>() && ImGui::Selectable("Mesh Animation")) {
             MeshAnimationComponent c;
             entity.add<MeshAnimationComponent>(c);
+        }
+        if (!entity.has<Singleton>() && ImGui::Selectable("Singleton")) {
+            Singleton c;
+            entity.add<Singleton>(c);
         }
         ImGui::EndMenu();
     }

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -549,6 +549,9 @@
         {
             "name": "Singleton",
             "display_name": "Singleton",
+            "flags": {
+                "SCRIPTABLE": false
+            },
             "attributes": []
         }
     ]

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -545,6 +545,11 @@
                     "default": "1.0f"
                 }
             ]
+        },
+        {
+            "name": "Singleton",
+            "display_name": "Singleton",
+            "attributes": []
         }
     ]
 }

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -2,9 +2,11 @@
 #include "Window.h"
 #include "Stopwatch.h"
 #include "Log.h"
+#include "Events.h"
 
 #include <exception>
 #include <format>
+#include <utility>
 
 namespace Sprocket {
 
@@ -13,7 +15,23 @@ struct RunOptions
     bool showFramerate = false;
 };
 
-template <typename App>
+template <typename T>
+concept legacy_runnable = requires(T t, ev::Event& event, double dt)
+{
+    { t.OnEvent(event) } -> std::same_as<void>;
+    { t.OnUpdate(dt) } -> std::same_as<void>;
+    { t.OnRender() } -> std::same_as<void>;
+};
+
+template <typename T>
+concept runnable = requires(T t, ev::Event& event, double dt)
+{
+    { t.on_event(event) } -> std::same_as<void>;
+    { t.on_update(dt) } -> std::same_as<void>;
+    { t.on_render() } -> std::same_as<void>;
+};
+
+template <legacy_runnable App>
 int Run(App& app, Window& window, const RunOptions& options = {})
 {
     std::string name = window.GetWindowName();
@@ -29,6 +47,33 @@ int Run(App& app, Window& window, const RunOptions& options = {})
         double dt = watch.OnUpdate();
         app.OnUpdate(dt);
         app.OnRender();
+
+        if (options.showFramerate) {
+            window.SetWindowName(std::format("{} [FPS: {}]", name, watch.Framerate()));
+        }
+
+        window.OnUpdate();
+    }
+
+    return 0;
+}
+
+template <runnable App>
+int Run(App& app, Window& window, const RunOptions& options = {})
+{
+    std::string name = window.GetWindowName();
+    Stopwatch watch;
+
+    window.SetCallback([&app](ev::Event& event) {
+        app.on_event(event);
+    });
+
+    while (window.Running()) {
+        window.Clear();
+        
+        double dt = watch.OnUpdate();
+        app.on_update(dt);
+        app.on_render();
 
         if (options.showFramerate) {
             window.SetWindowName(std::format("{} [FPS: {}]", name, watch.Framerate()));

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -142,5 +142,9 @@ struct MeshAnimationComponent
     float speed = 1.0f;
 };
 
+struct Singleton
+{
+};
+
 
 }

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -28,7 +28,8 @@ using registry = apx::registry<
     Sprocket::SunComponent,
     Sprocket::AmbienceComponent,
     Sprocket::ParticleComponent,
-    Sprocket::MeshAnimationComponent
+    Sprocket::MeshAnimationComponent,
+    Sprocket::Singleton
 >;
 
 using entity = typename registry::handle_type;

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -359,6 +359,13 @@ void Load(const std::string& file, spkt::registry* reg)
             e.add<Singleton>(c);
         }
     }
+
+    // Add the singleton entity if the scene does not have one.
+    auto singleton = reg->find<Singleton>();
+    if (!reg->valid(singleton)) {
+        singleton = reg->create();
+        reg->emplace<Singleton>(singleton);
+    }
 }
 
 spkt::entity Copy(spkt::registry* reg, spkt::entity entity)

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -363,8 +363,10 @@ void Load(const std::string& file, spkt::registry* reg)
     // Add the singleton entity if the scene does not have one.
     auto singleton = reg->find<Singleton>();
     if (!reg->valid(singleton)) {
+        log::info("Adding a singleton entity to the loaded scene");
         singleton = reg->create();
         reg->emplace<Singleton>(singleton);
+        reg->emplace<NameComponent>(singleton, "::Singleton");
     }
 }
 

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -170,6 +170,11 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "speed" << YAML::Value << c.speed;
             out << YAML::EndMap;
         }
+        if (entity.has<Singleton>()) {
+            const auto& c = entity.get<Singleton>();
+            out << YAML::Key << "Singleton" << YAML::BeginMap;
+            out << YAML::EndMap;
+        }
         out << YAML::EndMap;
     }
     out << YAML::EndSeq;
@@ -349,6 +354,10 @@ void Load(const std::string& file, spkt::registry* reg)
             c.speed = transform(spec["speed"].as<float>());
             e.add<MeshAnimationComponent>(c);
         }
+        if (auto spec = entity["Singleton"]) {
+            Singleton c;
+            e.add<Singleton>(c);
+        }
     }
 }
 
@@ -411,6 +420,9 @@ spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
     }
     if (entity.has<MeshAnimationComponent>()) {
         e.add<MeshAnimationComponent>(entity.get<MeshAnimationComponent>());
+    }
+    if (entity.has<Singleton>()) {
+        e.add<Singleton>(entity.get<Singleton>());
     }
     return e;
 }
@@ -589,6 +601,11 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.time = transform(source_comp.time);
             target_comp.speed = transform(source_comp.speed);
             dst.add<MeshAnimationComponent>(target_comp);
+        }
+        if (src.has<Singleton>()) {
+            const Singleton& source_comp = src.get<Singleton>();
+            Singleton target_comp;
+            dst.add<Singleton>(target_comp);
         }
     }
 }

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -92,8 +92,10 @@ DATAMATIC_END
     // Add the singleton entity if the scene does not have one.
     auto singleton = reg->find<Singleton>();
     if (!reg->valid(singleton)) {
+        log::info("Adding a singleton entity to the loaded scene");
         singleton = reg->create();
         reg->emplace<Singleton>(singleton);
+        reg->emplace<NameComponent>(singleton, "::Singleton");
     }
 }
 

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -88,6 +88,13 @@ DATAMATIC_BEGIN SAVABLE=true
         }
 DATAMATIC_END
     }
+
+    // Add the singleton entity if the scene does not have one.
+    auto singleton = reg->find<Singleton>();
+    if (!reg->valid(singleton)) {
+        singleton = reg->create();
+        reg->emplace<Singleton>(singleton);
+    }
 }
 
 spkt::entity Copy(spkt::registry* reg, spkt::entity entity)

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -21,9 +21,6 @@ Scene::Scene()
 
 Scene::~Scene()
 {
-    // We need to clear the registry before destruction of the dispatcher and
-    // systems so that they are still valid when clearing the entities.
-    d_registry.clear();
 }
 
 void Scene::Load(std::string_view file)

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -19,10 +19,6 @@ Scene::Scene()
     });
 }
 
-Scene::~Scene()
-{
-}
-
 void Scene::Load(std::string_view file)
 {
     Loader::Load(std::string(file), &Entities());

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -21,7 +21,6 @@ class Scene
 
 public:
     Scene();
-    ~Scene();
 
     spkt::registry& Entities() { return d_registry; }
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -1483,61 +1483,6 @@ void load_entity_component_functions(lua::Script& script)
     lua_register(L, "HasMeshAnimationComponent", &_has_impl<MeshAnimationComponent>);
 
 
-    // Functions for Singleton =====================================================
-
-    luaL_dostring(L, R"lua(
-        Singleton = Class(function(self, )
-        end)
-    )lua");
-
-    lua_register(L, "_GetSingleton", [](lua_State* L) {
-        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::entity e = Converter<spkt::entity>::read(L, 1);
-        assert(e.has<Singleton>());
-        const auto& c = e.get<Singleton>();
-        return 0;
-    });
-
-    luaL_dostring(L, R"lua(
-        function GetSingleton(entity)
-             = _GetSingleton(entity)
-            return Singleton()
-        end
-    )lua");
-
-    lua_register(L, "_SetSingleton", [](lua_State* L) {
-        if (!CheckArgCount(L, 0 + 1)) { return luaL_error(L, "Bad number of args"); }
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
-        auto& c = e.get<Singleton>();
-        return 0;
-    });
-
-    luaL_dostring(L, R"lua(
-        function SetSingleton(entity, c)
-            _SetSingleton(entity, )
-        end
-    )lua");
-
-    lua_register(L, "_AddSingleton", [](lua_State* L) {
-        if (!CheckArgCount(L, 0 + 1)) { return luaL_error(L, "Bad number of args"); }
-        int ptr = 0;
-        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
-        assert(!e.has<Singleton>());
-        Singleton c;
-        e.add<Singleton>(c);
-        return 0;
-    });
-
-    luaL_dostring(L, R"lua(
-        function AddSingleton(entity, c)
-            _AddSingleton(entity, )
-        end
-    )lua");
-
-    lua_register(L, "HasSingleton", &_has_impl<Singleton>);
-
-
 }
 
 }

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -1483,6 +1483,61 @@ void load_entity_component_functions(lua::Script& script)
     lua_register(L, "HasMeshAnimationComponent", &_has_impl<MeshAnimationComponent>);
 
 
+    // Functions for Singleton =====================================================
+
+    luaL_dostring(L, R"lua(
+        Singleton = Class(function(self, )
+        end)
+    )lua");
+
+    lua_register(L, "_GetSingleton", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::entity e = Converter<spkt::entity>::read(L, 1);
+        assert(e.has<Singleton>());
+        const auto& c = e.get<Singleton>();
+        return 0;
+    });
+
+    luaL_dostring(L, R"lua(
+        function GetSingleton(entity)
+             = _GetSingleton(entity)
+            return Singleton()
+        end
+    )lua");
+
+    lua_register(L, "_SetSingleton", [](lua_State* L) {
+        if (!CheckArgCount(L, 0 + 1)) { return luaL_error(L, "Bad number of args"); }
+        int ptr = 0;
+        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        auto& c = e.get<Singleton>();
+        return 0;
+    });
+
+    luaL_dostring(L, R"lua(
+        function SetSingleton(entity, c)
+            _SetSingleton(entity, )
+        end
+    )lua");
+
+    lua_register(L, "_AddSingleton", [](lua_State* L) {
+        if (!CheckArgCount(L, 0 + 1)) { return luaL_error(L, "Bad number of args"); }
+        int ptr = 0;
+        spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
+        assert(!e.has<Singleton>());
+        Singleton c;
+        e.add<Singleton>(c);
+        return 0;
+    });
+
+    luaL_dostring(L, R"lua(
+        function AddSingleton(entity, c)
+            _AddSingleton(entity, )
+        end
+    )lua");
+
+    lua_register(L, "HasSingleton", &_has_impl<Singleton>);
+
+
 }
 
 }


### PR DESCRIPTION
* The idea here is that we will slowly remove all state from systems, and their state can reside in component types that we only have one of each. These reside in a special `::Singleton` entity.
* The `Loader` has been changed to add a singleton entity to any scene that does not have one.
* Added `Singleton` as a component with no attributes, intended to be used as a tag component to tag the singleton entity.
* In the future, runtime checks will be added to enforce that there is only one singleton entity, as the ECS model does not directly support it. This component is not scriptable, and should also be excluded from the level editor in time.
* Used C++20 concepts to create two version of the `Run` function, one that has the old PascalCase names for the update, event and render functions, and one that expects snake_case. The PascalCase will be removed in time.
* `Scene` now has a trivial destructor now that the `Dispatcher` is no more.