### PR TITLE
Make ScriptRunner Stateless

### DIFF
--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -152,6 +152,8 @@ void Inspector::Show(Anvil& editor)
             ImGui::PushID(count++);
             ImGuiXtra::File("Script", editor.window(), &c.script, "*.lua");
             ImGui::Checkbox("Active", &c.active);
+            ;
+            ImGui::Checkbox("Requested Deletion", &c.requested_deletion);
             
             if (ImGui::Button("Delete")) { entity.remove<ScriptComponent>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -153,7 +153,6 @@ void Inspector::Show(Anvil& editor)
             ImGuiXtra::File("Script", editor.window(), &c.script, "*.lua");
             ImGui::Checkbox("Active", &c.active);
             ;
-            ImGui::Checkbox("Requested Deletion", &c.requested_deletion);
             
             if (ImGui::Button("Delete")) { entity.remove<ScriptComponent>(); }
             ImGui::PopID();

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -310,16 +310,6 @@
                         "SCRIPTABLE": false,
                         "SAVABLE": false
                     }
-                },
-                {
-                    "name": "requested_deletion",
-                    "display_name": "Requested Deletion",
-                    "type": "bool",
-                    "default": "false",
-                    "flags": {
-                        "SCRIPTABLE": false,
-                        "SAVABLE": false  
-                    }
                 }
             ]
         },

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -300,6 +300,26 @@
                     "display_name": "Active",
                     "type": "bool",
                     "default": "true"
+                },
+                {
+                    "name": "script_runtime",
+                    "display_name": "Script Runtime",
+                    "type": "std::shared_ptr<lua::Script>",
+                    "default": "nullptr",
+                    "flags": {
+                        "SCRIPTABLE": false,
+                        "SAVABLE": false
+                    }
+                },
+                {
+                    "name": "requested_deletion",
+                    "display_name": "Requested Deletion",
+                    "type": "bool",
+                    "default": "false",
+                    "flags": {
+                        "SCRIPTABLE": false,
+                        "SAVABLE": false  
+                    }
                 }
             ]
         },

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <unordered_map>
 #include <optional>
+#include <memory>
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/hash.hpp>
@@ -13,6 +14,7 @@
 #include "apecs.hpp"
 
 namespace Sprocket {
+namespace lua { class Script; }
 
 // Components
 DATAMATIC_BEGIN

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <unordered_map>
 #include <optional>
+#include <memory>
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/hash.hpp>
@@ -13,6 +14,7 @@
 #include "apecs.hpp"
 
 namespace Sprocket {
+namespace lua { class Script; }
 
 // Components
 struct TemporaryComponent
@@ -86,6 +88,8 @@ struct ScriptComponent
 {
     std::string script = "";
     bool active = true;
+    std::shared_ptr<lua::Script> script_runtime = nullptr;
+    bool requested_deletion = false;
 };
 
 struct Camera3DComponent

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -89,7 +89,6 @@ struct ScriptComponent
     std::string script = "";
     bool active = true;
     std::shared_ptr<lua::Script> script_runtime = nullptr;
-    bool requested_deletion = false;
 };
 
 struct Camera3DComponent

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -432,11 +432,11 @@ void Copy(spkt::registry* source, spkt::registry* target)
         id_remapper[id] = new_id;
     }
 
