### PR TITLE
Input Singleton Enhancements

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -199,7 +199,7 @@ void Anvil::on_render()
             if (ImGui::MenuItem("Run")) {
                 d_activeScene = std::make_shared<Scene>(d_window); 
                 d_activeScene->Add<PhysicsEngine3D>();
-                d_activeScene->Add<CameraSystem>(d_window->AspectRatio());
+                d_activeScene->Add<CameraSystem>();
                 d_activeScene->Add<ScriptRunner>(d_window);
                 d_activeScene->Add<ParticleSystem>(&d_particle_manager);
                 d_activeScene->Add<AnimationSystem>();

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -117,6 +117,8 @@ void Anvil::on_update(double dt)
         const auto& transform = d_scene->Entities().get<Transform3DComponent>(entity);
         return transform.position.y < -50;
     });
+
+    d_activeScene->post_update();
 }
 
 glm::mat4 Anvil::get_proj_matrix() const

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -200,7 +200,7 @@ void Anvil::on_render()
                 d_activeScene = std::make_shared<Scene>(d_window); 
                 d_activeScene->Add<PhysicsEngine3D>();
                 d_activeScene->Add<CameraSystem>();
-                d_activeScene->Add<ScriptRunner>(d_window);
+                d_activeScene->Add<ScriptRunner>();
                 d_activeScene->Add<ParticleSystem>(&d_particle_manager);
                 d_activeScene->Add<AnimationSystem>();
                 Loader::Copy(&d_scene->Entities(), &d_activeScene->Entities());

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -165,7 +165,7 @@ void Anvil::on_render()
                 if (!file.empty()) {
                     log::info("Creating {}...", d_sceneFile);
                     d_sceneFile = file;
-                    d_scene->Clear();
+                    d_activeScene = d_scene = std::make_shared<Scene>(d_window);
                     log::info("...done!");
                 }
             }
