### PR TITLE
RAII PhysicsEngine

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -9,6 +9,21 @@
 namespace Sprocket {
 namespace {
 
+struct delete_below_50 : public EntitySystem
+{
+    void on_update(spkt::registry& registry, double)
+    {
+        std::vector<apx::entity> to_delete;
+        for (auto entity : registry.view<Transform3DComponent>()) {
+            auto& t = registry.get<Transform3DComponent>(entity);
+            if (t.position.y < -50.0f) { to_delete.push_back(entity); }
+        }
+        for (auto entity : to_delete) {
+            registry.destroy(entity);
+        }
+    }
+};
+
 std::string Name(const spkt::entity& entity)
 {
     if (entity.has<NameComponent>()) {
@@ -203,6 +218,7 @@ void Anvil::on_render()
                 d_activeScene->Add<ScriptRunner>();
                 d_activeScene->Add<ParticleSystem>(&d_particle_manager);
                 d_activeScene->Add<AnimationSystem>();
+                d_activeScene->Add<delete_below_50>();
                 Loader::Copy(&d_scene->Entities(), &d_activeScene->Entities());
 
                 d_playingGame = true;

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -126,6 +126,7 @@ void Inspector::Show(Anvil& editor)
             ImGuiXtra::Euler("Orientation", &c.orientation);
             ImGui::DragFloat("Mass", &c.mass, 0.01f);
             ImGui::DragFloat("Radius", &c.radius, 0.01f);
+            ;
             
             if (ImGui::Button("Delete")) { entity.remove<SphereCollider3DComponent>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -111,6 +111,7 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Mass", &c.mass, 0.01f);
             ImGui::DragFloat3("Half Extents", &c.halfExtents.x, 0.1f);
             ImGui::Checkbox("Apply Scale", &c.applyScale);
+            ;
             
             if (ImGui::Button("Delete")) { entity.remove<BoxCollider3DComponent>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -96,6 +96,7 @@ void Inspector::Show(Anvil& editor)
             ImGui::SliderFloat("Rolling Resistance", &c.rollingResistance, 0.0f, 1.0f);
             ImGui::DragFloat3("Force", &c.force.x, 0.1f);
             ImGui::Checkbox("OnFloor", &c.onFloor);
+            ;
             
             if (ImGui::Button("Delete")) { entity.remove<RigidBody3DComponent>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -142,6 +142,7 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Mass", &c.mass, 0.01f);
             ImGui::DragFloat("Radius", &c.radius, 0.01f);
             ImGui::DragFloat("Height", &c.height, 0.01f);
+            ;
             
             if (ImGui::Button("Delete")) { entity.remove<CapsuleCollider3DComponent>(); }
             ImGui::PopID();

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -167,6 +167,16 @@
                     "flags": {
                         "SAVABLE": false
                     }
+                },
+                {
+                    "name": "runtime",
+                    "display_name": "Runtime",
+                    "type": "std::shared_ptr<rigid_body_runtime>",
+                    "default": "nullptr",
+                    "flags": {
+                        "SAVABLE": false,
+                        "SCRIPTABLE": false
+                    }
                 }
             ]
         },

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -249,6 +249,16 @@
                     "display_name": "Radius",
                     "type": "float",
                     "default": "1.0f"
+                },
+                {
+                    "name": "runtime",
+                    "display_name": "Runtime",
+                    "type": "std::shared_ptr<collider_runtime>",
+                    "default": "nullptr",
+                    "flags": {
+                        "SAVABLE": false,
+                        "SCRIPTABLE": false
+                    }
                 }
             ]
         },

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -298,6 +298,16 @@
                     "display_name": "Height",
                     "type": "float",
                     "default": "1.0f"
+                },
+                {
+                    "name": "runtime",
+                    "display_name": "Runtime",
+                    "type": "std::shared_ptr<collider_runtime>",
+                    "default": "nullptr",
+                    "flags": {
+                        "SAVABLE": false,
+                        "SCRIPTABLE": false
+                    }
                 }
             ]
         },

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -206,6 +206,16 @@
                     "display_name": "Apply Scale",
                     "type": "bool",
                     "default": "true"
+                },
+                {
+                    "name": "runtime",
+                    "display_name": "Runtime",
+                    "type": "std::shared_ptr<collider_runtime>",
+                    "default": "nullptr",
+                    "flags": {
+                        "SAVABLE": false,
+                        "SCRIPTABLE": false
+                    }
                 }
             ]
         },

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -15,6 +15,7 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
+class rigid_body_runtime;
 class collider_runtime;
 
 // Components

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -15,8 +15,8 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
-class rigid_body_runtime;
-class collider_runtime;
+struct rigid_body_runtime;
+struct collider_runtime;
 
 // Components
 DATAMATIC_BEGIN

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -15,6 +15,7 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
+class collider_runtime;
 
 // Components
 DATAMATIC_BEGIN

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -15,6 +15,7 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
+class rigid_body_runtime;
 class collider_runtime;
 
 // Components
@@ -57,6 +58,7 @@ struct RigidBody3DComponent
     float rollingResistance = 0.0f;
     glm::vec3 force = {0.0f, 0.0f, 0.0f};
     bool onFloor = false;
+    std::shared_ptr<rigid_body_runtime> runtime = nullptr;
 };
 
 struct BoxCollider3DComponent

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -75,6 +75,7 @@ struct SphereCollider3DComponent
     glm::quat orientation = {0.0f, 0.0f, 0.0f, 1.0f};
     float mass = 1.0f;
     float radius = 1.0f;
