### PR TITLE
Make GameGrid Stateless

### DIFF
--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -316,6 +316,32 @@ void Inspector::Show(Anvil& editor)
         }
     }
 
+    if (entity.has<GameGridSingleton>()) {
+        auto& c = entity.get<GameGridSingleton>();
+        if (ImGui::CollapsingHeader("Game Grid Singleton")) {
+            ImGui::PushID(count++);
+            ;
+            ;
+            ;
+            ;
+            ;
+            
+            if (ImGui::Button("Delete")) { entity.remove<GameGridSingleton>(); }
+            ImGui::PopID();
+        }
+    }
+
+    if (entity.has<CameraSingleton>()) {
+        auto& c = entity.get<CameraSingleton>();
+        if (ImGui::CollapsingHeader("Camera Singleton")) {
+            ImGui::PushID(count++);
+            ;
+            
+            if (ImGui::Button("Delete")) { entity.remove<CameraSingleton>(); }
+            ImGui::PopID();
+        }
+    }
+
     ImGui::Separator();
 
     if (ImGui::Button("Add Component")) {
@@ -410,6 +436,14 @@ void Inspector::Show(Anvil& editor)
         if (!entity.has<InputSingleton>() && ImGui::Selectable("Input Singleton")) {
             InputSingleton c;
             entity.add<InputSingleton>(c);
+        }
+        if (!entity.has<GameGridSingleton>() && ImGui::Selectable("Game Grid Singleton")) {
+            GameGridSingleton c;
+            entity.add<GameGridSingleton>(c);
+        }
+        if (!entity.has<CameraSingleton>() && ImGui::Selectable("Camera Singleton")) {
+            CameraSingleton c;
+            entity.add<CameraSingleton>(c);
         }
         ImGui::EndMenu();
     }

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -180,12 +180,13 @@ void WorldLayer::OnEvent(Sprocket::ev::Event& event)
                 std::queue<glm::vec3>().swap(path.markers);
                 auto pos = d_worker.get<Transform3DComponent>().position;
                 if (glm::distance(pos, mousePos) > 1.0f) {
+                    auto& registry = d_scene.Entities();
+                    const auto& grid = get_singleton<GameGridSingleton>(registry);
                     path.markers = GenerateAStarPath(
                         pos,
                         mousePos,
                         [&](const glm::ivec2& pos) {
-                            auto e = d_scene.Get<GameGrid>().At(d_scene.Entities(), pos);
-                            return e.valid();
+                            return registry.valid(grid.game_grid.at(pos));
                         }
                     );
                 } else {

--- a/Resources/Scripts/ThirdPersonCamera.lua
+++ b/Resources/Scripts/ThirdPersonCamera.lua
@@ -60,12 +60,9 @@ function OnUpdate(entity, dt)
     end
 
     SetLookAt(entity, pos, TARGET)
-end
 
-function OnMouseScrolledEvent(xOffset, yOffset)
-    if ABS_VERT == nil then return false end
-        -- If we receive an event before update, just ignore it
-
-    ABS_VERT = Clamp(ABS_VERT - yOffset, ABS_VERT_LOW, ABS_VERT_HIGH)
-    return true
+    local offset = GetMouseScrolled()
+    if offset.y ~= 0 and ABS_VERT ~= nil then
+        ABS_VERT = Clamp(ABS_VERT - offset.y, ABS_VERT_LOW, ABS_VERT_HIGH)
+    end
 end

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -639,6 +639,62 @@
                     "default": "false"
                 }
             ]
+        },
+        {
+            "name": "GameGridSingleton",
+            "display_name": "Game Grid Singleton",
+            "flags": {
+                "SCRIPTABLE": false,
+                "SAVABLE": false
+            },
+            "attributes": [
+                {
+                    "name": "hovered_square_entity",
+                    "display_name": "Hovered Square Entity",
+                    "type": "apx::entity",
+                    "default": "apx::null"
+                },
+                {
+                    "name": "clicked_square_entity",
+                    "display_name": "Clicked Square Entity",
+                    "type": "apx::entity",
+                    "default": "apx::null"
+                },
+                {
+                    "name": "hovered_square",
+                    "display_name": "Hovered Square",
+                    "type": "glm::ivec2",
+                    "default": "{0, 0}"
+                },
+                {
+                    "name": "clicked_square",
+                    "display_name": "Clicked Square",
+                    "type": "std::optional<glm::ivec2>",
+                    "default": "std::nullopt"
+                },
+                {
+                    "name": "game_grid",
+                    "display_name": "Game Grid",
+                    "type": "std::unordered_map<glm::ivec2, apx::entity>",
+                    "default": "{}"
+                }
+            ]
+        },
+        {
+            "name": "CameraSingleton",
+            "display_name": "Camera Singleton",
+            "flags": {
+                "SCRIPTABLE": false,
+                "SAVABLE": false
+            },
+            "attributes": [
+                {
+                    "name": "camera_entity",
+                    "display_name": "Camera Entity",
+                    "type": "apx::entity",
+                    "default": "apx::null"
+                }
+            ]
         }
     ]
 }

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -4,6 +4,11 @@
 #include <string>
 #include <utility>
 #include <array>