@@ -174,7 +174,7 @@ void Anvil::on_render()
                 if (!file.empty()) {
                     log::info("Loading {}...", d_sceneFile);
                     d_sceneFile = file;
-                    d_scene->Clear();
+                    d_activeScene = d_scene = std::make_shared<Scene>(d_window);
                     Loader::Load(file, &d_scene->Entities());
                     log::info("...done!");
                 }

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -47,7 +47,7 @@ Anvil::Anvil(Window* window)
 {
     d_window->SetCursorVisibility(true);
 
-    d_scene = std::make_shared<Scene>();    
+    d_scene = std::make_shared<Scene>(window);    
     d_scene->Load(d_sceneFile);
 
     d_runtimeCamera = d_scene->find([](spkt::entity entity) {
@@ -197,7 +197,7 @@ void Anvil::on_render()
         }
         if (ImGui::BeginMenu("Scene")) {
             if (ImGui::MenuItem("Run")) {
-                d_activeScene = std::make_shared<Scene>(); 
+                d_activeScene = std::make_shared<Scene>(d_window); 
                 d_activeScene->Add<PhysicsEngine3D>();
                 d_activeScene->Add<CameraSystem>(d_window->AspectRatio());
                 d_activeScene->Add<ScriptRunner>(d_window);

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -64,6 +64,7 @@ public:
     void on_event(ev::Event& event);
     void on_update(double dt);
     void on_render();
+    void post_update();
 
     spkt::entity selected() { return d_selected; }
     void set_selected(spkt::entity e) { d_selected = e; }

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -296,6 +296,18 @@ void Inspector::Show(Anvil& editor)
         }
     }
 
+    if (entity.has<InputSingleton>()) {
+        auto& c = entity.get<InputSingleton>();
+        if (ImGui::CollapsingHeader("Input Singleton")) {
+            ImGui::PushID(count++);
+            ;
+            ;
+            
+            if (ImGui::Button("Delete")) { entity.remove<InputSingleton>(); }
+            ImGui::PopID();
+        }
+    }
+
     ImGui::Separator();
 
     if (ImGui::Button("Add Component")) {
@@ -386,6 +398,10 @@ void Inspector::Show(Anvil& editor)
         if (!entity.has<CollisionSingleton>() && ImGui::Selectable("Collision Singleton")) {
             CollisionSingleton c;
             entity.add<CollisionSingleton>(c);
+        }
+        if (!entity.has<InputSingleton>() && ImGui::Selectable("Input Singleton")) {
+            InputSingleton c;
+            entity.add<InputSingleton>(c);
         }
         ImGui::EndMenu();
     }

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -302,6 +302,8 @@ void Inspector::Show(Anvil& editor)
             ImGui::PushID(count++);
             ;
             ;
+            ;
+            ;
             
             if (ImGui::Button("Delete")) { entity.remove<InputSingleton>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -309,6 +309,7 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat2("Mouse Scrolled", &c.mouse_scrolled.x, 0.1f);
             ImGui::DragFloat("Window Width", &c.window_width, 0.01f);
             ImGui::DragFloat("Window Height", &c.window_height, 0.01f);
+            ImGui::Checkbox("Window Resized", &c.window_resized);
             
             if (ImGui::Button("Delete")) { entity.remove<InputSingleton>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -304,6 +304,11 @@ void Inspector::Show(Anvil& editor)
             ;
             ;
             ;
+            ImGui::DragFloat2("Mouse Position", &c.mouse_pos.x, 0.1f);
+            ImGui::DragFloat2("Mouse Offset", &c.mouse_offset.x, 0.1f);
+            ImGui::DragFloat2("Mouse Scrolled", &c.mouse_scrolled.x, 0.1f);
+            ImGui::DragFloat("Window Width", &c.window_width, 0.01f);
+            ImGui::DragFloat("Window Height", &c.window_height, 0.01f);
             
             if (ImGui::Button("Delete")) { entity.remove<InputSingleton>(); }
             ImGui::PopID();

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -105,10 +105,10 @@ void WorldLayer::LoadScene(std::string_view file)
 {
     using namespace Sprocket;
 
-    d_scene.Add<ScriptRunner>(d_window);
+    d_scene.Add<ScriptRunner>();
     d_scene.Add<CameraSystem>();
     d_scene.Add<PathFollower>();
-    d_scene.Add<GameGrid>();
+    auto& game_grid = d_scene.Add<GameGrid>();
     d_scene.Load(file);
     d_paused = false;
 
@@ -122,7 +122,7 @@ void WorldLayer::LoadScene(std::string_view file)
         return entity.get<NameComponent>().name == "Camera";
     });
 
-    d_scene.Get<GameGrid>().SetCamera(d_camera);
+    game_grid.SetCamera(d_camera);
 
     assert(d_worker != spkt::null);
     assert(d_camera != spkt::null);
@@ -236,6 +236,8 @@ void WorldLayer::OnUpdate(double dt)
 
     d_devUI.OnUpdate(dt);
     d_escapeMenu.OnUpdate(dt);
+
+    d_scene.post_update();
 }
 
 void WorldLayer::OnRender()

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -106,7 +106,7 @@ void WorldLayer::LoadScene(std::string_view file)
     using namespace Sprocket;
 
     d_scene.Add<ScriptRunner>(d_window);
-    d_scene.Add<CameraSystem>(d_window->AspectRatio());
+    d_scene.Add<CameraSystem>();
     d_scene.Add<PathFollower>();
     d_scene.Add<GameGrid>(d_window);
     d_scene.Load(file);

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -105,7 +105,6 @@ void WorldLayer::LoadScene(std::string_view file)
 {
     using namespace Sprocket;
 
-    d_scene.Clear();
     d_scene.Add<ScriptRunner>(d_window);
     d_scene.Add<CameraSystem>(d_window->AspectRatio());
     d_scene.Add<PathFollower>();

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -108,7 +108,7 @@ void WorldLayer::LoadScene(std::string_view file)
     d_scene.Add<ScriptRunner>(d_window);
     d_scene.Add<CameraSystem>();
     d_scene.Add<PathFollower>();
-    d_scene.Add<GameGrid>(d_window);
+    d_scene.Add<GameGrid>();
     d_scene.Load(file);
     d_paused = false;
 

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -69,6 +69,7 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
 
 WorldLayer::WorldLayer(Window* window) 
     : d_window(window)
+    , d_scene(window)
     , d_assetManager()
     , d_mode(Mode::PLAYER)
     , d_entityRenderer(&d_assetManager)

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -50,6 +50,7 @@ public:
     void OnEvent(Sprocket::ev::Event& event);
     void OnUpdate(double dt);
     void OnRender();
+    void PostUpdate() {}
 
     void LoadScene(std::string_view file);
 

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -93,32 +93,3 @@ function Fire()
 
     return true
 end
-
-
-function OnMouseButtonPressedEvent(button, action, mods)
-    local newEntity = NewEntity()
-
-    local dir = GetForwardsDir(ENTITY)
-    local pos = GetTransform3DComponent(ENTITY).position
-    local vel = GetRigidBody3DComponent(ENTITY).velocity
-    
-    local tc = Transform3DComponent(pos + dir, vec3.new(0.1, 0.1, 0.1))
-    AddTransform3DComponent(newEntity, tc)
-
-    local rbc = RigidBody3DComponent(10 * dir + vel, true, false, 0.65, 0.3, 1, vec3.new(0, 0, 0), false)
-    AddRigidBody3DComponent(newEntity, rbc)
-
-    local sc = SphereCollider3DComponent(vec3.new(0, 0, 0), 20, 0.1)
-    AddSphereCollider3DComponent(newEntity, sc)
-
-    local lc = LightComponent(vec3.new(1, 1, 1), 20)
-    AddLightComponent(newEntity, lc)
-
-    local sc = ScriptComponent("Resources/Scripts/Grenade.lua", true)
-    AddScriptComponent(newEntity, sc)
-
-    local pc = ParticleComponent(0.01, vec3.new(0, 0, 0), 1, vec3.new(0, 0, 0), vec3.new(1, 1, 1), 1)
-    AddParticleComponent(newEntity, pc)
-
-    return true
-end

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -60,6 +60,38 @@ function OnUpdate(entity, dt)
         SetTransform3DComponent(entity, transform)
     end
 
+    if IsMouseClicked(0) then
+        Fire()
+    end
+
+end
+
+function Fire()
+    local newEntity = NewEntity()
+
+    local dir = GetForwardsDir(ENTITY)
+    local pos = GetTransform3DComponent(ENTITY).position
+    local vel = GetRigidBody3DComponent(ENTITY).velocity
+    
+    local tc = Transform3DComponent(pos + dir, vec3.new(0.1, 0.1, 0.1))
+    AddTransform3DComponent(newEntity, tc)
+
+    local rbc = RigidBody3DComponent(10 * dir + vel, true, false, 0.65, 0.3, 1, vec3.new(0, 0, 0), false)
+    AddRigidBody3DComponent(newEntity, rbc)
+
+    local sc = SphereCollider3DComponent(vec3.new(0, 0, 0), 20, 0.1)
+    AddSphereCollider3DComponent(newEntity, sc)
+
+    local lc = LightComponent(vec3.new(1, 1, 1), 20)
+    AddLightComponent(newEntity, lc)
+
+    local sc = ScriptComponent("Resources/Scripts/Grenade.lua", true)
+    AddScriptComponent(newEntity, sc)
+
+    local pc = ParticleComponent(0.01, vec3.new(0, 0, 0), 1, vec3.new(0, 0, 0), vec3.new(1, 1, 1), 1)
+    AddParticleComponent(newEntity, pc)
+
+    return true
 end
 
 

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -73,12 +73,6 @@ function OnMouseButtonPressedEvent(button, action, mods)
     local tc = Transform3DComponent(pos + dir, vec3.new(0.1, 0.1, 0.1))
     AddTransform3DComponent(newEntity, tc)
 
-    --local mc = ModelComponent(
-    --    "Resources/Models/Sphere.obj", 
-    --    "Resources/Materials/grey.yaml"
-    --)
-    --AddModelComponent(newEntity, mc)
-
     local rbc = RigidBody3DComponent(10 * dir + vel, true, false, 0.65, 0.3, 1, vec3.new(0, 0, 0), false)
     AddRigidBody3DComponent(newEntity, rbc)
 

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -9,6 +9,7 @@ const auto SPACE_DARK  = Sprocket::FromHex(0x2C3A47);
 
 Runtime::Runtime(Window* window) 
     : d_window(window)
+    , d_scene(window)
     , d_assetManager()
     , d_entityRenderer(&d_assetManager)
     , d_skyboxRenderer(&d_assetManager)

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -27,7 +27,7 @@ Runtime::Runtime(Window* window)
     d_entityRenderer.EnableParticles(&d_particleManager);
 
     d_scene.Add<PhysicsEngine3D>();
-    d_scene.Add<ScriptRunner>(d_window);
+    d_scene.Add<ScriptRunner>();
     d_scene.Add<CameraSystem>();
     d_scene.Add<ParticleSystem>(&d_particleManager);
     d_scene.Add<AnimationSystem>();

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -28,7 +28,7 @@ Runtime::Runtime(Window* window)
 
     d_scene.Add<PhysicsEngine3D>();
     d_scene.Add<ScriptRunner>(d_window);
-    d_scene.Add<CameraSystem>(d_window->AspectRatio());
+    d_scene.Add<CameraSystem>();
     d_scene.Add<ParticleSystem>(&d_particleManager);
     d_scene.Add<AnimationSystem>();
     d_scene.Load("Resources/Anvil.yaml");

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -68,6 +68,8 @@ void Runtime::OnUpdate(double dt)
         const auto& transform = d_scene.Entities().get<Transform3DComponent>(entity);
         return transform.position.y < -50;
     });
+
+    d_scene.post_update();
 }
 
 void Runtime::OnRender()

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -32,4 +32,5 @@ public:
     void OnEvent(Sprocket::ev::Event& event);
     void OnUpdate(double dt);
     void OnRender();