+    std::shared_ptr<collider_runtime> runtime = nullptr;
 };
 
 struct CapsuleCollider3DComponent

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -15,6 +15,7 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
+class collider_runtime;
 
 // Components
 struct TemporaryComponent
@@ -65,6 +66,7 @@ struct BoxCollider3DComponent
     float mass = 1.0f;
     glm::vec3 halfExtents = {0.0f, 0.0f, 0.0f};
     bool applyScale = true;
+    std::shared_ptr<collider_runtime> runtime = nullptr;
 };
 
 struct SphereCollider3DComponent

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -85,6 +85,7 @@ struct CapsuleCollider3DComponent
     float mass = 1.0f;
     float radius = 1.0f;
     float height = 1.0f;
+    std::shared_ptr<collider_runtime> runtime = nullptr;
 };
 
 struct ScriptComponent

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -15,8 +15,8 @@
 
 namespace Sprocket {
 namespace lua { class Script; }
-class rigid_body_runtime;
-class collider_runtime;
+struct rigid_body_runtime;
+struct collider_runtime;
 
 // Components
 struct TemporaryComponent

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -507,6 +507,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.orientation = transform(source_comp.orientation);
             target_comp.mass = transform(source_comp.mass);
             target_comp.radius = transform(source_comp.radius);
+            target_comp.runtime = transform(source_comp.runtime);
             dst.add<SphereCollider3DComponent>(target_comp);
         }
         if (src.has<CapsuleCollider3DComponent>()) {

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -487,6 +487,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.rollingResistance = transform(source_comp.rollingResistance);
             target_comp.force = transform(source_comp.force);
             target_comp.onFloor = transform(source_comp.onFloor);
+            target_comp.runtime = transform(source_comp.runtime);
             dst.add<RigidBody3DComponent>(target_comp);
         }
         if (src.has<BoxCollider3DComponent>()) {

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -497,6 +497,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.mass = transform(source_comp.mass);
             target_comp.halfExtents = transform(source_comp.halfExtents);
             target_comp.applyScale = transform(source_comp.applyScale);
+            target_comp.runtime = transform(source_comp.runtime);
             dst.add<BoxCollider3DComponent>(target_comp);
         }
         if (src.has<SphereCollider3DComponent>()) {

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -518,6 +518,7 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.mass = transform(source_comp.mass);
             target_comp.radius = transform(source_comp.radius);
             target_comp.height = transform(source_comp.height);
+            target_comp.runtime = transform(source_comp.runtime);
             dst.add<CapsuleCollider3DComponent>(target_comp);
         }
         if (src.has<ScriptComponent>()) {

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -26,6 +26,11 @@ Scene::Scene(Window* window)
     });
 }
 
+Scene::~Scene()
+{
+    d_registry.clear();
+}
+
 void Scene::Load(std::string_view file)
 {
     Loader::Load(std::string(file), &Entities());

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -35,6 +35,7 @@ class Scene
 
 public:
     Scene(Window* window);
+    ~Scene();
 
     spkt::registry& Entities() { return d_registry; }
 

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -20,7 +20,7 @@ Comp& get_singleton(spkt::registry& registry)
     assert(registry.valid(singleton));
     assert(registry.has<Comp>(singleton));
     return registry.get<Comp>(singleton);
-} 
+}
 
 
 class Scene
@@ -40,9 +40,6 @@ public:
 
     template <typename T, typename... Args>
     T& Add(Args&&... args);
-
-    template <typename T>
-    T& Get();
 
     void Load(std::string_view file);
 
@@ -68,12 +65,6 @@ T& Scene::Add(Args&&... args)
     d_systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
     d_systems.back()->on_startup(d_registry);
     return *static_cast<T*>(d_systems.back().get());
-}
-
-template <typename T>
-T& Scene::Get()
-{
-    return *static_cast<T*>(d_systems[d_lookup[spkt::type_info<T>]].get());
 }
 
 template <typename... Comps>

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -271,10 +271,6 @@ void PhysicsEngine3D::on_startup(spkt::registry& registry)
     registry.emplace<CollisionSingleton>(singleton);
 }
 
-void PhysicsEngine3D::on_event(spkt::registry& registry, ev::Event& event)
-{
-}
-
 void PhysicsEngine3D::on_update(spkt::registry& registry, double dt)
 {
     // Pre Update

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -24,7 +24,6 @@ public:
     ~PhysicsEngine3D() = default;
 
     void on_startup(spkt::registry& registry) override;
-    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 
     spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -8,6 +8,7 @@
 
 namespace Sprocket {
 
+struct rigid_body_runtime;
 struct collider_runtime;
 
 struct PhysicsEngine3DImpl;

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -8,6 +8,8 @@
 
 namespace Sprocket {
 
+struct collider_runtime;
+
 struct PhysicsEngine3DImpl;
 
 class PhysicsEngine3D : public EntitySystem


### PR DESCRIPTION
* Remove the internal per-entity storage from the physics engine.
* All physics components now have a "runtime" struct which is an RAII wrapper for the physics engine components.
* Components are added during `on_update`, if the runtime component is a null pointer, the engine will populate it with a component and add it to the physics world.
* If a component is deleted, the destructor will clean it up from the physics engine..
* Added a quick and easy "delete_below_50" system to `Anvil` to delete all entities with a y-position less that -50.
* Remove `Scene::Get`.