-    const auto transform = [&](auto&& param) {
+    const auto transform = [&] <typename T> (T&& param) {
         if constexpr (std::is_same_v<decltype(param), spkt::identifier>) {
             return id_remapper[param];
         }
-        return param;
+        return std::forward<T>(param);
     };
 
     for (auto id : source->all()) {
@@ -523,6 +523,8 @@ void Copy(spkt::registry* source, spkt::registry* target)
             ScriptComponent target_comp;
             target_comp.script = transform(source_comp.script);
             target_comp.active = transform(source_comp.active);
+            target_comp.script_runtime = transform(source_comp.script_runtime);
+            target_comp.requested_deletion = transform(source_comp.requested_deletion);
             dst.add<ScriptComponent>(target_comp);
         }
         if (src.has<Camera3DComponent>()) {

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -524,7 +524,6 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.script = transform(source_comp.script);
             target_comp.active = transform(source_comp.active);
             target_comp.script_runtime = transform(source_comp.script_runtime);
-            target_comp.requested_deletion = transform(source_comp.requested_deletion);
             dst.add<ScriptComponent>(target_comp);
         }
         if (src.has<Camera3DComponent>()) {

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -103,11 +103,11 @@ void Copy(spkt::registry* source, spkt::registry* target)
         id_remapper[id] = new_id;
     }
 
-    const auto transform = [&](auto&& param) {
+    const auto transform = [&] <typename T> (T&& param) {
         if constexpr (std::is_same_v<decltype(param), spkt::identifier>) {
             return id_remapper[param];
         }
-        return param;
+        return std::forward<T>(param);
     };
 
     for (auto id : source->all()) {

--- a/Sprocket/Scene/Systems/PathFollower.h
+++ b/Sprocket/Scene/Systems/PathFollower.h
@@ -7,7 +7,6 @@ namespace Sprocket {
 struct PathFollower : public EntitySystem
 {
     void on_update(spkt::registry& registry, double dt) override;
-        // Called once per entity per frame and before the system updates.
 };
 
 }

--- a/Sprocket/Scene/Systems/ScriptRunner.cpp
+++ b/Sprocket/Scene/Systems/ScriptRunner.cpp
@@ -17,12 +17,11 @@ void ScriptRunner::on_update(spkt::registry& registry, double dt)
 {
     std::vector<std::function<void()>> commands;
 
-    registry.erase_if<ScriptComponent>([&](apx::entity entity) {
+    for (apx::entity entity : registry.view<ScriptComponent>()) {
         auto& sc = registry.get<ScriptComponent>(entity);
-        if (sc.requested_deletion) {
-            return true;
-        }
-        else if (!sc.script_runtime) {
+        if (!sc.active) { continue; }
+
+        if (!sc.script_runtime) {
             sc.script_runtime = std::make_shared<lua::Script>(sc.script);
             lua::Script& script = *sc.script_runtime;
             lua::load_vec3_functions(script);
@@ -38,17 +37,11 @@ void ScriptRunner::on_update(spkt::registry& registry, double dt)
             script.set_value("__command_list__", &commands);
             script.call_function<void>("OnUpdate", spkt::entity{registry, entity}, dt);
         }
-        
-        return false;
-    });
+    }
 
     for (auto& command : commands) {
         command();
     }
-}
-
-void ScriptRunner::on_event(spkt::registry& registry, ev::Event& event)
-{
 }
 
 }

--- a/Sprocket/Scene/Systems/ScriptRunner.h
+++ b/Sprocket/Scene/Systems/ScriptRunner.h
@@ -1,19 +1,11 @@
 #pragma once
-#include "LuaScript.h"
 #include "ECS.h"
 #include "EntitySystem.h"
 
-#include <unordered_map>
-#include <apecs.hpp>
-
 namespace Sprocket {
 
-class ScriptRunner : public EntitySystem
+struct ScriptRunner : public EntitySystem
 {
-    std::unordered_map<spkt::entity, std::pair<lua::Script, bool>> d_engines;
-
-public:
-    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 };
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -69,6 +69,13 @@ template <typename T> int _has_impl(lua_State* L)
     return 1;
 }
 
+void add_command(lua_State* L, const std::function<void()>& command)
+{
+    using command_list_t = std::vector<std::function<void()>>;
+    command_list_t& command_list = *get_pointer<command_list_t>(L, "__command_list__");
+    command_list.push_back(command);
+}
+
 }
 
 void load_registry_functions(lua::Script& script, spkt::registry& registry)
@@ -87,8 +94,8 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
 
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        auto luaEntity = static_cast<spkt::entity*>(lua_touserdata(L, 1));
-        luaEntity->destroy();
+        spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
+        add_command(L, [=]() mutable { entity.destroy(); });
         return 0;
     });
 