+    void PostUpdate() {}
 };

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -624,13 +624,19 @@
                     "name": "window_width",
                     "display_name": "Window Width",
                     "type": "float",
-                    "default": "0.0f"
+                    "default": "1280.0f"
                 },
                 {
                     "name": "window_height",
                     "display_name": "Window Height",
                     "type": "float",
-                    "default": "0.0f"
+                    "default": "720.0f"
+                },
+                {
+                    "name": "window_resized",
+                    "display_name": "Window Resized",
+                    "type": "bool",
+                    "default": "false"
                 }
             ]
         }

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -582,37 +582,55 @@
                     "name": "keyboard",
                     "display_name": "Keyboard",
                     "type": "std::array<bool, 512>",
-                    "default": "{}",
-                    "flags": {
-                        "SCRIPTABLE": false
-                    }
+                    "default": "{}"
                 },
                 {
                     "name": "mouse",
                     "display_name": "Mouse",
                     "type": "std::array<bool, 5>",
-                    "default": "{}",
-                    "flags": {
-                        "SCRIPTABLE": false
-                    }
+                    "default": "{}"
                 },
                 {
                     "name": "mouse_click",
                     "display_name": "Mouse Click",
                     "type": "std::array<bool, 5>",
-                    "default": "{}",
-                    "flags": {
-                        "SCRIPTABLE": false
-                    }
+                    "default": "{}"
                 },
                 {
                     "name": "mouse_unclick",
                     "display_name": "Mouse Unclick",
                     "type": "std::array<bool, 5>",
-                    "default": "{}",
-                    "flags": {
-                        "SCRIPTABLE": false
-                    }
+                    "default": "{}"
+                },
+                {
+                    "name": "mouse_pos",
+                    "display_name": "Mouse Position",
+                    "type": "glm::vec2",
+                    "default": "{0.0, 0.0}"
+                },
+                {
+                    "name": "mouse_offset",
+                    "display_name": "Mouse Offset",
+                    "type": "glm::vec2",
+                    "default": "{0.0, 0.0}"
+                },
+                {
+                    "name": "mouse_scrolled",
+                    "display_name": "Mouse Scrolled",
+                    "type": "glm::vec2",
+                    "default": "{0.0, 0.0}"
+                },
+                {
+                    "name": "window_width",
+                    "display_name": "Window Width",
+                    "type": "float",
+                    "default": "0.0f"
+                },
+                {
+                    "name": "window_height",
+                    "display_name": "Window Height",
+                    "type": "float",
+                    "default": "0.0f"
                 }
             ]
         }

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -595,6 +595,24 @@
                     "flags": {
                         "SCRIPTABLE": false
                     }
+                },
+                {
+                    "name": "mouse_click",
+                    "display_name": "Mouse Click",
+                    "type": "std::array<bool, 5>",
+                    "default": "{}",
+                    "flags": {
+                        "SCRIPTABLE": false
+                    }
+                },
+                {
+                    "name": "mouse_unclick",
+                    "display_name": "Mouse Unclick",
+                    "type": "std::array<bool, 5>",
+                    "default": "{}",
+                    "flags": {
+                        "SCRIPTABLE": false
+                    }
                 }
             ]
         }

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -569,6 +569,34 @@
                     "default": "{}"
                 }
             ]
+        },
+        {
+            "name": "InputSingleton",
+            "display_name": "Input Singleton",
+            "flags": {
+                "SAVABLE": false,
+                "SCRIPTABLE": false
+            },
+            "attributes": [
+                {
+                    "name": "keyboard",
+                    "display_name": "Keyboard",
+                    "type": "std::array<bool, 512>",
+                    "default": "{}",
+                    "flags": {
+                        "SCRIPTABLE": false
+                    }
+                },
+                {
+                    "name": "mouse",
+                    "display_name": "Mouse",
+                    "type": "std::array<bool, 5>",
+                    "default": "{}",
+                    "flags": {
+                        "SCRIPTABLE": false
+                    }
+                }
+            ]
         }
     ]
 }

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -7,7 +7,6 @@
 #include <exception>
 #include <format>
 #include <utility>
