### PR TITLE
Generic lambda system

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -9,20 +9,17 @@
 namespace Sprocket {
 namespace {
 
-struct delete_below_50 : public EntitySystem
+void delete_below_50(spkt::registry& registry, double)
 {
-    void on_update(spkt::registry& registry, double)
-    {
-        std::vector<apx::entity> to_delete;
-        for (auto entity : registry.view<Transform3DComponent>()) {
-            auto& t = registry.get<Transform3DComponent>(entity);
-            if (t.position.y < -50.0f) { to_delete.push_back(entity); }
-        }
-        for (auto entity : to_delete) {
-            registry.destroy(entity);
-        }
+    std::vector<apx::entity> to_delete;
+    for (auto entity : registry.view<Transform3DComponent>()) {
+        auto& t = registry.get<Transform3DComponent>(entity);
+        if (t.position.y < -50.0f) { to_delete.push_back(entity); }
     }
-};
+    for (auto entity : to_delete) {
+        registry.destroy(entity);
+    }
+}
 
 std::string Name(const spkt::entity& entity)
 {
@@ -218,7 +215,7 @@ void Anvil::on_render()
                 d_activeScene->Add<ScriptRunner>();
                 d_activeScene->Add<ParticleSystem>(&d_particle_manager);
                 d_activeScene->Add<AnimationSystem>();
-                d_activeScene->Add<delete_below_50>();
+                d_activeScene->Add<LambdaSystem>(delete_below_50);
                 Loader::Copy(&d_scene->Entities(), &d_activeScene->Entities());
 
                 d_playingGame = true;

--- a/Sprocket/Scene/Systems/LambdaSystem.h
+++ b/Sprocket/Scene/Systems/LambdaSystem.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "EntitySystem.h"
+#include "ECS.h"
+
+#include <functional>
+
+namespace Sprocket {
+
+class LambdaSystem : public EntitySystem
+{
+    using lambda_t = std::function<void(spkt::registry&, double)>;
+    lambda_t lambda;
+
+public:
+    LambdaSystem(const lambda_t& l) : lambda(l) {}
+
+    void on_update(spkt::registry& registry, double dt) override
+    {
+        lambda(registry, dt);
+    }
+};
+
+}

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.cpp
@@ -112,11 +112,7 @@ struct rigid_body_runtime
 {
     rp3d::PhysicsWorld* world;
     rp3d::RigidBody*    body;
-
-    spkt::registry* registry;
-    apx::entity     entity;
-
-    spkt::entity handle; // TODO: Remove
+    spkt::entity handle;
 
     rigid_body_runtime(
         spkt::registry& registry_,
@@ -125,20 +121,18 @@ struct rigid_body_runtime
     )
         : world(world_)
         , body(nullptr)
-        , registry(&registry_)
-        , entity(entity_)
         , handle({registry_, entity_})
     {
-        auto& tc = registry->get<Transform3DComponent>(entity);
+        auto& tc = handle.get<Transform3DComponent>();
         body = world->createRigidBody(Convert(tc));
         body->setUserData(static_cast<void*>(&handle));
     }
 
     ~rigid_body_runtime()
     {
-        registry->remove<BoxCollider3DComponent>(entity);
-        registry->remove<SphereCollider3DComponent>(entity);
-        registry->remove<CapsuleCollider3DComponent>(entity);
+        handle.remove<BoxCollider3DComponent>();
+        handle.remove<SphereCollider3DComponent>();
+        handle.remove<CapsuleCollider3DComponent>();
         world->destroyRigidBody(body);
     }
 };
@@ -364,6 +358,7 @@ void PhysicsEngine3D::on_update(spkt::registry& registry, double dt)
     d_impl->listener.collisions().clear();
 }
 
+#if 0
 spkt::entity PhysicsEngine3D::Raycast(const glm::vec3& base,
                                    const glm::vec3& direction)
 {
@@ -378,5 +373,6 @@ spkt::entity PhysicsEngine3D::Raycast(const glm::vec3& base,
     d_impl->world->raycast(ray, &cb);
     return cb.GetEntity();
 }
+#endif
 
 }

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -26,7 +26,7 @@ public:
     void on_startup(spkt::registry& registry) override;
     void on_update(spkt::registry& registry, double dt) override;
 
-    spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);
+    //spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);
         // Given a position in the world and a direction from that point,
         // return a pointer to the entity that it hits, or null if it
         // does not.

--- a/Sprocket/Scene/Systems/PhysicsEngine3D.h
+++ b/Sprocket/Scene/Systems/PhysicsEngine3D.h
@@ -25,11 +25,6 @@ public:
 
     void on_startup(spkt::registry& registry) override;
     void on_update(spkt::registry& registry, double dt) override;
-
-    //spkt::entity Raycast(const glm::vec3& base, const glm::vec3& direction);
-        // Given a position in the world and a direction from that point,
-        // return a pointer to the entity that it hits, or null if it
-        // does not.
 };
 
 }

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -33,6 +33,7 @@
 #include "Scene/Systems/GameGrid.h"
 #include "Scene/Systems/PathFollower.h"
 #include "Scene/Systems/ScriptRunner.h"
+#include "Scene/Systems/LambdaSystem.h"
 
 // UTILITY
 #include "Utility/Log.h"


### PR DESCRIPTION
* Add `LambdaSystem`, an Entity system which accepts a `bsl::function<void(spkt::registry&, double)>` and just invokes it as part of `on_update`.
* Turn `delete_below_50` in Anvil into a function and pass it into a `LambdaSystem`.
* Remove `PhysicsEngine3D::Raycast` as it was unused. When we need it again, we will implement it as a free function operating on a singleton component.