+#include <unordered_map>
+#include <optional>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
 
 #include "apecs.hpp"
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -4,6 +4,11 @@
 #include <string>
 #include <utility>
 #include <array>
+#include <unordered_map>
+#include <optional>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
 
 #include "apecs.hpp"
 
@@ -167,6 +172,20 @@ struct InputSingleton
     float window_width = 1280.0f;
     float window_height = 720.0f;
     bool window_resized = false;
+};
+
+struct GameGridSingleton
+{
+    apx::entity hovered_square_entity = apx::null;
+    apx::entity clicked_square_entity = apx::null;
+    glm::ivec2 hovered_square = {0, 0};
+    std::optional<glm::ivec2> clicked_square = std::nullopt;
+    std::unordered_map<glm::ivec2, apx::entity> game_grid = {};
+};
+
+struct CameraSingleton
+{
+    apx::entity camera_entity = apx::null;
 };
 
 

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -31,7 +31,9 @@ using registry = apx::registry<
     Sprocket::MeshAnimationComponent,
     Sprocket::Singleton,
     Sprocket::CollisionSingleton,
-    Sprocket::InputSingleton
+    Sprocket::InputSingleton,
+    Sprocket::GameGridSingleton,
+    Sprocket::CameraSingleton
 >;
 
 using entity = typename registry::handle_type;

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -413,6 +413,12 @@ spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
     if (entity.has<InputSingleton>()) {
         e.add<InputSingleton>(entity.get<InputSingleton>());
     }
+    if (entity.has<GameGridSingleton>()) {
+        e.add<GameGridSingleton>(entity.get<GameGridSingleton>());
+    }
+    if (entity.has<CameraSingleton>()) {
+        e.add<CameraSingleton>(entity.get<CameraSingleton>());
+    }
     return e;
 }
 
@@ -616,6 +622,22 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.window_height = transform(source_comp.window_height);
             target_comp.window_resized = transform(source_comp.window_resized);
             dst.add<InputSingleton>(target_comp);