-#include <GLFW/glfw3.h>
 
 namespace Sprocket {
 

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -7,6 +7,7 @@
 #include <exception>
 #include <format>
 #include <utility>
+#include <GLFW/glfw3.h>
 
 namespace Sprocket {
 
@@ -70,7 +71,7 @@ int Run(App& app, Window& window, const RunOptions& options = {})
 
     while (window.Running()) {
         window.Clear();
-        
+
         double dt = watch.OnUpdate();
         app.on_update(dt);
         app.on_render();

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -3,6 +3,7 @@
 #include <queue>
 #include <string>
 #include <utility>
+#include <array>
 
 #include "apecs.hpp"
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -159,6 +159,8 @@ struct InputSingleton
 {
     std::array<bool, 512> keyboard = {};
     std::array<bool, 5> mouse = {};
+    std::array<bool, 5> mouse_click = {};
+    std::array<bool, 5> mouse_unclick = {};
 };
 
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -161,6 +161,11 @@ struct InputSingleton
     std::array<bool, 5> mouse = {};
     std::array<bool, 5> mouse_click = {};
     std::array<bool, 5> mouse_unclick = {};
+    glm::vec2 mouse_pos = {0.0, 0.0};
+    glm::vec2 mouse_offset = {0.0, 0.0};
+    glm::vec2 mouse_scrolled = {0.0, 0.0};
+    float window_width = 0.0f;
+    float window_height = 0.0f;
 };
 
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -164,8 +164,9 @@ struct InputSingleton
     glm::vec2 mouse_pos = {0.0, 0.0};
     glm::vec2 mouse_offset = {0.0, 0.0};
     glm::vec2 mouse_scrolled = {0.0, 0.0};
-    float window_width = 0.0f;
-    float window_height = 0.0f;
+    float window_width = 1280.0f;
+    float window_height = 720.0f;
+    bool window_resized = false;
 };
 
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -3,6 +3,7 @@
 #include <queue>
 #include <string>
 #include <utility>
+#include <array>
 
 #include "apecs.hpp"
 
@@ -152,6 +153,12 @@ struct Singleton
 struct CollisionSingleton
 {
     std::vector<std::pair<apx::entity, apx::entity>> collisions = {};
+};
+
+struct InputSingleton
+{
+    std::array<bool, 512> keyboard = {};
+    std::array<bool, 5> mouse = {};
 };
 
 

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -30,7 +30,8 @@ using registry = apx::registry<
     Sprocket::ParticleComponent,
     Sprocket::MeshAnimationComponent,
     Sprocket::Singleton,
-    Sprocket::CollisionSingleton
+    Sprocket::CollisionSingleton,
+    Sprocket::InputSingleton
 >;
 
 using entity = typename registry::handle_type;

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -616,6 +616,8 @@ void Copy(spkt::registry* source, spkt::registry* target)
             InputSingleton target_comp;
             target_comp.keyboard = transform(source_comp.keyboard);
             target_comp.mouse = transform(source_comp.mouse);
+            target_comp.mouse_click = transform(source_comp.mouse_click);
+            target_comp.mouse_unclick = transform(source_comp.mouse_unclick);
             dst.add<InputSingleton>(target_comp);
         }
     }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -618,6 +618,11 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.mouse = transform(source_comp.mouse);
             target_comp.mouse_click = transform(source_comp.mouse_click);
             target_comp.mouse_unclick = transform(source_comp.mouse_unclick);
+            target_comp.mouse_pos = transform(source_comp.mouse_pos);
+            target_comp.mouse_offset = transform(source_comp.mouse_offset);
+            target_comp.mouse_scrolled = transform(source_comp.mouse_scrolled);
+            target_comp.window_width = transform(source_comp.window_width);
+            target_comp.window_height = transform(source_comp.window_height);
             dst.add<InputSingleton>(target_comp);
         }
     }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -623,6 +623,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.mouse_scrolled = transform(source_comp.mouse_scrolled);
             target_comp.window_width = transform(source_comp.window_width);
             target_comp.window_height = transform(source_comp.window_height);
+            target_comp.window_resized = transform(source_comp.window_resized);
             dst.add<InputSingleton>(target_comp);
         }
     }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -342,15 +342,6 @@ void Load(const std::string& file, spkt::registry* reg)
             e.add<MeshAnimationComponent>(c);
         }
     }
-
-    // Add the singleton entity if the scene does not have one.
-    auto singleton = reg->find<Singleton>();
-    if (!reg->valid(singleton)) {
-        log::info("Adding a singleton entity to the loaded scene");
-        singleton = reg->create();
-        reg->emplace<Singleton>(singleton);
-        reg->emplace<NameComponent>(singleton, "::Singleton");
-    }
 }
 
 spkt::entity Copy(spkt::registry* reg, spkt::entity entity)

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -419,6 +419,9 @@ spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
     if (entity.has<CollisionSingleton>()) {
         e.add<CollisionSingleton>(entity.get<CollisionSingleton>());
     }
+    if (entity.has<InputSingleton>()) {
+        e.add<InputSingleton>(entity.get<InputSingleton>());
+    }
     return e;
 }
 
@@ -607,6 +610,13 @@ void Copy(spkt::registry* source, spkt::registry* target)
             CollisionSingleton target_comp;
             target_comp.collisions = transform(source_comp.collisions);
             dst.add<CollisionSingleton>(target_comp);
+        }
+        if (src.has<InputSingleton>()) {
+            const InputSingleton& source_comp = src.get<InputSingleton>();
+            InputSingleton target_comp;
+            target_comp.keyboard = transform(source_comp.keyboard);
+            target_comp.mouse = transform(source_comp.mouse);
+            dst.add<InputSingleton>(target_comp);
         }
     }
 }

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -80,15 +80,6 @@ DATAMATIC_BEGIN SAVABLE=true
         }
 DATAMATIC_END
     }
-
-    // Add the singleton entity if the scene does not have one.
-    auto singleton = reg->find<Singleton>();
-    if (!reg->valid(singleton)) {
-        log::info("Adding a singleton entity to the loaded scene");
-        singleton = reg->create();
-        reg->emplace<Singleton>(singleton);
-        reg->emplace<NameComponent>(singleton, "::Singleton");
-    }
 }
 
 spkt::entity Copy(spkt::registry* reg, spkt::entity entity)

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -54,15 +54,27 @@ void Scene::OnEvent(ev::Event& event)
         else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
             if (!event.is_consumed()) { 
                 input.mouse[data->button] = true;
+                input.mouse_click[data->button] = true;
             }
         }
         else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
             input.mouse[data->button] = false;
+            input.mouse_unclick[data->button] = true;
         }
     }
 
     for (auto& system : d_systems) {
         system->on_event(d_registry, event);
+    }
+}
+
+void Scene::post_update()
+{
+    auto singleton = d_registry.find<Singleton>();
+    if (d_registry.valid(singleton)) {
+        auto& input = d_registry.get<InputSingleton>(singleton);
+        input.mouse_click.fill(false);
+        input.mouse_unclick.fill(false);
     }
 }
 

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -41,41 +41,43 @@ void Scene::OnUpdate(double dt)
 void Scene::OnEvent(ev::Event& event)
 {
     auto singleton = d_registry.find<Singleton>();
-    if (d_registry.valid(singleton)) {
-        auto& input = d_registry.get<InputSingleton>(singleton);
-
-        if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
-            if (!event.is_consumed()) {
-                input.keyboard[data->key] = true;
-            }
-        }
-        else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
-            input.keyboard[data->key] = false;
-        }
-        else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
-            if (!event.is_consumed()) { 
-                input.mouse[data->button] = true;
-                input.mouse_click[data->button] = true;
-            }
-        }
-        else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
-            input.mouse[data->button] = false;
-            input.mouse_unclick[data->button] = true;
-        }
-        else if (auto data = event.get_if<ev::MouseScrolled>()) {
-            input.mouse_offset.x += data->x_offset;
-            input.mouse_offset.y += data->y_offset;
-        }
-        else if (auto data = event.get_if<ev::WindowResize>()) {
-            input.window_resized = true;
-        }
-
-        input.mouse_pos = d_window->GetMousePos();
-        input.mouse_offset = d_window->GetMouseOffset();
-
-        input.window_width = (float)d_window->Width();
-        input.window_height = (float)d_window->Height();
+    if (!d_registry.valid(singleton)) {
+        return;
     }