@@ -335,7 +342,8 @@ int _AddNameComponent(lua_State* L) {
     assert(!e.has<NameComponent>());
     NameComponent c;
     c.name = Converter<std::string>::read(L, ++ptr);
-    e.add<NameComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<NameComponent>(c); });
     return 0;
 }
 
@@ -372,7 +380,8 @@ int _AddTransform2DComponent(lua_State* L) {
     c.position = Converter<glm::vec2>::read(L, ++ptr);
     c.rotation = Converter<float>::read(L, ++ptr);
     c.scale = Converter<glm::vec2>::read(L, ++ptr);
-    e.add<Transform2DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<Transform2DComponent>(c); });
     return 0;
 }
 
@@ -406,7 +415,8 @@ int _AddTransform3DComponent(lua_State* L) {
     Transform3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
-    e.add<Transform3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<Transform3DComponent>(c); });
     return 0;
 }
 
@@ -440,7 +450,8 @@ int _AddModelComponent(lua_State* L) {
     ModelComponent c;
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
-    e.add<ModelComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<ModelComponent>(c); });
     return 0;
 }
 
@@ -492,7 +503,8 @@ int _AddRigidBody3DComponent(lua_State* L) {
     c.rollingResistance = Converter<float>::read(L, ++ptr);
     c.force = Converter<glm::vec3>::read(L, ++ptr);
     c.onFloor = Converter<bool>::read(L, ++ptr);
-    e.add<RigidBody3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<RigidBody3DComponent>(c); });
     return 0;
 }
 
@@ -532,7 +544,8 @@ int _AddBoxCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.halfExtents = Converter<glm::vec3>::read(L, ++ptr);
     c.applyScale = Converter<bool>::read(L, ++ptr);
-    e.add<BoxCollider3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<BoxCollider3DComponent>(c); });
     return 0;
 }
 
@@ -569,7 +582,8 @@ int _AddSphereCollider3DComponent(lua_State* L) {
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
-    e.add<SphereCollider3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<SphereCollider3DComponent>(c); });
     return 0;
 }
 
@@ -609,7 +623,8 @@ int _AddCapsuleCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
     c.height = Converter<float>::read(L, ++ptr);
-    e.add<CapsuleCollider3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<CapsuleCollider3DComponent>(c); });
     return 0;
 }
 
@@ -643,7 +658,8 @@ int _AddScriptComponent(lua_State* L) {
     ScriptComponent c;
     c.script = Converter<std::string>::read(L, ++ptr);
     c.active = Converter<bool>::read(L, ++ptr);
-    e.add<ScriptComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<ScriptComponent>(c); });
     return 0;
 }
 
@@ -677,7 +693,8 @@ int _AddCamera3DComponent(lua_State* L) {
     Camera3DComponent c;
     c.fov = Converter<float>::read(L, ++ptr);
     c.pitch = Converter<float>::read(L, ++ptr);
-    e.add<Camera3DComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<Camera3DComponent>(c); });
     return 0;
 }
 
@@ -711,7 +728,8 @@ int _AddSelectComponent(lua_State* L) {
     SelectComponent c;
     c.selected = Converter<bool>::read(L, ++ptr);
     c.hovered = Converter<bool>::read(L, ++ptr);
-    e.add<SelectComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<SelectComponent>(c); });
     return 0;
 }
 
@@ -742,7 +760,8 @@ int _AddPathComponent(lua_State* L) {
     assert(!e.has<PathComponent>());
     PathComponent c;
     c.speed = Converter<float>::read(L, ++ptr);
-    e.add<PathComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<PathComponent>(c); });
     return 0;
 }
 
@@ -776,7 +795,8 @@ int _AddGridComponent(lua_State* L) {
     GridComponent c;
     c.x = Converter<int>::read(L, ++ptr);
     c.z = Converter<int>::read(L, ++ptr);
-    e.add<GridComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<GridComponent>(c); });
     return 0;
 }
 
@@ -810,7 +830,8 @@ int _AddLightComponent(lua_State* L) {
     LightComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    e.add<LightComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<LightComponent>(c); });
     return 0;
 }
 