+        }
+        if (src.has<GameGridSingleton>()) {
+            const GameGridSingleton& source_comp = src.get<GameGridSingleton>();
+            GameGridSingleton target_comp;
+            target_comp.hovered_square_entity = transform(source_comp.hovered_square_entity);
+            target_comp.clicked_square_entity = transform(source_comp.clicked_square_entity);
+            target_comp.hovered_square = transform(source_comp.hovered_square);
+            target_comp.clicked_square = transform(source_comp.clicked_square);
+            target_comp.game_grid = transform(source_comp.game_grid);
+            dst.add<GameGridSingleton>(target_comp);
+        }
+        if (src.has<CameraSingleton>()) {
+            const CameraSingleton& source_comp = src.get<CameraSingleton>();
+            CameraSingleton target_comp;
+            target_comp.camera_entity = transform(source_comp.camera_entity);
+            dst.add<CameraSingleton>(target_comp);
         }
     }
 }

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -66,8 +66,8 @@ void Scene::OnEvent(ev::Event& event)
         input.mouse_unclick[data->button] = true;
     }
     else if (auto data = event.get_if<ev::MouseScrolled>()) {
-        input.mouse_offset.x += data->x_offset;
-        input.mouse_offset.y += data->y_offset;
+        input.mouse_scrolled.x += data->x_offset;
+        input.mouse_scrolled.y += data->y_offset;
     }
     else if (auto data = event.get_if<ev::WindowResize>()) {
         input.window_resized = true;
@@ -91,6 +91,8 @@ void Scene::post_update()
         auto& input = d_registry.get<InputSingleton>(singleton);
         input.mouse_click.fill(false);
         input.mouse_unclick.fill(false);
+        input.mouse_offset = {0.0, 0.0};
+        input.mouse_scrolled = {0.0, 0.0};
     }
 }
 

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -25,48 +25,57 @@ GameGrid::GameGrid()
 
 void GameGrid::on_startup(spkt::registry& registry)
 {
+    auto singleton = registry.find<Singleton>();
+    auto& grid = registry.emplace<GameGridSingleton>(singleton);
+    registry.emplace<CameraSingleton>(singleton);
+
     std::string gridSquare = "Resources/Models/Square.obj";
 
-    d_hoveredSquare = apx::create_from(registry);
-    auto& n1 = d_hoveredSquare.emplace<NameComponent>();
-    d_hoveredSquare.emplace<TemporaryComponent>();
-    n1.name = "Hovered Grid Highlighter";
-    auto& tr1 = d_hoveredSquare.emplace<Transform3DComponent>();
+    grid.hovered_square_entity = registry.create();
+    registry.emplace<NameComponent>(grid.hovered_square_entity, "Hovered Grid Highlighter");
+    registry.emplace<TemporaryComponent>(grid.hovered_square_entity);
+    auto& tr1 = registry.emplace<Transform3DComponent>(grid.hovered_square_entity);
     tr1.scale = {0.3f, 0.3f, 0.3f};
-    auto& model1 = d_hoveredSquare.emplace<ModelComponent>();
+    auto& model1 = registry.emplace<ModelComponent>(grid.hovered_square_entity);
     model1.mesh = gridSquare;
 
-    d_selectedSquare = apx::create_from(registry);
-    auto& n2 = d_selectedSquare.emplace<NameComponent>();
-    d_selectedSquare.emplace<TemporaryComponent>();
-    n2.name = "Selected Grid Highlighter";
-    auto& tr2 = d_selectedSquare.emplace<Transform3DComponent>();
+    grid.clicked_square_entity = registry.create();
+    registry.emplace<NameComponent>(grid.clicked_square_entity, "Clicked Grid Highlighter");
+    registry.emplace<TemporaryComponent>(grid.clicked_square_entity);
+    auto& tr2 = registry.emplace<Transform3DComponent>(grid.clicked_square_entity);
     tr2.scale = {0.5f, 0.5f, 0.5f};
-    auto& model2 = d_selectedSquare.emplace<ModelComponent>();
+    auto& model2 = registry.emplace<ModelComponent>(grid.clicked_square_entity);
     model2.mesh = gridSquare;
 }
 
 void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
 {
+    auto singleton = registry.find<Singleton>();
+    if (!registry.valid(singleton)) {
+        return;
+    }
+
+    auto& grid = registry.get<GameGridSingleton>(singleton);
+
     if (auto e = event.get_if<spkt::added<GridComponent>>()) {
         spkt::entity entity = e->entity;
         auto& transform = entity.get<Transform3DComponent>();
         const auto& gc = entity.get<GridComponent>();
 
-        assert(!d_gridEntities.contains({gc.x, gc.z}));
+        assert(!grid.game_grid.contains({gc.x, gc.z}));
     
         transform.position.x = gc.x + 0.5f;
         transform.position.z = gc.z + 0.5f;
-        d_gridEntities[{gc.x, gc.z}] = entity;
+        grid.game_grid[{gc.x, gc.z}] = entity.entity();
     }
     else if (auto e = event.get_if<spkt::removed<GridComponent>>()) {
         auto& gc = e->entity.get<GridComponent>();
-        auto it = d_gridEntities.find({gc.x, gc.z});
-        if (it == d_gridEntities.end()) {
+        auto it = grid.game_grid.find({gc.x, gc.z});
+        if (it == grid.game_grid.end()) {
             log::warn("No entity exists at this coord!");
         }
         else {
-            d_gridEntities.erase(it);
+            grid.game_grid.erase(it);
         }
     }
 }
@@ -74,54 +83,69 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
 void GameGrid::on_update(spkt::registry& registry, double dt)
 {
     const auto& input = get_singleton<InputSingleton>(registry);
+    const auto& cam = get_singleton<CameraSingleton>(registry);
+    auto& grid = get_singleton<GameGridSingleton>(registry);
 
     if (input.mouse_click[Mouse::LEFT]) {
-        d_selected = d_hovered;
+        grid.clicked_square = grid.hovered_square;
     } else if (input.mouse_click[Mouse::RIGHT]) {
-        d_selected = std::nullopt;
+        grid.clicked_square = std::nullopt;
     }
 
-    auto& camTr = d_camera.get<Transform3DComponent>();
+    auto& camTr = registry.get<Transform3DComponent>(cam.camera_entity);
 
     glm::vec3 cameraPos = camTr.position;
     glm::vec3 direction = Maths::GetMouseRay(
         input.mouse_pos,
         input.window_width,
         input.window_height,
-        MakeView(d_camera),
-        MakeProj(d_camera)
+        MakeView({registry, cam.camera_entity}),
+        MakeProj({registry, cam.camera_entity})
     );
 
     float lambda = -cameraPos.y / direction.y;
     glm::vec3 mousePos = cameraPos + lambda * direction;
-    d_hovered = {(int)std::floor(mousePos.x), (int)std::floor(mousePos.z)};
+    grid.hovered_square = {(int)std::floor(mousePos.x), (int)std::floor(mousePos.z)};
 
-    d_hoveredSquare.get<Transform3DComponent>().position = { d_hovered.x + 0.5f, 0.05f, d_hovered.y + 0.5f };
-    if (d_selected.has_value()) {
-        d_selectedSquare.get<Transform3DComponent>().position = { d_selected.value().x + 0.5f, 0.05f, d_selected.value().y + 0.5f };
+    registry.get<Transform3DComponent>(grid.hovered_square_entity).position = {
+        grid.hovered_square.x + 0.5f, 0.05f, grid.hovered_square.y + 0.5f
+    };
+
+    if (grid.clicked_square.has_value()) {
+        auto square = grid.clicked_square.value();
+        registry.get<Transform3DComponent>(grid.clicked_square_entity).position = {
+            square.x + 0.5f, 0.05f, square.y + 0.5f
+        };
     } else {
-        d_selectedSquare.get<Transform3DComponent>().position = { 0.5f, -1.0f, 0.5f };
+        registry.get<Transform3DComponent>(grid.clicked_square_entity).position = {
+            0.5f, -1.0f, 0.5f
+        };
     }
 }
 
-spkt::entity GameGrid::At(const glm::ivec2& pos) const
+spkt::entity GameGrid::At(spkt::registry& registry, const glm::ivec2& pos) const
 {
-    auto it = d_gridEntities.find(pos);
-    if (it != d_gridEntities.end()) {
-        return it->second;
+    const auto& grid = get_singleton<GameGridSingleton>(registry);
+
+    auto it = grid.game_grid.find(pos);
+    if (it != grid.game_grid.end()) {
+        return {registry, it->second};
     }
     return spkt::null;
 }
 
-spkt::entity GameGrid::Hovered() const
+spkt::entity GameGrid::Hovered(spkt::registry& registry) const
 {
-    return At(d_hovered);
+    const auto& grid = get_singleton<GameGridSingleton>(registry);
+    return At(registry, grid.hovered_square);
 }
 
-spkt::entity GameGrid::Selected() const
+spkt::entity GameGrid::Selected(spkt::registry& registry) const
 {
-    if (d_selected.has_value()) {
-        return At(d_selected.value());
+    const auto& grid = get_singleton<GameGridSingleton>(registry);
+
+    if (grid.clicked_square.has_value()) {
+        return At(registry, grid.clicked_square.value());
     }
     return spkt::null;
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -66,7 +66,7 @@ void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
     }
 }
 
-void GameGrid::on_update(spkt::registry& registry, double dt)
+void GameGrid::on_update(spkt::registry& registry, double)
 {
     const auto& input = get_singleton<InputSingleton>(registry);
     const auto& cam = get_singleton<CameraSingleton>(registry);

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -117,31 +117,4 @@ void GameGrid::on_update(spkt::registry& registry, double dt)
     }
 }
 
-spkt::entity GameGrid::At(spkt::registry& registry, const glm::ivec2& pos) const
-{
-    const auto& grid = get_singleton<GameGridSingleton>(registry);
-
-    auto it = grid.game_grid.find(pos);
-    if (it != grid.game_grid.end()) {
-        return {registry, it->second};
-    }
-    return spkt::null;
-}
-
-spkt::entity GameGrid::Hovered(spkt::registry& registry) const
-{
-    const auto& grid = get_singleton<GameGridSingleton>(registry);
-    return At(registry, grid.hovered_square);
-}
-
-spkt::entity GameGrid::Selected(spkt::registry& registry) const
-{
-    const auto& grid = get_singleton<GameGridSingleton>(registry);
-
-    if (grid.clicked_square.has_value()) {
-        return At(registry, grid.clicked_square.value());
-    }
-    return spkt::null;
-}
-
 }

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -5,17 +5,9 @@
 #include "MouseCodes.h"
 #include "Log.h"
 
-#include <random>
 #include <cassert>
 
 namespace Sprocket {
-
-std::string Name(const spkt::entity& e) {
-    if (e.has<NameComponent>()) {
-        return e.get<NameComponent>().name;
-    }
-    return "Entity";
-}
 
 void GameGrid::on_startup(spkt::registry& registry)
 {

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -17,12 +17,6 @@ std::string Name(const spkt::entity& e) {
     return "Entity";
 }
 
-GameGrid::GameGrid()
-    : d_hovered({0.0, 0.0})
-    , d_selected({})
-{
-}
-
 void GameGrid::on_startup(spkt::registry& registry)
 {
     auto singleton = registry.find<Singleton>();

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -1,15 +1,7 @@
 #pragma once
+#include "Events.h"
 #include "ECS.h"
 #include "EntitySystem.h"
-#include "Hashing.h"
-#include "Maths.h"
-
-#include <memory>
-#include <unordered_map>
-#include <optional>
-
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/hash.hpp>
 
 namespace Sprocket {
 
@@ -18,11 +10,6 @@ struct GameGrid : public EntitySystem
     void on_startup(spkt::registry& registry) override;
     void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
-
-    spkt::entity At(spkt::registry& registry, const glm::ivec2& pos) const;
-
-    spkt::entity Hovered(spkt::registry& registry) const;
-    spkt::entity Selected(spkt::registry& registry) const;
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -13,36 +13,16 @@
 
 namespace Sprocket {
 
-class GameGrid : public EntitySystem
+struct GameGrid : public EntitySystem
 {
-public:
-    using GridMap = std::unordered_map<glm::ivec2, spkt::entity>;
-
-private:
-    spkt::entity d_camera;
-    spkt::entity d_hoveredSquare;
-    spkt::entity d_selectedSquare;
-
-    glm::ivec2 d_hovered; // TODO: make optional
-    std::optional<glm::ivec2> d_selected;
-
-    GridMap d_gridEntities; 
-
-public:
-    GameGrid();
-
     void on_startup(spkt::registry& registry) override;
     void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 
     spkt::entity At(spkt::registry& registry, const glm::ivec2& pos) const;
 
-    void SetCamera(spkt::entity entity) { d_camera = entity; }
-
     spkt::entity Hovered(spkt::registry& registry) const;
     spkt::entity Selected(spkt::registry& registry) const;
-
-    std::optional<glm::ivec2> SelectedPosition() const { return d_selected; }
 };
 
 }

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -35,12 +35,12 @@ public:
     void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 
-    spkt::entity At(const glm::ivec2& pos) const;
+    spkt::entity At(spkt::registry& registry, const glm::ivec2& pos) const;
 
     void SetCamera(spkt::entity entity) { d_camera = entity; }
 
-    spkt::entity Hovered() const;
-    spkt::entity Selected() const;
+    spkt::entity Hovered(spkt::registry& registry) const;
+    spkt::entity Selected(spkt::registry& registry) const;
 
     std::optional<glm::ivec2> SelectedPosition() const { return d_selected; }
 };

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -157,6 +157,14 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "GetMouseScrolled", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(registry);
+        Converter<glm::vec2>::push(L, input.mouse_scrolled);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -156,7 +156,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         Converter<glm::vec2>::push(L, input.mouse_offset);
         return 1;
     });
-  
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -157,6 +157,14 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         return 1;
     });
 
+    lua_register(L, "GetMouseScrolled", [](lua_State* L) {
+        if (!CheckArgCount(L, 0)) { return luaL_error(L, "Bad number of args"); }
+        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(registry);
+        Converter<glm::vec2>::push(L, input.mouse_scrolled);
+        return 1;
+    });
+
     // Add functions for iterating over all entities in __scene__. The C++ functions
     // should not be used directly, instead they should be used via the Scene:Each
     // function implemented last in Lua.


### PR DESCRIPTION
* Added `CameraSingleton` and `GameGridSingleton` for storing game state found in the game grid system.
* Remove all state from `GameGrid`.
* Remove all functions from `GameGrid` except for the system interface.
* Added `GetMouseScrolled` to Lua.