+
+    auto& input = d_registry.get<InputSingleton>(singleton);
+
+    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+        if (!event.is_consumed()) {
+            input.keyboard[data->key] = true;
+        }
+    }
+    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
+        input.keyboard[data->key] = false;
+    }
+    else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+        if (!event.is_consumed()) { 
+            input.mouse[data->button] = true;
+            input.mouse_click[data->button] = true;
+        }
+    }
+    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+        input.mouse[data->button] = false;
+        input.mouse_unclick[data->button] = true;
+    }
+    else if (auto data = event.get_if<ev::MouseScrolled>()) {
+        input.mouse_offset.x += data->x_offset;
+        input.mouse_offset.y += data->y_offset;
+    }
+    else if (auto data = event.get_if<ev::WindowResize>()) {
+        input.window_resized = true;
+    }
+
+    input.mouse_pos = d_window->GetMousePos();
+    input.mouse_offset = d_window->GetMouseOffset();
+
+    input.window_width = (float)d_window->Width();
+    input.window_height = (float)d_window->Height();
 
     for (auto& system : d_systems) {
         system->on_event(d_registry, event);

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -4,7 +4,8 @@
 
 namespace Sprocket {
 
-Scene::Scene()
+Scene::Scene(Window* window)
+    : d_window(window)
 {
     auto singleton = d_registry.create();
     d_registry.emplace<Singleton>(singleton);

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -62,6 +62,19 @@ void Scene::OnEvent(ev::Event& event)
             input.mouse[data->button] = false;
             input.mouse_unclick[data->button] = true;
         }
+        else if (auto data = event.get_if<ev::MouseScrolled>()) {
+            input.mouse_offset.x += data->x_offset;
+            input.mouse_offset.y += data->y_offset;
+        }
+        else if (auto data = event.get_if<ev::WindowResize>()) {
+            input.window_resized = true;
+        }
+
+        input.mouse_pos = d_window->GetMousePos();
+        input.mouse_offset = d_window->GetMouseOffset();
+
+        input.window_width = (float)d_window->Width();
+        input.window_height = (float)d_window->Height();
     }
 
     for (auto& system : d_systems) {

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -84,11 +84,4 @@ std::size_t Scene::Size() const
     return d_registry.size();
 }
 
-void Scene::Clear()
-{
-    d_registry.clear();
-    d_lookup.clear();
-    d_systems.clear();
-}
-
 }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -31,7 +31,6 @@ public:
     template <typename T, typename... Args>
     T& Add(Args&&... args);
 
-    template <typename T> bool Has();
     template <typename T> T& Get();
 
     void Load(std::string_view file);
@@ -42,8 +41,6 @@ public:
     void post_update();
 
     std::size_t Size() const;
-
-    void Clear();
 
     template <typename... Comps>
     spkt::entity find(const std::function<bool(spkt::entity)>& function = [](spkt::entity) { return true; });
@@ -60,11 +57,6 @@ T& Scene::Add(Args&&... args)
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
     d_systems.back()->on_startup(d_registry);
     return *static_cast<T*>(d_systems.back().get());
-}
-
-template <typename T> bool Scene::Has()
-{
-    return d_lookup.find(spkt::type_info<T>) != d_lookup.end();
 }
 
 template <typename T> T& Scene::Get()

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -35,6 +35,8 @@ public:
     void OnUpdate(double dt);
     void OnEvent(ev::Event& event);
 
+    void post_update();
+
     std::size_t Size() const;
 
     void Clear();

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -4,6 +4,7 @@
 #include "EntitySystem.h"
 #include "Events.h"
 #include "TypeInfo.h"
+#include "Window.h"
 
 #include <memory>
 #include <vector>