@@ -850,7 +871,8 @@ int _AddSunComponent(lua_State* L) {
     c.brightness = Converter<float>::read(L, ++ptr);
     c.direction = Converter<glm::vec3>::read(L, ++ptr);
     c.shadows = Converter<bool>::read(L, ++ptr);
-    e.add<SunComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<SunComponent>(c); });
     return 0;
 }
 
@@ -884,7 +906,8 @@ int _AddAmbienceComponent(lua_State* L) {
     AmbienceComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    e.add<AmbienceComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<AmbienceComponent>(c); });
     return 0;
 }
 
@@ -930,7 +953,8 @@ int _AddParticleComponent(lua_State* L) {
     c.acceleration = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
     c.life = Converter<float>::read(L, ++ptr);
-    e.add<ParticleComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<ParticleComponent>(c); });
     return 0;
 }
 
@@ -967,7 +991,8 @@ int _AddMeshAnimationComponent(lua_State* L) {
     c.name = Converter<std::string>::read(L, ++ptr);
     c.time = Converter<float>::read(L, ++ptr);
     c.speed = Converter<float>::read(L, ++ptr);
-    e.add<MeshAnimationComponent>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<MeshAnimationComponent>(c); });
     return 0;
 }
 
@@ -998,7 +1023,8 @@ int _AddCollisionSingleton(lua_State* L) {
     assert(!e.has<CollisionSingleton>());
     CollisionSingleton c;
     c.collisions = Converter<std::vector<std::pair<apx::entity, apx::entity>>>::read(L, ++ptr);
-    e.add<CollisionSingleton>(c);
+    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
+    add_command(L, [e, c]() mutable { e.add<CollisionSingleton>(c); });
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -95,7 +95,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
-        add_command(L, [=]() mutable { entity.destroy(); });
+        add_command(L, [entity]() mutable { entity.destroy(); });
         return 0;
     });
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -342,7 +342,6 @@ int _AddNameComponent(lua_State* L) {
     assert(!e.has<NameComponent>());
     NameComponent c;
     c.name = Converter<std::string>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<NameComponent>(c); });
     return 0;
 }
@@ -380,7 +379,6 @@ int _AddTransform2DComponent(lua_State* L) {
     c.position = Converter<glm::vec2>::read(L, ++ptr);
     c.rotation = Converter<float>::read(L, ++ptr);
     c.scale = Converter<glm::vec2>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<Transform2DComponent>(c); });
     return 0;
 }
@@ -415,7 +413,6 @@ int _AddTransform3DComponent(lua_State* L) {
     Transform3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<Transform3DComponent>(c); });
     return 0;
 }
@@ -450,7 +447,6 @@ int _AddModelComponent(lua_State* L) {
     ModelComponent c;
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<ModelComponent>(c); });
     return 0;
 }
@@ -503,7 +499,6 @@ int _AddRigidBody3DComponent(lua_State* L) {
     c.rollingResistance = Converter<float>::read(L, ++ptr);
     c.force = Converter<glm::vec3>::read(L, ++ptr);
     c.onFloor = Converter<bool>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<RigidBody3DComponent>(c); });
     return 0;
 }
@@ -544,7 +539,6 @@ int _AddBoxCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.halfExtents = Converter<glm::vec3>::read(L, ++ptr);
     c.applyScale = Converter<bool>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<BoxCollider3DComponent>(c); });
     return 0;
 }
@@ -582,7 +576,6 @@ int _AddSphereCollider3DComponent(lua_State* L) {
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<SphereCollider3DComponent>(c); });
     return 0;
 }
@@ -623,7 +616,6 @@ int _AddCapsuleCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
     c.height = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<CapsuleCollider3DComponent>(c); });
     return 0;
 }
@@ -658,7 +650,6 @@ int _AddScriptComponent(lua_State* L) {
     ScriptComponent c;
     c.script = Converter<std::string>::read(L, ++ptr);
     c.active = Converter<bool>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<ScriptComponent>(c); });
     return 0;
 }