@@ -14,13 +15,16 @@ namespace Sprocket {
 
 class Scene
 {
+    // Temporary, will be removed when then the InputSingleton gets updated via a system.
+    Window* d_window;
+
     std::unordered_map<::spkt::type_info_t, std::size_t> d_lookup;
     std::vector<std::unique_ptr<EntitySystem>> d_systems;
 
     spkt::registry d_registry;
 
 public:
-    Scene();
+    Scene(Window* window);
 
     spkt::registry& Entities() { return d_registry; }
 

--- a/Sprocket/Scene/Systems/AnimationSystem.h
+++ b/Sprocket/Scene/Systems/AnimationSystem.h
@@ -4,9 +4,8 @@
 
 namespace Sprocket {
 
-class AnimationSystem : public EntitySystem
+struct AnimationSystem : public EntitySystem
 {
-public:
     void on_update(spkt::registry& registry, double dt) override;
 };
 

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -4,27 +4,42 @@
 #include "Scene.h"
 #include "ECS.h"
 
-namespace Sprocket {
+#include <cassert>
 
-CameraSystem::CameraSystem(float aspectRatio)
-    : d_aspectRatio(aspectRatio)
-{}
+namespace Sprocket {
+namespace {
+
+float aspect_ratio(const InputSingleton& input)
+{
+    assert(input.window_height > 0);
+    return input.window_width / input.window_height;
+}
+
+}
 
 void CameraSystem::on_event(spkt::registry& registry, ev::Event& event)
 {
     if (auto e = event.get_if<spkt::added<Camera3DComponent>>()) {
+        auto singleton = registry.find<Singleton>();
+        const auto& input = registry.get<InputSingleton>(singleton);
+
         spkt::entity entity = e->entity;
         auto& camera = entity.get<Camera3DComponent>();
         camera.projection = glm::perspective(
-            camera.fov, d_aspectRatio, 0.1f, 1000.0f
+            camera.fov, aspect_ratio(input), 0.1f, 1000.0f
         );
     }
-    else if (auto e = event.get_if<ev::WindowResize>()) {
-        d_aspectRatio = (float)e->width / e->height;
+}
+
+void CameraSystem::on_update(spkt::registry& registry, double dt)
+{
+    auto singleton = registry.find<Singleton>();
+    if (registry.valid(singleton)) {
+        const auto& input = registry.get<InputSingleton>(singleton);
         for (auto entity : registry.view<Camera3DComponent>()) {
             auto& camera = registry.get<Camera3DComponent>(entity);
             camera.projection = glm::perspective(
-                camera.fov, d_aspectRatio, 0.1f, 1000.0f
+                camera.fov, aspect_ratio(input), 0.1f, 1000.0f
             );
         }
     }

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -4,9 +4,8 @@
 
 namespace Sprocket {
 
-class CameraSystem : public EntitySystem
+struct CameraSystem : public EntitySystem
 {
-public:
     void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 };

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -6,11 +6,9 @@ namespace Sprocket {
 
 class CameraSystem : public EntitySystem
 {
-    float d_aspectRatio;
-
 public:
-    CameraSystem(float aspectRatio);
     void on_event(spkt::registry& registry, ev::Event& event) override;
+    void on_update(spkt::registry& registry, double dt) override;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -73,8 +73,7 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
 
 void GameGrid::on_update(spkt::registry& registry, double dt)
 {
-    auto singleton = registry.find<Singleton>();
-    const auto& input = registry.get<InputSingleton>(singleton);
+    const auto& input = get_singleton<InputSingleton>(registry);
 
     if (input.mouse_click[Mouse::LEFT]) {
         d_selected = d_hovered;

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -17,9 +17,8 @@ std::string Name(const spkt::entity& e) {
     return "Entity";
 }
 
-GameGrid::GameGrid(Window* window)
-    : d_window(window)
-    , d_hovered({0.0, 0.0})
+GameGrid::GameGrid()
+    : d_hovered({0.0, 0.0})
     , d_selected({})
 {
 }
@@ -79,15 +78,18 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
     }
 }
 
-void GameGrid::on_update(spkt::registry&, double dt)
+void GameGrid::on_update(spkt::registry& registry, double dt)
 {
+    auto singleton = registry.find<Singleton>();
+    const auto& input = registry.get<InputSingleton>(singleton);
+
     auto& camTr = d_camera.get<Transform3DComponent>();
 
     glm::vec3 cameraPos = camTr.position;
     glm::vec3 direction = Maths::GetMouseRay(
-        d_window->GetMousePos(),
-        d_window->Width(),
-        d_window->Height(),
+        input.mouse_pos,
+        input.window_width,
+        input.window_height,
         MakeView(d_camera),
         MakeProj(d_camera)
     );

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -69,19 +69,18 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
             d_gridEntities.erase(it);
         }
     }
-    else if (auto e = event.get_if<ev::MouseButtonPressed>()) {
-        if (e->button == Mouse::LEFT) {
-            d_selected = d_hovered;
-        } else {
-            d_selected = std::nullopt;
-        }
-    }
 }
 
 void GameGrid::on_update(spkt::registry& registry, double dt)
 {
     auto singleton = registry.find<Singleton>();
     const auto& input = registry.get<InputSingleton>(singleton);
+
+    if (input.mouse_click[Mouse::LEFT]) {
+        d_selected = d_hovered;
+    } else if (input.mouse_click[Mouse::RIGHT]) {
+        d_selected = std::nullopt;
+    }
 
     auto& camTr = d_camera.get<Transform3DComponent>();
 

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -2,7 +2,6 @@
 #include "ECS.h"
 #include "EntitySystem.h"
 #include "Hashing.h"
-#include "Window.h"
 #include "Maths.h"
 
 #include <memory>
@@ -20,8 +19,6 @@ public:
     using GridMap = std::unordered_map<glm::ivec2, spkt::entity>;
 
 private:
-    Window*       d_window;
-
     spkt::entity d_camera;
     spkt::entity d_hoveredSquare;
     spkt::entity d_selectedSquare;
@@ -32,7 +29,7 @@ private:
     GridMap d_gridEntities; 
 
 public:
-    GameGrid(Window* window);
+    GameGrid();
 
     void on_startup(spkt::registry& registry) override;
     void on_event(spkt::registry& registry, ev::Event& event) override;

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -4,9 +4,8 @@
 
 namespace Sprocket {
 
-class PathFollower : public EntitySystem
+struct PathFollower : public EntitySystem
 {
-public:
     void on_update(spkt::registry& registry, double dt) override;
         // Called once per entity per frame and before the system updates.
 };

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -254,7 +254,7 @@ void PhysicsEngine3D::on_event(spkt::registry& registry, ev::Event& event)
         entry.capsuleCollider = entry.body->addCollider(shape, transform);
         SetMaterial(entry.capsuleCollider, e->entity.get<RigidBody3DComponent>()); 
     }
-    else if (auto e = event.get_if<spkt::removed<SphereCollider3DComponent>>()) {
+    else if (auto e = event.get_if<spkt::removed<CapsuleCollider3DComponent>>()) {
         auto& entry = d_impl->entityData[e->entity];
         entry.body->removeCollider(entry.capsuleCollider);
     }

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -324,8 +324,7 @@ void PhysicsEngine3D::on_update(spkt::registry& registry, double dt)
     }
 
     // Update the CollisionSingleton
-    auto singleton = registry.find<Singleton>();
-    auto& cs = registry.get<CollisionSingleton>(singleton);
+    auto& cs = get_singleton<CollisionSingleton>(registry);
     cs.collisions = d_impl->listener.collisions();
     d_impl->listener.collisions().clear();
 }

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -48,14 +48,11 @@ apx::generator<lua::Script&> ScriptRunner::active_scripts()
 
 void ScriptRunner::on_event(spkt::registry& registry, ev::Event& event)
 {
-    d_input.on_event(event);
-
     if (auto e = event.get_if<spkt::added<ScriptComponent>>()) {
         lua::Script script(e->entity.get<ScriptComponent>().script);
         lua::load_vec3_functions(script);
         lua::load_vec2_functions(script);
         lua::load_registry_functions(script, registry);
-        lua::load_input_functions(script, d_input);
         lua::load_window_functions(script, *d_window);
 
         lua::load_entity_transformation_functions(script);

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -75,14 +75,6 @@ void ScriptRunner::on_event(spkt::registry& registry, ev::Event& event)
             }
         }
     }
-    else if (auto e = event.get_if<ev::MouseButtonPressed>()) {
-        for (auto& script : active_scripts()) {
-            if (script.has_function("OnMouseButtonPressedEvent") &&
-                script.call_function<bool>("OnMouseButtonPressedEvent", e->button, e->action, e->mods)) {
-                event.consume();
-            }
-        }
-    }
     else if (auto e = event.get_if<ev::MouseScrolled>()) {
         for (auto& script : active_scripts()) {
             if (script.has_function("OnMouseScrolledEvent") &&

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -2,7 +2,6 @@
 #include "LuaScript.h"
 #include "ECS.h"
 #include "EntitySystem.h"
-#include "Window.h"
 
 #include <unordered_map>
 #include <apecs.hpp>
@@ -11,15 +10,9 @@ namespace Sprocket {
 
 class ScriptRunner : public EntitySystem
 {
-    Window*    d_window;
-
     std::unordered_map<spkt::entity, std::pair<lua::Script, bool>> d_engines;
 
-    apx::generator<lua::Script&> active_scripts();
-
 public:
-    ScriptRunner(Window* window);
-
     void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 };

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -2,7 +2,6 @@
 #include "LuaScript.h"
 #include "ECS.h"
 #include "EntitySystem.h"
-#include "InputProxy.h"
 #include "Window.h"
 
 #include <unordered_map>
@@ -13,7 +12,6 @@ namespace Sprocket {
 class ScriptRunner : public EntitySystem
 {
     Window*    d_window;
-    InputProxy d_input;
 
     std::unordered_map<spkt::entity, std::pair<lua::Script, bool>> d_engines;
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -145,6 +145,24 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "GetMousePos", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        const auto& input = registry.get<InputSingleton>(singleton);
+        Converter<glm::vec2>::push(L, input.mouse_pos);
+        return 1;
+    });
+
+    lua_register(L, "GetMouseOffset", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        const auto& input = registry.get<InputSingleton>(singleton);
+        Converter<glm::vec2>::push(L, input.mouse_offset);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.
@@ -220,28 +238,6 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
             end
         end
     )lua");
-}
-
-void load_window_functions(lua::Script& script, Window& window)
-{
-    lua_State* L = script.native_handle();
-    script.set_value("__window__", &window);
-
-    lua_register(L, "GetMousePos", [](lua_State* L) {
-        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto w = get_pointer<Window>(L, "__window__");
-        glm::vec2 mouse_pos = w ? w->GetMousePos() : glm::vec2(0.0, 0.0);
-        Converter<glm::vec2>::push(L, mouse_pos);
-        return 1;
-    });
-
-    lua_register(L, "GetMouseOffset", [](lua_State* L) {
-        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto w = get_pointer<Window>(L, "__window__");
-        glm::vec2 mouse_offset = w ? w->GetMouseOffset() : glm::vec2(0.0, 0.0);
-        Converter<glm::vec2>::push(L, mouse_offset);
-        return 1;
-    });
 }
 
 void load_entity_transformation_functions(lua::Script& script)

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -112,8 +112,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsKeyDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -121,8 +120,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseClicked", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -130,8 +128,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -139,8 +136,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -148,8 +144,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "GetMousePos", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        const auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<glm::vec2>::push(L, input.mouse_pos);
         return 1;
     });
@@ -157,8 +152,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "GetMouseOffset", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        const auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<glm::vec2>::push(L, input.mouse_offset);
         return 1;
     });

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -109,6 +109,25 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    // Input access via the singleton component.
+    lua_register(L, "IsKeyDown", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
+    lua_register(L, "IsMouseDown", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.
@@ -184,28 +203,6 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
             end
         end
     )lua");
-}
-
-void load_input_functions(lua::Script& script, InputProxy& input)
-{
-    lua_State* L = script.native_handle();
-    script.set_value("__input__", &input);
-
-    lua_register(L, "IsKeyDown", [](lua_State* L) {
-        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        auto ip = get_pointer<InputProxy>(L, "__input__");
-        bool keyboard_down = ip ? ip->is_keyboard_down((int)lua_tointeger(L, 1)) : false;
-        Converter<bool>::push(L, keyboard_down);
-        return 1;
-    });
-
-    lua_register(L, "IsMouseDown", [](lua_State* L) {
-        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        auto ip = get_pointer<InputProxy>(L, "__input__");
-        bool mouse_down = ip ? ip->is_mouse_down((int)lua_tointeger(L, 1)) : false;
-        Converter<bool>::push(L, mouse_down);
-        return 1;
-    });
 }
 
 void load_window_functions(lua::Script& script, Window& window)

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -118,6 +118,24 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "IsMouseClicked", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
+    lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -3,7 +3,6 @@
 #include "LuaConverter.h"
 #include "ECS.h"
 #include "Scene.h"
-#include "InputProxy.h"
 #include "Window.h"
 #include "Components.h"
 #include "Log.h"

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -145,6 +145,24 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "GetMousePos", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        const auto& input = registry.get<InputSingleton>(singleton);
+        Converter<glm::vec2>::push(L, input.mouse_pos);
+        return 1;
+    });
+
+    lua_register(L, "GetMouseOffset", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        const auto& input = registry.get<InputSingleton>(singleton);
+        Converter<glm::vec2>::push(L, input.mouse_offset);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.
@@ -220,28 +238,6 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
             end
         end
     )lua");
-}
-
-void load_window_functions(lua::Script& script, Window& window)
-{   
-    lua_State* L = script.native_handle();
-    script.set_value("__window__", &window);
-
-    lua_register(L, "GetMousePos", [](lua_State* L) {
-        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto w = get_pointer<Window>(L, "__window__");
-        glm::vec2 mouse_pos = w ? w->GetMousePos() : glm::vec2(0.0, 0.0);
-        Converter<glm::vec2>::push(L, mouse_pos);
-        return 1;
-    });
-
-    lua_register(L, "GetMouseOffset", [](lua_State* L) {
-        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        auto w = get_pointer<Window>(L, "__window__");
-        glm::vec2 mouse_offset = w ? w->GetMouseOffset() : glm::vec2(0.0, 0.0);
-        Converter<glm::vec2>::push(L, mouse_offset);
-        return 1;
-    });
 }
 
 void load_entity_transformation_functions(lua::Script& script)

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -112,8 +112,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsKeyDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -121,8 +120,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseClicked", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -130,8 +128,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -139,8 +136,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
         return 1;
     });
@@ -148,8 +144,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "GetMousePos", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        const auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<glm::vec2>::push(L, input.mouse_pos);
         return 1;
     });
@@ -157,8 +152,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "GetMouseOffset", [](lua_State* L) {
         if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        const auto& input = registry.get<InputSingleton>(singleton);
+        const auto& input = get_singleton<InputSingleton>(registry);
         Converter<glm::vec2>::push(L, input.mouse_offset);
         return 1;
     });

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -109,6 +109,25 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    // Input access via the singleton component.
+    lua_register(L, "IsKeyDown", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
+    lua_register(L, "IsMouseDown", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.
@@ -184,28 +203,6 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
             end
         end
     )lua");
-}
-
-void load_input_functions(lua::Script& script, InputProxy& input)
-{
-    lua_State* L = script.native_handle();
-    script.set_value("__input__", &input);
-
-    lua_register(L, "IsKeyDown", [](lua_State* L) {
-        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        auto ip = get_pointer<InputProxy>(L, "__input__");
-        bool keyboard_down = ip ? ip->is_keyboard_down((int)lua_tointeger(L, 1)) : false;
-        Converter<bool>::push(L, keyboard_down);
-        return 1;
-    });
-
-    lua_register(L, "IsMouseDown", [](lua_State* L) {
-        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        auto ip = get_pointer<InputProxy>(L, "__input__");
-        bool mouse_down = ip ? ip->is_mouse_down((int)lua_tointeger(L, 1)) : false;
-        Converter<bool>::push(L, mouse_down);
-        return 1;
-    });
 }
 
 void load_window_functions(lua::Script& script, Window& window)

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -118,6 +118,24 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "IsMouseClicked", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
+    lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
+        if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = registry.find<Singleton>();
+        auto& input = registry.get<InputSingleton>(singleton);
+        Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
+        return 1;
+    });
+
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -3,7 +3,6 @@
 #include "LuaConverter.h"
 #include "ECS.h"
 #include "Scene.h"