@@ -693,7 +684,6 @@ int _AddCamera3DComponent(lua_State* L) {
     Camera3DComponent c;
     c.fov = Converter<float>::read(L, ++ptr);
     c.pitch = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<Camera3DComponent>(c); });
     return 0;
 }
@@ -728,7 +718,6 @@ int _AddSelectComponent(lua_State* L) {
     SelectComponent c;
     c.selected = Converter<bool>::read(L, ++ptr);
     c.hovered = Converter<bool>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<SelectComponent>(c); });
     return 0;
 }
@@ -760,7 +749,6 @@ int _AddPathComponent(lua_State* L) {
     assert(!e.has<PathComponent>());
     PathComponent c;
     c.speed = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<PathComponent>(c); });
     return 0;
 }
@@ -795,7 +783,6 @@ int _AddGridComponent(lua_State* L) {
     GridComponent c;
     c.x = Converter<int>::read(L, ++ptr);
     c.z = Converter<int>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<GridComponent>(c); });
     return 0;
 }
@@ -830,7 +817,6 @@ int _AddLightComponent(lua_State* L) {
     LightComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<LightComponent>(c); });
     return 0;
 }
@@ -871,7 +857,6 @@ int _AddSunComponent(lua_State* L) {
     c.brightness = Converter<float>::read(L, ++ptr);
     c.direction = Converter<glm::vec3>::read(L, ++ptr);
     c.shadows = Converter<bool>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<SunComponent>(c); });
     return 0;
 }
@@ -906,7 +891,6 @@ int _AddAmbienceComponent(lua_State* L) {
     AmbienceComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<AmbienceComponent>(c); });
     return 0;
 }
@@ -953,7 +937,6 @@ int _AddParticleComponent(lua_State* L) {
     c.acceleration = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
     c.life = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<ParticleComponent>(c); });
     return 0;
 }
@@ -991,7 +974,6 @@ int _AddMeshAnimationComponent(lua_State* L) {
     c.name = Converter<std::string>::read(L, ++ptr);
     c.time = Converter<float>::read(L, ++ptr);
     c.speed = Converter<float>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<MeshAnimationComponent>(c); });
     return 0;
 }
@@ -1023,7 +1005,6 @@ int _AddCollisionSingleton(lua_State* L) {
     assert(!e.has<CollisionSingleton>());
     CollisionSingleton c;
     c.collisions = Converter<std::vector<std::pair<apx::entity, apx::entity>>>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<CollisionSingleton>(c); });
     return 0;
 }

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -95,7 +95,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
         spkt::entity entity = *static_cast<spkt::entity*>(lua_touserdata(L, 1));
-        add_command(L, [=]() mutable { entity.destroy(); });
+        add_command(L, [entity]() mutable { entity.destroy(); });
         return 0;
     });
 

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -343,7 +343,6 @@ int _Add{{Comp::name}}(lua_State* L) {
     assert(!e.has<{{Comp::name}}>());
     {{Comp::name}} c;
     c.{{Attr::name}} = Converter<{{Attr::type}}>::read(L, ++ptr);
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
     add_command(L, [e, c]() mutable { e.add<{{Comp::name}}>(c); });
     return 0;
 }


### PR DESCRIPTION
* `ScriptRunner` is now completely stateless, and only has an `on_update` function!
* Because of this, `ScriptRunner` no longer reacts to events for adding and removing script components. Instead, when looping, it checks if `script_runtime` is nullptr. If it is, it constucts a new engine and calls `init`, otherwise it calls `on_update`. When the component is deleted, there is nothing else to do as the script was on the component and would get cleaned up like that.
* As we are looping over components directly now in the update function rather than a separate map of functions, this breaks removing entities and adding/removing script components from within scripts. To fix, all of these actions are now "delayed" and passed into a vector of commands which get executed after all scripts have ran. This raises some issues that users need to be aware of. For example, when you call `AddSomeComponent(entity)`, that has not yet added the component (it gets done after), so `HasSomeComponent(entity)` will still return false.