-#include "InputProxy.h"
 #include "Window.h"
 #include "Components.h"
 #include "Log.h"

--- a/Sprocket/Scripting/LuaLibrary.h
+++ b/Sprocket/Scripting/LuaLibrary.h
@@ -7,20 +7,15 @@ struct lua_State;
 
 namespace Sprocket {
 
-class Window;
-
 namespace lua {
 
 class Script;
 
 // Loads the given scene into the given lua state, and provides functions for
 // creating/deleting entities as well as iterating entities. Also provides functions
-// for access the singleton entity.
+// for access the singleton entity, which in turn gives access to the keyboard, mouse
+// and window via the InputSingleton.
 void load_registry_functions(lua::Script& script, spkt::registry& registry);
-
-// Loads the given window into the given lua state, and provides functions for
-// checking the current mouse position and the mouse offset from the previous frame.
-void load_window_functions(lua::Script& script, Window& window);
 
 // Loads a bunch of helper functions to ease entity manipulation.
 void load_entity_transformation_functions(lua::Script& script);

--- a/Sprocket/Scripting/LuaLibrary.h
+++ b/Sprocket/Scripting/LuaLibrary.h
@@ -8,19 +8,15 @@ struct lua_State;
 namespace Sprocket {
 
 class Window;
-class InputProxy;
 
 namespace lua {
 
 class Script;
 
 // Loads the given scene into the given lua state, and provides functions for
-// creating/deleting entities as well as iterating entities.
+// creating/deleting entities as well as iterating entities. Also provides functions
+// for access the singleton entity.
 void load_registry_functions(lua::Script& script, spkt::registry& registry);
-
-// Loads the given input proxy into the given lua state, and provides functions
-// for checking if keyboard and mouse buttons are currently pressed.
-void load_input_functions(lua::Script& script, InputProxy& input);
 
 // Loads the given window into the given lua state, and provides functions for
 // checking the current mouse position and the mouse offset from the previous frame.

--- a/Sprocket/Utility/Maths.cpp
+++ b/Sprocket/Utility/Maths.cpp
@@ -67,7 +67,7 @@ glm::mat4 NoScale(const glm::mat4& matrix)
     return Maths::Transform(pos, ori);
 }
 
-glm::vec3 GetMouseRay(const glm::vec2& mousePos, u32 w, u32 h, const glm::mat4& view, const glm::mat4& proj)
+glm::vec3 GetMouseRay(const glm::vec2& mousePos, float w, float h, const glm::mat4& view, const glm::mat4& proj)
 {
     // Homogeneous Clip Space
     glm::vec4 ray = {(2.0f * mousePos.x) / w - 1, -((2.0f * mousePos.y) / h - 1), -1.0f, 1.0f};

--- a/Sprocket/Utility/Maths.h
+++ b/Sprocket/Utility/Maths.h
@@ -18,7 +18,7 @@ void Decompose(const glm::mat4& matrix, glm::vec3* position, glm::quat* orientat
 glm::vec3 GetTranslation(const glm::mat4& m);
 float Modulo(float val, float high);
 glm::mat4 NoScale(const glm::mat4& matrix);
-glm::vec3 GetMouseRay(const glm::vec2& mousePos, u32 w, u32 h, const glm::mat4& view, const glm::mat4& proj);
+glm::vec3 GetMouseRay(const glm::vec2& mousePos, float w, float h, const glm::mat4& view, const glm::mat4& proj);
 glm::vec3 ApplyTransform(const glm::mat4& matrix, const glm::vec3& v);
 
 }

--- a/imgui.ini
+++ b/imgui.ini
@@ -80,7 +80,7 @@ Collapsed=1
 
 [Window][Viewport]
 Pos=0,21
-Size=973,699
+Size=1055,699
 Collapsed=0
 DockId=0x00000004,0
 
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=975,418
-Size=305,235
+Pos=1057,418
+Size=223,235
 Collapsed=0
 DockId=0x00000005,0
 
@@ -131,8 +131,8 @@ Size=287,329
 Collapsed=0
 
 [Window][Explorer]
-Pos=975,21
-Size=305,395
+Pos=1057,21
+Size=223,395
 Collapsed=0
 DockId=0x00000003,0
 
@@ -157,15 +157,15 @@ Size=277,422
 Collapsed=0
 
 [Window][Options]
-Pos=975,655
-Size=305,65
+Pos=1057,655
+Size=223,65
 Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
 DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=449,699 CentralNode=1 Selected=0x995B0CF8
-  DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=305,699 Split=Y Selected=0x1E89CEB8
+  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=1055,699 CentralNode=1 Selected=0x995B0CF8
+  DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=223,699 Split=Y Selected=0x1E89CEB8
     DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0x1E89CEB8
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=309,395 Selected=0x1E89CEB8
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=309,235 Selected=0xF02CD328


### PR DESCRIPTION
* Add `mouse_click`, `mouse_unlick`, `mouse_pos`, `mouse_offset`, `mouse_scrolled`, `window_resized`, `window_width` and `window_height` to the `InputSingleton`.
* Removed the `Window*` from all systems, now that data is accessed through the singleton.
* Removed `Scene::Clear`, just recreate the scene from scratch when needed.
* Add `Scene::post_update` for resetting parts of the input singleton that contain per-frame data.
* The `Loader` no longer adds the singleton, that is done in the scene constructor.
* `CameraSystem` is now stateless.