### PR TITLE
Replace `GridComponent` with `TileMapSingleton`

### DIFF
--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -329,7 +329,6 @@ void Inspector::Show(Anvil& editor)
             ;
             ;
             ;
-            ;
             
             if (ImGui::Button("Delete")) { entity.remove<GameGridSingleton>(); }
             ImGui::PopID();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -336,6 +336,17 @@ void Inspector::Show(Anvil& editor)
         }
     }
 
+    if (entity.has<TileMapSingleton>()) {
+        auto& c = entity.get<TileMapSingleton>();
+        if (ImGui::CollapsingHeader("Tile Map Singleton")) {
+            ImGui::PushID(count++);
+            ;
+            
+            if (ImGui::Button("Delete")) { entity.remove<TileMapSingleton>(); }
+            ImGui::PopID();
+        }
+    }
+
     if (entity.has<CameraSingleton>()) {
         auto& c = entity.get<CameraSingleton>();
         if (ImGui::CollapsingHeader("Camera Singleton")) {
@@ -445,6 +456,10 @@ void Inspector::Show(Anvil& editor)
         if (!entity.has<GameGridSingleton>() && ImGui::Selectable("Game Grid Singleton")) {
             GameGridSingleton c;
             entity.add<GameGridSingleton>(c);
+        }
+        if (!entity.has<TileMapSingleton>() && ImGui::Selectable("Tile Map Singleton")) {
+            TileMapSingleton c;
+            entity.add<TileMapSingleton>(c);
         }
         if (!entity.has<CameraSingleton>() && ImGui::Selectable("Camera Singleton")) {
             CameraSingleton c;

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -200,18 +200,6 @@ void Inspector::Show(Anvil& editor)
         }
     }
 
-    if (entity.has<GridComponent>()) {
-        auto& c = entity.get<GridComponent>();
-        if (ImGui::CollapsingHeader("Grid")) {
-            ImGui::PushID(count++);
-            ;
-            ;
-            
-            if (ImGui::Button("Delete")) { entity.remove<GridComponent>(); }
-            ImGui::PopID();
-        }
-    }
-
     if (entity.has<LightComponent>()) {
         auto& c = entity.get<LightComponent>();
         if (ImGui::CollapsingHeader("Light")) {
@@ -415,10 +403,6 @@ void Inspector::Show(Anvil& editor)
         if (!entity.has<PathComponent>() && ImGui::Selectable("Path")) {
             PathComponent c;
             entity.add<PathComponent>(c);
-        }
-        if (!entity.has<GridComponent>() && ImGui::Selectable("Grid")) {
-            GridComponent c;
-            entity.add<GridComponent>(c);
         }
         if (!entity.has<LightComponent>() && ImGui::Selectable("Light")) {
             LightComponent c;

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -489,6 +489,7 @@ void WorldLayer::AddTree(const glm::ivec2& pos)
     name.name = "Tree";
 
     auto& tr = newEntity.emplace<Transform3DComponent>();
+    tr.position = {pos.x + 0.5f, 0.0f, pos.y + 0.5f};
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), Random(0.0f, 360.0f), {0, 1, 0});
     float r = Random(1.0f, 1.3f);
     tr.scale = {r, r, r};
@@ -498,8 +499,12 @@ void WorldLayer::AddTree(const glm::ivec2& pos)
     modelData.material = "Resources/Materials/tree.yaml";
     newEntity.emplace<SelectComponent>();
 
-    GridComponent gc = {pos.x, pos.y};
-    newEntity.emplace<GridComponent>(gc);
+    // Add the new entity to the grid.
+    auto& registry = d_scene.Entities();
+    auto tile_map = registry.find<TileMapSingleton>();
+    assert(registry.valid(tile_map));
+    auto& tms = registry.get<TileMapSingleton>(tile_map);
+    tms.tiles[pos] = newEntity.entity();
 }
 
 void WorldLayer::AddRockBase(
@@ -514,6 +519,7 @@ void WorldLayer::AddRockBase(
     n.name = name;
 
     auto& tr = newEntity.emplace<Transform3DComponent>();
+    tr.position = {pos.x + 0.5f, 0.0f, pos.y + 0.5f};
     tr.position.y -= Random(0.0f, 0.5f);
     float randomRotation = glm::half_pi<float>() * Random(0, 3);
     tr.orientation = glm::rotate(glm::identity<glm::quat>(), randomRotation, {0.0, 1.0, 0.0});
@@ -524,8 +530,12 @@ void WorldLayer::AddRockBase(
     modelData.material = material;
     newEntity.emplace<SelectComponent>();
 
-    GridComponent gc = {pos.x, pos.y};
-    newEntity.emplace<GridComponent>(gc);
+    // Add the new entity to the grid.
+    auto& registry = d_scene.Entities();
+    auto tile_map = registry.find<TileMapSingleton>();
+    assert(registry.valid(tile_map));
+    auto& tms = registry.get<TileMapSingleton>(tile_map);
+    tms.tiles[pos] = newEntity.entity();
 }
 
 void WorldLayer::AddRock(const glm::ivec2& pos)

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -186,7 +186,9 @@ void WorldLayer::OnEvent(Sprocket::ev::Event& event)
                         pos,
                         mousePos,
                         [&](const glm::ivec2& pos) {
-                            return registry.valid(grid.game_grid.at(pos));
+                            auto it = grid.game_grid.find(pos);
+                            apx::entity entity = it != grid.game_grid.end() ? it->second : apx::null;
+                            return registry.valid(entity);
                         }
                     );
                 } else {

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -127,6 +127,17 @@ void WorldLayer::LoadScene(std::string_view file)
 
     assert(d_worker != spkt::null);
     assert(d_camera != spkt::null);
+
+    apx::entity entity = spkt::identifier{3131031158784};
+    const auto& gg = d_scene.Entities().get<GridComponent>(entity);
+    log::info("At position {} {}", gg.x, gg.z);
+}
+
+void WorldLayer::SaveScene(std::string_view file)
+{
+    log::info("Saving...");
+    Loader::Save(std::string(file), &d_scene.Entities());
+    log::info("Done!");
 }
 
 void WorldLayer::OnEvent(Sprocket::ev::Event& event)
@@ -409,6 +420,13 @@ void WorldLayer::OnRender()
     buttonRegion.y += 60;
     if (d_escapeMenu.Button("Reload", buttonRegion)) {
         LoadScene(d_sceneFile);
+    }
+
+    buttonRegion.y += 60;
+    if (d_escapeMenu.Button("Save", buttonRegion)) {
+        log::info("Saving to {}", d_sceneFile);
+        Loader::Save(d_sceneFile, &d_scene.Entities());
+        log::info("Done!");
     }
     
     d_escapeMenu.EndPanel();

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -52,6 +52,7 @@ public:
     void OnRender();
     void PostUpdate() {}
 
+    void SaveScene(std::string_view file);
     void LoadScene(std::string_view file);
 
     void AddTree(const glm::ivec2& pos);

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -14,8 +14,8 @@ Entities:
       scale: [1, 1, 1]
     SunComponent:
       colour: [1, 0.945, 0.789]
-      brightness: 1.999984
-      direction: [-0.003956872, -0.9999922, -0.0003956872]
+      brightness: 1.999999
+      direction: [-0.0007732788, -0.9999997, -7.732788e-05]
       shadows: true
   - ID#: 21474836480
     NameComponent:
@@ -1041,7 +1041,7 @@ Entities:
     NameComponent:
       name: Worker
     Transform3DComponent:
-      position: [7.640841, 0.5, -3.894935]
+      position: [-2.149857, 0.5, -7.815848]
       orientation: [1, 0, 0, 0]
       scale: [0.5, 0.5, 0.5]
     ModelComponent:
@@ -1055,8 +1055,8 @@ Entities:
     NameComponent:
       name: Camera
     Transform3DComponent:
-      position: [-28.63946, 9.99995, -27.83229]
-      orientation: [0.5393238, -0.2592116, -0.7221345, -0.3470747]
+      position: [8, 10, 0]
+      orientation: [0.6373177, -0.3063107, 0.6373177, 0.3063107]
       scale: [1, 1, 1]
     ScriptComponent:
       script: Resources/Scripts/ThirdPersonCamera.lua
@@ -1073,7 +1073,7 @@ Entities:
       material: Resources/Materials/green.yaml
     SelectComponent:
       {}
-  - ID#: 4440996184064
+  - ID#: 326417514496
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -1088,7 +1088,7 @@ Entities:
     GridComponent:
       x: -6
       z: -13
-  - ID#: 4436701216768
+  - ID#: 330712481792
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -1859,7 +1859,6 @@ Entities:
         [-3, 22]: 2254857830400
         [-5, 19]: 128849018880
         [-25, -19]: 352187318272
-        [-3, -16]: 4458176053248
         [-11, -22]: 1795296329728
         [-10, 11]: 64424509440
         [-17, -21]: 1331439861760
@@ -1874,11 +1873,11 @@ Entities:
         [16, -24]: 3225520439296
         [5, 7]: 292057776128
         [-12, 15]: 90194313216
-        [-7, 18]: 201863462912
         [-4, 15]: 1821066133504
+        [-7, 18]: 201863462912
         [19, 4]: 3453153705984
-        [-23, 6]: 858993459200
         [10, 14]: 4239132721152
+        [-23, 6]: 858993459200
         [5, -6]: 2770253905920
         [-18, 5]: 1275605286912
         [-14, 18]: 94489280512
@@ -2105,7 +2104,6 @@ Entities:
         [-12, -24]: 1722281885696
         [-24, -9]: 609885356032
         [1, -1]: 2469606195200
-        [-3, -15]: 4449586118656
         [-24, -8]: 614180323328
         [-9, 2]: 1906965479424
         [-12, -14]: 1739461754880
@@ -2324,8 +2322,8 @@ Entities:
         [19, 23]: 3466038607872
         [-17, -7]: 1335734829056
         [-17, -5]: 1344324763648
-        [24, -3]: 4063039062016
         [-17, -4]: 1348619730944
+        [24, -3]: 4063039062016
         [-17, -3]: 1352914698240
         [-17, -2]: 1357209665536
         [-8, 1]: 1971389988864
@@ -2358,7 +2356,6 @@ Entities:
         [21, -22]: 3517578215424
         [17, -25]: 3289944948736
         [-16, -7]: 1443109011456
-        [-4, -15]: 4453881085952
         [-16, -4]: 1455993913344
         [-8, -21]: 1954210119680
         [23, -6]: 3843995729920
@@ -2370,6 +2367,7 @@ Entities:
         [-16, 5]: 1481763717120
         [-16, 23]: 1490353651712
         [22, -17]: 3637837299712
+        [-5, -8]: 4436701216768
         [-15, -25]: 1498943586304
         [1, -24]: 2448131358720
         [14, -25]: 3143916060672
@@ -2658,7 +2656,6 @@ Entities:
         [8, 22]: 2993592205312
         [23, -9]: 3831110828032
         [22, 22]: 3749506449408
-        [-6, -13]: 4440996184064
         [8, 23]: 2997887172608
         [8, 24]: 3002182139904
         [9, -25]: 3006477107200
@@ -2842,10 +2839,7 @@ Entities:
         [-5, -12]: 4423816314880
         [-5, -13]: 4428111282176
         [-4, -14]: 4432406249472
-        [-5, -14]: 4436701216768
-        [-4, -12]: 4445291151360
-        [-5, -11]: 4462471020544
-        [-4, 7]: 4466765987840
+        [-5, -9]: 4440996184064
   - ID#: 541165879296
     NameComponent:
       name: Rock
@@ -14096,7 +14090,7 @@ Entities:
     GridComponent:
       x: 22
       z: 24
-  - ID#: 4445291151360
+  - ID#: 3762391351296
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -14801,7 +14795,7 @@ Entities:
     GridComponent:
       x: 23
       z: 23
-  - ID#: 4458176053248
+  - ID#: 3964254814208
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -14816,7 +14810,7 @@ Entities:
     GridComponent:
       x: -3
       z: -16
-  - ID#: 4453881085952
+  - ID#: 3968549781504
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -14831,7 +14825,7 @@ Entities:
     GridComponent:
       x: -4
       z: -15
-  - ID#: 4449586118656
+  - ID#: 3972844748800
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -15551,7 +15545,7 @@ Entities:
     GridComponent:
       x: 24
       z: 23
-  - ID#: 4462471020544
+  - ID#: 4179003179008
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -16451,3 +16445,27 @@ Entities:
     GridComponent:
       x: -4
       z: -14
+  - ID#: 4436701216768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.4073618, -7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+  - ID#: 4440996184064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.0677385, -8.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -1,11 +1,11 @@
 Entities:
-  - ID#: 0
+  - ID#: 12884901888
     NameComponent:
       name: Ambience
     AmbienceComponent:
       colour: [0.96875, 0.9335938, 0.7265625]
       brightness: 0.01
-  - ID#: 4294967296
+  - ID#: 17179869184
     NameComponent:
       name: Sun
     Transform3DComponent:
@@ -14,10 +14,10 @@ Entities:
       scale: [1, 1, 1]
     SunComponent:
       colour: [1, 0.945, 0.789]
-      brightness: 0.8
-      direction: [-0.002256002, -0.9999974, -0.0002256002]
+      brightness: 1.999984
+      direction: [-0.003956872, -0.9999922, -0.0003956872]
       shadows: true
-  - ID#: 8589934592
+  - ID#: 21474836480
     NameComponent:
       name: Iron
     Transform3DComponent:
@@ -32,7 +32,7 @@ Entities:
     GridComponent:
       x: 5
       z: 12
-  - ID#: 12884901888
+  - ID#: 25769803776
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -47,7 +47,7 @@ Entities:
     GridComponent:
       x: -2
       z: -2
-  - ID#: 17179869184
+  - ID#: 30064771072
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -62,7 +62,7 @@ Entities:
     GridComponent:
       x: -3
       z: 14
-  - ID#: 21474836480
+  - ID#: 34359738368
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -77,7 +77,7 @@ Entities:
     GridComponent:
       x: -6
       z: 11
-  - ID#: 25769803776
+  - ID#: 38654705664
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -92,7 +92,7 @@ Entities:
     GridComponent:
       x: -17
       z: 20
-  - ID#: 30064771072
+  - ID#: 42949672960
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -107,7 +107,7 @@ Entities:
     GridComponent:
       x: -12
       z: 14
-  - ID#: 34359738368
+  - ID#: 47244640256
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -122,7 +122,7 @@ Entities:
     GridComponent:
       x: -4
       z: 21
-  - ID#: 38654705664
+  - ID#: 51539607552
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -137,7 +137,7 @@ Entities:
     GridComponent:
       x: -3
       z: 15
-  - ID#: 42949672960
+  - ID#: 55834574848
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -152,7 +152,7 @@ Entities:
     GridComponent:
       x: -7
       z: 11
-  - ID#: 47244640256
+  - ID#: 60129542144
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -167,7 +167,7 @@ Entities:
     GridComponent:
       x: -8
       z: 11
-  - ID#: 51539607552
+  - ID#: 64424509440
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -182,7 +182,7 @@ Entities:
     GridComponent:
       x: -10
       z: 11
-  - ID#: 55834574848
+  - ID#: 68719476736
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -197,7 +197,7 @@ Entities:
     GridComponent:
       x: -9
       z: 11
-  - ID#: 60129542144
+  - ID#: 73014444032
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -212,7 +212,7 @@ Entities:
     GridComponent:
       x: -18
       z: 21
-  - ID#: 64424509440
+  - ID#: 77309411328
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -227,7 +227,7 @@ Entities:
     GridComponent:
       x: -16
       z: 20
-  - ID#: 68719476736
+  - ID#: 81604378624
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -242,7 +242,7 @@ Entities:
     GridComponent:
       x: -15
       z: 19
-  - ID#: 73014444032
+  - ID#: 85899345920
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -257,7 +257,7 @@ Entities:
     GridComponent:
       x: -16
       z: 21
-  - ID#: 77309411328
+  - ID#: 90194313216
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -272,7 +272,7 @@ Entities:
     GridComponent:
       x: -12
       z: 15
-  - ID#: 81604378624
+  - ID#: 94489280512
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -287,7 +287,7 @@ Entities:
     GridComponent:
       x: -14
       z: 18
-  - ID#: 85899345920
+  - ID#: 98784247808
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -302,7 +302,7 @@ Entities:
     GridComponent:
       x: -14
       z: 19
-  - ID#: 90194313216
+  - ID#: 103079215104
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -317,7 +317,7 @@ Entities:
     GridComponent:
       x: -3
       z: 19
-  - ID#: 94489280512
+  - ID#: 107374182400
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -332,7 +332,7 @@ Entities:
     GridComponent:
       x: -13
       z: 22
-  - ID#: 98784247808
+  - ID#: 111669149696
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -347,7 +347,7 @@ Entities:
     GridComponent:
       x: -15
       z: 21
-  - ID#: 103079215104
+  - ID#: 115964116992
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -362,7 +362,7 @@ Entities:
     GridComponent:
       x: -15
       z: 20
-  - ID#: 107374182400
+  - ID#: 120259084288
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -377,7 +377,7 @@ Entities:
     GridComponent:
       x: -14
       z: 20
-  - ID#: 111669149696
+  - ID#: 124554051584
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -392,7 +392,7 @@ Entities:
     GridComponent:
       x: -5
       z: 21
-  - ID#: 115964116992
+  - ID#: 128849018880
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -407,7 +407,7 @@ Entities:
     GridComponent:
       x: -5
       z: 19
-  - ID#: 120259084288
+  - ID#: 133143986176
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -422,7 +422,7 @@ Entities:
     GridComponent:
       x: -5
       z: 20
-  - ID#: 124554051584
+  - ID#: 137438953472
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -437,7 +437,7 @@ Entities:
     GridComponent:
       x: -8
       z: 20
-  - ID#: 128849018880
+  - ID#: 141733920768
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -452,7 +452,7 @@ Entities:
     GridComponent:
       x: -9
       z: 20
-  - ID#: 133143986176
+  - ID#: 146028888064
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -467,7 +467,7 @@ Entities:
     GridComponent:
       x: -10
       z: 20
-  - ID#: 137438953472
+  - ID#: 150323855360
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -482,7 +482,7 @@ Entities:
     GridComponent:
       x: -11
       z: 20
-  - ID#: 141733920768
+  - ID#: 154618822656
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -497,7 +497,7 @@ Entities:
     GridComponent:
       x: -12
       z: 20
-  - ID#: 146028888064
+  - ID#: 158913789952
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -512,7 +512,7 @@ Entities:
     GridComponent:
       x: -13
       z: 20
-  - ID#: 150323855360
+  - ID#: 163208757248
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -527,7 +527,7 @@ Entities:
     GridComponent:
       x: -13
       z: 19
-  - ID#: 154618822656
+  - ID#: 167503724544
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -542,7 +542,7 @@ Entities:
     GridComponent:
       x: -13
       z: 18
-  - ID#: 158913789952
+  - ID#: 171798691840
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -557,7 +557,7 @@ Entities:
     GridComponent:
       x: -13
       z: 17
-  - ID#: 163208757248
+  - ID#: 176093659136
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -572,7 +572,7 @@ Entities:
     GridComponent:
       x: -13
       z: 16
-  - ID#: 167503724544
+  - ID#: 180388626432
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -587,7 +587,7 @@ Entities:
     GridComponent:
       x: -12
       z: 16
-  - ID#: 171798691840
+  - ID#: 184683593728
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -602,7 +602,7 @@ Entities:
     GridComponent:
       x: -11
       z: 18
-  - ID#: 176093659136
+  - ID#: 188978561024
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -617,7 +617,7 @@ Entities:
     GridComponent:
       x: -9
       z: 18
-  - ID#: 180388626432
+  - ID#: 193273528320
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -632,7 +632,7 @@ Entities:
     GridComponent:
       x: -10
       z: 18
-  - ID#: 184683593728
+  - ID#: 197568495616
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -647,7 +647,7 @@ Entities:
     GridComponent:
       x: -8
       z: 18
-  - ID#: 188978561024
+  - ID#: 201863462912
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -662,7 +662,7 @@ Entities:
     GridComponent:
       x: -7
       z: 18
-  - ID#: 193273528320
+  - ID#: 206158430208
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -677,7 +677,7 @@ Entities:
     GridComponent:
       x: -6
       z: 18
-  - ID#: 197568495616
+  - ID#: 210453397504
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -692,7 +692,7 @@ Entities:
     GridComponent:
       x: -6
       z: 17
-  - ID#: 201863462912
+  - ID#: 214748364800
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -707,7 +707,7 @@ Entities:
     GridComponent:
       x: -6
       z: 16
-  - ID#: 206158430208
+  - ID#: 219043332096
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -722,7 +722,7 @@ Entities:
     GridComponent:
       x: -8
       z: 16
-  - ID#: 210453397504
+  - ID#: 223338299392
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -737,7 +737,7 @@ Entities:
     GridComponent:
       x: -9
       z: 16
-  - ID#: 214748364800
+  - ID#: 227633266688
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -752,7 +752,7 @@ Entities:
     GridComponent:
       x: -10
       z: 16
-  - ID#: 219043332096
+  - ID#: 231928233984
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -767,7 +767,7 @@ Entities:
     GridComponent:
       x: -11
       z: 16
-  - ID#: 223338299392
+  - ID#: 236223201280
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -782,7 +782,7 @@ Entities:
     GridComponent:
       x: -11
       z: 15
-  - ID#: 227633266688
+  - ID#: 240518168576
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -797,7 +797,7 @@ Entities:
     GridComponent:
       x: -11
       z: 14
-  - ID#: 231928233984
+  - ID#: 244813135872
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -812,7 +812,7 @@ Entities:
     GridComponent:
       x: -11
       z: 13
-  - ID#: 236223201280
+  - ID#: 249108103168
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -827,7 +827,7 @@ Entities:
     GridComponent:
       x: -11
       z: 12
-  - ID#: 240518168576
+  - ID#: 253403070464
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -842,7 +842,7 @@ Entities:
     GridComponent:
       x: -10
       z: 12
-  - ID#: 244813135872
+  - ID#: 257698037760
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -857,7 +857,7 @@ Entities:
     GridComponent:
       x: -9
       z: 12
-  - ID#: 249108103168
+  - ID#: 261993005056
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -872,7 +872,7 @@ Entities:
     GridComponent:
       x: -8
       z: 12
-  - ID#: 253403070464
+  - ID#: 266287972352
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -887,7 +887,7 @@ Entities:
     GridComponent:
       x: -7
       z: 12
-  - ID#: 257698037760
+  - ID#: 270582939648
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -902,7 +902,7 @@ Entities:
     GridComponent:
       x: -6
       z: 12
-  - ID#: 261993005056
+  - ID#: 274877906944
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -917,7 +917,7 @@ Entities:
     GridComponent:
       x: -9
       z: 14
-  - ID#: 266287972352
+  - ID#: 279172874240
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -932,7 +932,7 @@ Entities:
     GridComponent:
       x: -8
       z: 14
-  - ID#: 270582939648
+  - ID#: 283467841536
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -947,7 +947,7 @@ Entities:
     GridComponent:
       x: -7
       z: 14
-  - ID#: 274877906944
+  - ID#: 287762808832
     NameComponent:
       name: Mithril
     Transform3DComponent:
@@ -962,7 +962,7 @@ Entities:
     GridComponent:
       x: 5
       z: -3
-  - ID#: 279172874240
+  - ID#: 292057776128
     NameComponent:
       name: Mithril
     Transform3DComponent:
@@ -977,7 +977,7 @@ Entities:
     GridComponent:
       x: 5
       z: 7
-  - ID#: 283467841536
+  - ID#: 296352743424
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -992,7 +992,7 @@ Entities:
     GridComponent:
       x: -6
       z: 15
-  - ID#: 287762808832
+  - ID#: 300647710720
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -1007,7 +1007,7 @@ Entities:
     GridComponent:
       x: -6
       z: 14
-  - ID#: 292057776128
+  - ID#: 304942678016
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -1022,7 +1022,7 @@ Entities:
     GridComponent:
       x: 0
       z: -1
-  - ID#: 296352743424
+  - ID#: 309237645312
     NameComponent:
       name: Mithril
     Transform3DComponent:
@@ -1037,7 +1037,7 @@ Entities:
     GridComponent:
       x: -2
       z: 3
-  - ID#: 300647710720
+  - ID#: 313532612608
     NameComponent:
       name: Worker
     Transform3DComponent:
@@ -1051,17 +1051,17 @@ Entities:
       {}
     PathComponent:
       speed: 3
-  - ID#: 304942678016
+  - ID#: 317827579904
     NameComponent:
       name: Camera
     Transform3DComponent:
-      position: [2.77499, 7.343201, 12.0269]
-      orientation: [0.8874592, -0.3455494, 0.2841952, 0.1106569]
+      position: [-28.63946, 9.99995, -27.83229]
+      orientation: [0.5393238, -0.2592116, -0.7221345, -0.3470747]
       scale: [1, 1, 1]
     ScriptComponent:
       script: Resources/Scripts/ThirdPersonCamera.lua
       active: true
-  - ID#: 309237645312
+  - ID#: 322122547200
     NameComponent:
       name: Terrain
     Transform3DComponent:
@@ -1073,14377 +1073,7 @@ Entities:
       material: Resources/Materials/green.yaml
     SelectComponent:
       {}
-  - ID#: 313532612608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4073618, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -25
-  - ID#: 317827579904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.0677385, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -24
-  - ID#: 322122547200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.452896, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -23
-  - ID#: 326417514496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4175043, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -22
-  - ID#: 330712481792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.06349341, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -21
-  - ID#: 335007449088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4844339, -19.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -20
-  - ID#: 339302416384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4566879, -18.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -19
-  - ID#: 343597383680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.110517, -17.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -18
-  - ID#: 347892350976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3161796, -16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -17
-  - ID#: 352187318272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.1540835, -15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -16
-  - ID#: 356482285568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.0487702, -14.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -15
-  - ID#: 360777252864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.2736103, -13.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -14
-  - ID#: 365072220160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.1392491, -12.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -13
-  - ID#: 369367187456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.09419098, -11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -12
-  - ID#: 373662154752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.2734407, -10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -11
-  - ID#: 377957122048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4964406, -9.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -10
-  - ID#: 382252089344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4787534, -8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -9
-  - ID#: 386547056640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4982307, -7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -8
-  - ID#: 390842023936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4824443, -6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -7
-  - ID#: 395136991232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4838475, -5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -6
-  - ID#: 399431958528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.07880654, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -5
-  - ID#: 403726925824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3629195, -3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -4
-  - ID#: 408021893120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4852964, -2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -3
-  - ID#: 412316860416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4905548, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -2
-  - ID#: 416611827712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4785835, -0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: -1
-  - ID#: 420906795008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.05493088, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 0
-  - ID#: 425201762304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.2426878, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 1
-  - ID#: 429496729600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3990529, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 2
-  - ID#: 433791696896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4001402, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 3
-  - ID#: 438086664192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.1485147, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 4
-  - ID#: 442381631488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.07094317, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 5
-  - ID#: 446676598784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.002391742, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 6
-  - ID#: 450971566080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.2108806, 7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 7
-  - ID#: 455266533376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.05623226, 8.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 8
-  - ID#: 459561500672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4578678, 9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 9
-  - ID#: 463856467968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3198817, 10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 10
-  - ID#: 468151435264
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3961037, 11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 11
-  - ID#: 472446402560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4392153, 12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 12
-  - ID#: 476741369856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4797462, 13.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 13
-  - ID#: 481036337152
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.2518314, 14.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 14
-  - ID#: 485331304448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3278703, 15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 15
-  - ID#: 489626271744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3989643, 16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 16
-  - ID#: 493921239040
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.01785584, 17.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 17
-  - ID#: 498216206336
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.180647, 18.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 18
-  - ID#: 502511173632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4245647, 19.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 19
-  - ID#: 506806140928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.1059622, 20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 20
-  - ID#: 511101108224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.4669966, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 21
-  - ID#: 515396075520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3406798, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 22
-  - ID#: 519691042816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.3393676, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 23
-  - ID#: 523986010112
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-24.5, -0.1993693, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -25
-      z: 24
-  - ID#: 528280977408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3788701, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -25
-  - ID#: 532575944704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3703236, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -24
-  - ID#: 536870912000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3715662, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -23
-  - ID#: 541165879296
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2373793, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -22
-  - ID#: 545460846592
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1961135, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -21
-  - ID#: 549755813888
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2110438, -19.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -20
-  - ID#: 554050781184
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3277389, -18.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -19
-  - ID#: 558345748480
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.08693258, -17.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -18
-  - ID#: 562640715776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.08559334, -16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -17
-  - ID#: 566935683072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1509566, -15.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -16
-  - ID#: 571230650368
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3530231, -14.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -15
-  - ID#: 575525617664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3986399, -13.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -14
-  - ID#: 579820584960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.01591642, -12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -13
-  - ID#: 584115552256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1582752, -11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -12
-  - ID#: 588410519552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1384615, -10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -11
-  - ID#: 592705486848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.4362144, -9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -10
-  - ID#: 597000454144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.02308569, -8.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -9
-  - ID#: 601295421440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.07455699, -7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -8
-  - ID#: 605590388736
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.04856589, -6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -7
-  - ID#: 609885356032
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.4970343, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -6
-  - ID#: 614180323328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.4117289, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -5
-  - ID#: 618475290624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.4109516, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -4
-  - ID#: 622770257920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3474143, -2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -3
-  - ID#: 627065225216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.06259138, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -2
-  - ID#: 631360192512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1585497, -0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: -1
-  - ID#: 635655159808
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.381875, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 0
-  - ID#: 639950127104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.475111, 1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 1
-  - ID#: 644245094400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2452945, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 2
-  - ID#: 648540061696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.01722304, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 3
-  - ID#: 652835028992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3318028, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 4
-  - ID#: 657129996288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2193722, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 5
-  - ID#: 661424963584
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.06294832, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 6
-  - ID#: 665719930880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1907792, 7.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 7
-  - ID#: 670014898176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.1051045, 8.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 8
-  - ID#: 674309865472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3827584, 9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 9
-  - ID#: 678604832768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.02560821, 10.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 10
-  - ID#: 682899800064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3976, 11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 11
-  - ID#: 687194767360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.01822063, 12.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 12
-  - ID#: 691489734656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.0934363, 13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 13
-  - ID#: 695784701952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2043656, 16.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 16
-  - ID#: 700079669248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2448822, 17.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 17
-  - ID#: 704374636544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2289946, 18.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 18
-  - ID#: 708669603840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2227931, 19.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 19
-  - ID#: 712964571136
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.2437845, 20.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 20
-  - ID#: 717259538432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3231565, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 21
-  - ID#: 721554505728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3969875, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 22
-  - ID#: 725849473024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.3546824, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 23
-  - ID#: 730144440320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-23.5, -0.4604374, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -24
-      z: 24
-  - ID#: 734439407616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3773433, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -25
-  - ID#: 738734374912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4037655, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -24
-  - ID#: 743029342208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.1380125, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -23
-  - ID#: 747324309504
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3528871, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -22
-  - ID#: 751619276800
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3398513, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -21
-  - ID#: 755914244096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.001409216, -19.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -20
-  - ID#: 760209211392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.327549, -18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -19
-  - ID#: 764504178688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3553519, -17.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -18
-  - ID#: 768799145984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.08130587, -16.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -17
-  - ID#: 773094113280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3219805, -15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -16
-  - ID#: 777389080576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.05949884, -14.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -15
-  - ID#: 781684047872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2280164, -13.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -14
-  - ID#: 785979015168
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.249182, -12.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -13
-  - ID#: 790273982464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3869586, -11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -12
-  - ID#: 794568949760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.479872, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -6
-  - ID#: 798863917056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2868773, -4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -5
-  - ID#: 803158884352
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.1701929, -3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -4
-  - ID#: 807453851648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4383787, -2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -3
-  - ID#: 811748818944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2926339, -1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -2
-  - ID#: 816043786240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4040878, -0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: -1
-  - ID#: 820338753536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.111906, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 0
-  - ID#: 824633720832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.008886948, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 1
-  - ID#: 828928688128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3756335, 2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 2
-  - ID#: 833223655424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.410623, 3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 3
-  - ID#: 837518622720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.1275476, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 4
-  - ID#: 841813590016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4104204, 5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 5
-  - ID#: 846108557312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2529785, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 6
-  - ID#: 850403524608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.470037, 7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 7
-  - ID#: 854698491904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3495384, 8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 8
-  - ID#: 858993459200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2063333, 9.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 9
-  - ID#: 863288426496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4454516, 10.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 10
-  - ID#: 867583393792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2115826, 11.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 11
-  - ID#: 871878361088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.4796457, 17.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 17
-  - ID#: 876173328384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2904783, 18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 18
-  - ID#: 880468295680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.2736078, 19.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 19
-  - ID#: 884763262976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.07902879, 20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 20
-  - ID#: 889058230272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.06931222, 21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 21
-  - ID#: 893353197568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.3808656, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 22
-  - ID#: 897648164864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.074647, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 23
-  - ID#: 901943132160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-22.5, -0.115078, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -23
-      z: 24
-  - ID#: 906238099456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1287541, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -25
-  - ID#: 910533066752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4048673, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -24
-  - ID#: 914828034048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4203586, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -23
-  - ID#: 919123001344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4942608, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -22
-  - ID#: 923417968640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1271411, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -21
-  - ID#: 927712935936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1662241, -19.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -20
-  - ID#: 932007903232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4071424, -18.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -19
-  - ID#: 936302870528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1499159, -17.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -18
-  - ID#: 940597837824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1217625, -16.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -17
-  - ID#: 944892805120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.006769563, -15.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -16
-  - ID#: 949187772416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4646318, -1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -2
-  - ID#: 953482739712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1086189, -0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: -1
-  - ID#: 957777707008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1749919, 0.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 0
-  - ID#: 962072674304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4536824, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 1
-  - ID#: 966367641600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.09829763, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 3
-  - ID#: 970662608896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4242339, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 4
-  - ID#: 974957576192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1255419, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 5
-  - ID#: 979252543488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4775088, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 6
-  - ID#: 983547510784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.3080224, 8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 8
-  - ID#: 987842478080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.3894489, 9.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 9
-  - ID#: 992137445376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.2366444, 20.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 20
-  - ID#: 996432412672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4937298, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 21
-  - ID#: 1000727379968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.1758298, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 22
-  - ID#: 1005022347264
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.03379769, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 23
-  - ID#: 1009317314560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-21.5, -0.4154143, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -22
-      z: 24
-  - ID#: 1013612281856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.3967988, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: -25
-  - ID#: 1017907249152
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.292632, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: -24
-  - ID#: 1022202216448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.2972518, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: -23
-  - ID#: 1026497183744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.2748618, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: -22
-  - ID#: 1030792151040
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.3663993, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: 22
-  - ID#: 1035087118336
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.4585968, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: 23
-  - ID#: 1039382085632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-20.5, -0.3476164, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -21
-      z: 24
-  - ID#: 1043677052928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.1429195, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -25
-  - ID#: 1047972020224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.3399099, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -24
-  - ID#: 1052266987520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.3786001, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -23
-  - ID#: 1056561954816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.1961602, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -22
-  - ID#: 1060856922112
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-19.5, 0, -6.5]
-      orientation: [-0.7153419, 0, 0.6987746, 0]
-      scale: [1.168467, 1.168467, 1.168467]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -7
-  - ID#: 1065151889408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.1902229, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -6
-  - ID#: 1069446856704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.104034, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: -5
-  - ID#: 1073741824000
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-19.5, 0, 3.5]
-      orientation: [-0.2114594, 0, 0.9773868, 0]
-      scale: [1.158211, 1.158211, 1.158211]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 3
-  - ID#: 1078036791296
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-19.5, -0.03792715, 9.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 9
-  - ID#: 1082331758592
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-19.5, -0.2021043, 10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 10
-  - ID#: 1086626725888
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-19.5, 0, 11.5]
-      orientation: [0.985671, 0, 0.168679, 0]
-      scale: [1.105829, 1.105829, 1.105829]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 11
-  - ID#: 1090921693184
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.2653988, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 21
-  - ID#: 1095216660480
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.2964119, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 22
-  - ID#: 1099511627776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.3895836, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 23
-  - ID#: 1103806595072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-19.5, -0.1781726, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -20
-      z: 24
-  - ID#: 1108101562368
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.4670053, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -25
-  - ID#: 1112396529664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.4824832, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -24
-  - ID#: 1116691496960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.0649531, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -23
-  - ID#: 1120986464256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.07721921, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -22
-  - ID#: 1125281431552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.2844118, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -21
-  - ID#: 1129576398848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.1974541, -7.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -8
-  - ID#: 1133871366144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.2346953, -6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -7
-  - ID#: 1138166333440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.193648, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -6
-  - ID#: 1142461300736
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-18.5, 0, -0.5]
-      orientation: [0.999301, 0, 0.03738274, 0]
-      scale: [1.218086, 1.218086, 1.218086]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: -1
-  - ID#: 1146756268032
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.1685613, 2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 2
-  - ID#: 1151051235328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.1942849, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 3
-  - ID#: 1155346202624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.08109115, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 4
-  - ID#: 1159641169920
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-18.5, -0.4637464, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 5
-  - ID#: 1163936137216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.3971423, 6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 6
-  - ID#: 1168231104512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.2180588, 7.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 7
-  - ID#: 1172526071808
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-18.5, -0.1556075, 8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 8
-  - ID#: 1176821039104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.4313391, 9.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 9
-  - ID#: 1181116006400
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-18.5, -0.2642666, 13.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 13
-  - ID#: 1185410973696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.31018, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 21
-  - ID#: 1189705940992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.08282436, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 22
-  - ID#: 1194000908288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.05977359, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 23
-  - ID#: 1198295875584
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-18.5, -0.300991, 24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -19
-      z: 24
-  - ID#: 1202590842880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.2359784, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -25
-  - ID#: 1206885810176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.1314856, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -24
-  - ID#: 1211180777472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.1701099, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -23
-  - ID#: 1215475744768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.3270395, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -22
-  - ID#: 1219770712064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.264921, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -21
-  - ID#: 1224065679360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.3446073, -3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -4
-  - ID#: 1228360646656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.3580503, -2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -3
-  - ID#: 1232655613952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.3740758, -1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -2
-  - ID#: 1236950581248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.4941897, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: -1
-  - ID#: 1241245548544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.2252708, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 0
-  - ID#: 1245540515840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.3602467, 1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 1
-  - ID#: 1249835483136
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-17.5, -0.04191069, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 2
-  - ID#: 1254130450432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.4562888, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 3
-  - ID#: 1258425417728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.1144885, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 4
-  - ID#: 1262720385024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.2527493, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 5
-  - ID#: 1267015352320
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-17.5, -0.4566687, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 6
-  - ID#: 1271310319616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.2791344, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 7
-  - ID#: 1275605286912
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-17.5, -0.07618901, 10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 10
-  - ID#: 1279900254208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.251595, 11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 11
-  - ID#: 1284195221504
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-17.5, 0, 15.5]
-      orientation: [-0.8539785, 0, 0.5203084, 0]
-      scale: [1.138742, 1.138742, 1.138742]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 15
-  - ID#: 1288490188800
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.2691712, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 22
-  - ID#: 1292785156096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.273296, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 23
-  - ID#: 1297080123392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-17.5, -0.4980673, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -18
-      z: 24
-  - ID#: 1301375090688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.2237922, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -25
-  - ID#: 1305670057984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.03908776, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -24
-  - ID#: 1309965025280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4272255, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -23
-  - ID#: 1314259992576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.2213391, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -22
-  - ID#: 1318554959872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.3021157, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -21
-  - ID#: 1322849927168
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-16.5, 0, -6.5]
-      orientation: [0.9443907, 0, 0.3288254, 0]
-      scale: [1.149563, 1.149563, 1.149563]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -7
-  - ID#: 1327144894464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.480949, -5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -6
-  - ID#: 1331439861760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4899628, -4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -5
-  - ID#: 1335734829056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.002317113, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -4
-  - ID#: 1340029796352
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.01715866, -2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -3
-  - ID#: 1344324763648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.3874552, -1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -2
-  - ID#: 1348619730944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.488501, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: -1
-  - ID#: 1352914698240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4086516, 0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 0
-  - ID#: 1357209665536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.1815932, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 1
-  - ID#: 1361504632832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4343474, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 2
-  - ID#: 1365799600128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.3397599, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 3
-  - ID#: 1370094567424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.04221793, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 4
-  - ID#: 1374389534720
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-16.5, 0, 9.5]
-      orientation: [0.4645019, 0, 0.8855721, 0]
-      scale: [1.119935, 1.119935, 1.119935]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 9
-  - ID#: 1378684502016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4279376, 21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 21
-  - ID#: 1382979469312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.1299352, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 22
-  - ID#: 1387274436608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.02252977, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 23
-  - ID#: 1391569403904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-16.5, -0.4000342, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -17
-      z: 24
-  - ID#: 1395864371200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.3300597, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -25
-  - ID#: 1400159338496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.2157069, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -24
-  - ID#: 1404454305792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.3749705, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -23
-  - ID#: 1408749273088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.4553238, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -22
-  - ID#: 1413044240384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.06649802, -20.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -21
-  - ID#: 1417339207680
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-15.5, 0, -15.5]
-      orientation: [0.8412046, 0, 0.540717, 0]
-      scale: [1.294708, 1.294708, 1.294708]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -16
-  - ID#: 1421634174976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.1319015, -8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -9
-  - ID#: 1425929142272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.04767759, -7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -8
-  - ID#: 1430224109568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.07276949, -6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -7
-  - ID#: 1434519076864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.1413366, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -6
-  - ID#: 1438814044160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.06803428, -4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -5
-  - ID#: 1443109011456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.4010557, -3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -4
-  - ID#: 1447403978752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.4346461, -2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -3
-  - ID#: 1451698946048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.03877851, -1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -2
-  - ID#: 1455993913344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.2898523, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: -1
-  - ID#: 1460288880640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.3136922, 0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 0
-  - ID#: 1464583847936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.2749301, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 4
-  - ID#: 1468878815232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.004046956, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 5
-  - ID#: 1473173782528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.0724774, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 22
-  - ID#: 1477468749824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.3401435, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 23
-  - ID#: 1481763717120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-15.5, -0.4265155, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -16
-      z: 24
-  - ID#: 1486058684416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.2669666, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -25
-  - ID#: 1490353651712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.3110276, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -24
-  - ID#: 1494648619008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.2193334, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -23
-  - ID#: 1498943586304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.1754762, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -22
-  - ID#: 1503238553600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.0997756, -20.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -21
-  - ID#: 1507533520896
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-14.5, 0, -17.5]
-      orientation: [-0.04161245, 0, 0.9991338, 0]
-      scale: [1.0414, 1.0414, 1.0414]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -18
-  - ID#: 1511828488192
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-14.5, -0.200904, -16.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -17
-  - ID#: 1516123455488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.1911665, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -6
-  - ID#: 1520418422784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.03798334, -4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -5
-  - ID#: 1524713390080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.3812107, -3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: -4
-  - ID#: 1529008357376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.1199581, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: 3
-  - ID#: 1533303324672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.02023556, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: 4
-  - ID#: 1537598291968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.06165947, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: 22
-  - ID#: 1541893259264
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.126478, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: 23
-  - ID#: 1546188226560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-14.5, -0.0919539, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -15
-      z: 24
-  - ID#: 1550483193856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.2523855, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -25
-  - ID#: 1554778161152
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.1199763, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -24
-  - ID#: 1559073128448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4113025, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -23
-  - ID#: 1563368095744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.2086335, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -22
-  - ID#: 1567663063040
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4908616, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -21
-  - ID#: 1571958030336
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-13.5, -0.02482721, -12.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -13
-  - ID#: 1576252997632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4117277, -11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -12
-  - ID#: 1580547964928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4513581, -10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -11
-  - ID#: 1584842932224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.1509137, -9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -10
-  - ID#: 1589137899520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4723936, -8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: -9
-  - ID#: 1593432866816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.02397214, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 2
-  - ID#: 1597727834112
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.245432, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 3
-  - ID#: 1602022801408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.1239238, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 4
-  - ID#: 1606317768704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.2446263, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 5
-  - ID#: 1610612736000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.2720281, 6.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 6
-  - ID#: 1614907703296
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.3986399, 18.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 18
-  - ID#: 1619202670592
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-13.5, -0.4438631, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -14
-      z: 24
-  - ID#: 1623497637888
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.4500269, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -25
-  - ID#: 1627792605184
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.1719198, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -24
-  - ID#: 1632087572480
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.1846234, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -23
-  - ID#: 1636382539776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.01663428, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -22
-  - ID#: 1640677507072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.05560138, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -21
-  - ID#: 1644972474368
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-12.5, -0.08143606, -15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -16
-  - ID#: 1649267441664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.390126, -14.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -15
-  - ID#: 1653562408960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.438682, -13.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -14
-  - ID#: 1657857376256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.1948694, -12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -13
-  - ID#: 1662152343552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.1051509, -11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -12
-  - ID#: 1666447310848
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-12.5, -0.1208456, -10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -11
-  - ID#: 1670742278144
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-12.5, 0, -7.5]
-      orientation: [0.6547996, 0, 0.7558026, 0]
-      scale: [1.121174, 1.121174, 1.121174]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: -8
-  - ID#: 1675037245440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.246221, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 2
-  - ID#: 1679332212736
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.04822727, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 3
-  - ID#: 1683627180032
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.11171, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 4
-  - ID#: 1687922147328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.06598665, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 5
-  - ID#: 1692217114624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.2451507, 6.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 6
-  - ID#: 1696512081920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.3530231, 17.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 17
-  - ID#: 1700807049216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-12.5, -0.4774717, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -13
-      z: 24
-  - ID#: 1705102016512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.4780673, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -25
-  - ID#: 1709396983808
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.3259843, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -24
-  - ID#: 1713691951104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.2876043, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -23
-  - ID#: 1717986918400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.3787518, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -22
-  - ID#: 1722281885696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.02988977, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -21
-  - ID#: 1726576852992
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-11.5, 0, -13.5]
-      orientation: [0.2020314, 0, 0.9793791, 0]
-      scale: [1.070434, 1.070434, 1.070434]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -14
-  - ID#: 1730871820288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.2764406, -12.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -13
-  - ID#: 1735166787584
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-11.5, -0.1765793, -11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: -12
-  - ID#: 1739461754880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.02657628, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 4
-  - ID#: 1743756722176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.410597, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 5
-  - ID#: 1748051689472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.1612554, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 6
-  - ID#: 1752346656768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.007701721, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 7
-  - ID#: 1756641624064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.2024907, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 22
-  - ID#: 1760936591360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1509566, 16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 16
-  - ID#: 1765231558656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-11.5, -0.4542168, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -12
-      z: 24
-  - ID#: 1769526525952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.08449502, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -25
-  - ID#: 1773821493248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.4045686, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -24
-  - ID#: 1778116460544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.3245578, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -23
-  - ID#: 1782411427840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.1291479, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -22
-  - ID#: 1786706395136
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-10.5, -0.3658612, -8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -9
-  - ID#: 1791001362432
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-10.5, 0, -7.5]
-      orientation: [0.917946, 0, 0.3967054, 0]
-      scale: [1.194324, 1.194324, 1.194324]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: -8
-  - ID#: 1795296329728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.2466634, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: 4
-  - ID#: 1799591297024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.2254619, 5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: 5
-  - ID#: 1803886264320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.1892502, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: 22
-  - ID#: 1808181231616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.08693258, 15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 15
-  - ID#: 1812476198912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-10.5, -0.359235, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -11
-      z: 24
-  - ID#: 1816771166208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.1481604, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: -25
-  - ID#: 1821066133504
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.1439025, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: -24
-  - ID#: 1825361100800
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.3723464, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: -23
-  - ID#: 1829656068096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.3117178, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: -22
-  - ID#: 1833951035392
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-9.5, 0, -2.5]
-      orientation: [0.8289214, 0, 0.5593651, 0]
-      scale: [1.243562, 1.243562, 1.243562]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: -3
-  - ID#: 1838246002688
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-9.5, -0.3433877, 1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: 1
-  - ID#: 1842540969984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.156254, 5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: 5
-  - ID#: 1846835937280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.09175558, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: 22
-  - ID#: 1851130904576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.08559334, 16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 16
-  - ID#: 1855425871872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-9.5, -0.1842423, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -10
-      z: 24
-  - ID#: 1859720839168
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.1719649, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -25
-  - ID#: 1864015806464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.3128093, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -24
-  - ID#: 1868310773760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.4078845, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -23
-  - ID#: 1872605741056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.3901137, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -22
-  - ID#: 1876900708352
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-8.5, 0, -6.5]
-      orientation: [-0.5071069, 0, 0.8618832, 0]
-      scale: [1.024338, 1.024338, 1.024338]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -7
-  - ID#: 1881195675648
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-8.5, -0.1897094, -0.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: -1
-  - ID#: 1885490642944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.464693, 0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 0
-  - ID#: 1889785610240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.2292484, 1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 1
-  - ID#: 1894080577536
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-8.5, -0.3161796, 2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 2
-  - ID#: 1898375544832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.151807, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 5
-  - ID#: 1902670512128
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-8.5, -0.2433958, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 6
-  - ID#: 1906965479424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.3989643, 18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 18
-  - ID#: 1911260446720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.2179293, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 22
-  - ID#: 1915555414016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.3277389, 14.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 14
-  - ID#: 1919850381312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-8.5, -0.2233919, 24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -9
-      z: 24
-  - ID#: 1924145348608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.3778949, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -25
-  - ID#: 1928440315904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.1531747, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -24
-  - ID#: 1932735283200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.05403096, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -23
-  - ID#: 1937030250496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.2542543, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -22
-  - ID#: 1941325217792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.1967949, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -21
-  - ID#: 1945620185088
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-7.5, 0, -3.5]
-      orientation: [-0.03383341, 0, 0.9994275, 0]
-      scale: [1.261056, 1.261056, 1.261056]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -4
-  - ID#: 1949915152384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.4088139, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: -1
-  - ID#: 1954210119680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.1804304, 0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 0
-  - ID#: 1958505086976
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-7.5, -0.06349341, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 1
-  - ID#: 1962800054272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.4585589, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 2
-  - ID#: 1967095021568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.3221591, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 3
-  - ID#: 1971389988864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.3278703, 20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 20
-  - ID#: 1975684956160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.1893047, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 22
-  - ID#: 1979979923456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.2110438, 13.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 13
-  - ID#: 1984274890752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-7.5, -0.4057902, 24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -8
-      z: 24
-  - ID#: 1988569858048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.09993643, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -25
-  - ID#: 1992864825344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.2664128, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -24
-  - ID#: 1997159792640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.4744625, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -23
-  - ID#: 2001454759936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.1753636, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -22
-  - ID#: 2005749727232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.495055, -20.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -21
-  - ID#: 2010044694528
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-6.5, -0.4695008, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -2
-  - ID#: 2014339661824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.120038, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: -1
-  - ID#: 2018634629120
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-6.5, -0.4844339, 0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 0
-  - ID#: 2022929596416
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-6.5, -0.4073618, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 1
-  - ID#: 2027224563712
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-6.5, -0.4175043, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 2
-  - ID#: 2031519531008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.1943076, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 3
-  - ID#: 2035814498304
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-6.5, -0.3112375, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 4
-  - ID#: 2040109465600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.3898447, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 5
-  - ID#: 2044404432896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.2935224, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 22
-  - ID#: 2048699400192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.1961135, 12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 12
-  - ID#: 2052994367488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-6.5, -0.1038711, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -7
-      z: 24
-  - ID#: 2057289334784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.270069, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -25
-  - ID#: 2061584302080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.1506232, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -24
-  - ID#: 2065879269376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.009225422, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -23
-  - ID#: 2070174236672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.2354617, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -22
-  - ID#: 2074469203968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.4500916, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -21
-  - ID#: 2078764171264
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-5.5, 0, -5.5]
-      orientation: [0.749096, 0, 0.6624615, 0]
-      scale: [1.058349, 1.058349, 1.058349]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -6
-  - ID#: 2083059138560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.4221544, -4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -5
-  - ID#: 2087354105856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.4429991, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -4
-  - ID#: 2091649073152
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.09738214, -2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -3
-  - ID#: 2095944040448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.2206117, -1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -2
-  - ID#: 2100239007744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.1129609, -0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: -1
-  - ID#: 2104533975040
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-5.5, -0.452896, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 0
-  - ID#: 2108828942336
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-5.5, -0.0677385, 1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 1
-  - ID#: 2113123909632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.1197512, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 2
-  - ID#: 2117418876928
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-5.5, -0.1138321, 3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 3
-  - ID#: 2121713844224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.3998266, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 4
-  - ID#: 2126008811520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.2178493, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 22
-  - ID#: 2130303778816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.2373793, 12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 12
-  - ID#: 2134598746112
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-5.5, -0.3715662, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -6
-      z: 24
-  - ID#: 2138893713408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.04491158, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -25
-  - ID#: 2143188680704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.4616898, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -24
-  - ID#: 2147483648000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.3222753, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -23
-  - ID#: 2151778615296
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.2151037, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -22
-  - ID#: 2156073582592
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.3165318, -20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -21
-  - ID#: 2160368549888
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.09240816, -1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -2
-  - ID#: 2164663517184
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-4.5, -0.110517, -0.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -1
-  - ID#: 2168958484480
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-4.5, -0.4566879, 0.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 0
-  - ID#: 2173253451776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.3633272, 1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 1
-  - ID#: 2177548419072
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-4.5, -0.1540835, 2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 2
-  - ID#: 2181843386368
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [-4.5, -0.2736103, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 3
-  - ID#: 2186138353664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.219435, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 22
-  - ID#: 2190433320960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.3788701, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 22
-  - ID#: 2194728288256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.05555961, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: 24
-  - ID#: 2199023255552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.3536608, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -25
-  - ID#: 2203318222848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.1290323, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -24
-  - ID#: 2207613190144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.08116426, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -23
-  - ID#: 2211908157440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.2043599, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -22
-  - ID#: 2216203124736
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.06686819, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -21
-  - ID#: 2220498092032
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-3.5, 0, -3.5]
-      orientation: [-0.2937282, 0, 0.955889, 0]
-      scale: [1.134867, 1.134867, 1.134867]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -4
-  - ID#: 2224793059328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.1311059, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -1
-  - ID#: 2229088026624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.02102706, 0.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 0
-  - ID#: 2233382993920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.3014216, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 1
-  - ID#: 2237677961216
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-3.5, -0.3986821, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 2
-  - ID#: 2241972928512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1993693, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 22
-  - ID#: 2246267895808
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.0837779, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 24
-  - ID#: 2250562863104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1108734, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -25
-  - ID#: 2254857830400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.4156072, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -24
-  - ID#: 2259152797696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.05870883, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -23
-  - ID#: 2263447764992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1624818, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -22
-  - ID#: 2267742732288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1483379, -20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -21
-  - ID#: 2272037699584
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-2.5, -0.3278899, -4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -5
-  - ID#: 2276332666880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.1593892, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -4
-  - ID#: 2280627634176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.210095, -2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -3
-  - ID#: 2284922601472
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-2.5, 0, -0.5]
-      orientation: [0.2359899, 0, 0.9717555, 0]
-      scale: [1.234573, 1.234573, 1.234573]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -1
-  - ID#: 2289217568768
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-2.5, -0.2539291, 1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 1
-  - ID#: 2293512536064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.05659627, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 23
-  - ID#: 2297807503360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-2.5, -0.04275789, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: 24
-  - ID#: 2302102470656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.4967674, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: -25
-  - ID#: 2306397437952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.1312411, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: -24
-  - ID#: 2310692405248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.09078649, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: -23
-  - ID#: 2314987372544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.4005073, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: -22
-  - ID#: 2319282339840
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [-1.5, 0, -5.5]
-      orientation: [-0.7352417, 0, 0.6778049, 0]
-      scale: [1.008766, 1.008766, 1.008766]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: -6
-  - ID#: 2323577307136
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.1329603, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: 22
-  - ID#: 2327872274432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.4644271, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: 23
-  - ID#: 2332167241728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-1.5, -0.1220691, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -2
-      z: 24
-  - ID#: 2336462209024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.3651654, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: -25
-  - ID#: 2340757176320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.05036924, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: -24
-  - ID#: 2345052143616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.2443045, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: -23
-  - ID#: 2349347110912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.172164, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: -22
-  - ID#: 2353642078208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.2892625, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: 22
-  - ID#: 2357937045504
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.1408137, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: 23
-  - ID#: 2362232012800
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-0.5, -0.1186418, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -1
-      z: 24
-  - ID#: 2366526980096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.4843202, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -25
-  - ID#: 2370821947392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.2294244, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -24
-  - ID#: 2375116914688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.1068864, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -23
-  - ID#: 2379411881984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.4815443, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -22
-  - ID#: 2383706849280
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [0.5, 0, -6.5]
-      orientation: [-0.3266748, 0, 0.9451368, 0]
-      scale: [1.164042, 1.164042, 1.164042]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -7
-  - ID#: 2388001816576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.1132757, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -6
-  - ID#: 2392296783872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.2605679, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: -5
-  - ID#: 2396591751168
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [0.5, 0, 3.5]
-      orientation: [0.8272474, 0, 0.5618377, 0]
-      scale: [1.069478, 1.069478, 1.069478]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 3
-  - ID#: 2400886718464
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [0.5, -0.2007857, 9.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 9
-  - ID#: 2405181685760
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [0.5, -0.2444489, 10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 10
-  - ID#: 2409476653056
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [0.5, 0, 11.5]
-      orientation: [0.2690491, 0, 0.9631265, 0]
-      scale: [1.187218, 1.187218, 1.187218]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 11
-  - ID#: 2413771620352
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.08507614, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 21
-  - ID#: 2418066587648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.3395678, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 22
-  - ID#: 2422361554944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.1495259, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 23
-  - ID#: 2426656522240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [0.5, -0.1977576, 24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 0
-      z: 24
-  - ID#: 2430951489536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.3182343, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -25
-  - ID#: 2435246456832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.1837183, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -24
-  - ID#: 2439541424128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.07578708, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -23
-  - ID#: 2443836391424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.493991, -7.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -8
-  - ID#: 2448131358720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.3846216, -6.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -7
-  - ID#: 2452426326016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.01886943, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -6
-  - ID#: 2456721293312
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [1.5, 0, -0.5]
-      orientation: [-0.9342938, 0, 0.356504, 0]
-      scale: [1.26555, 1.26555, 1.26555]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: -1
-  - ID#: 2461016260608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.4796108, 2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 2
-  - ID#: 2465311227904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.4566434, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 3
-  - ID#: 2469606195200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.009033135, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 4
-  - ID#: 2473901162496
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [1.5, -0.3980919, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 5
-  - ID#: 2478196129792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.2914232, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 6
-  - ID#: 2482491097088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.04935614, 7.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 7
-  - ID#: 2486786064384
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [1.5, -0.3834271, 8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 8
-  - ID#: 2491081031680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.1309356, 9.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 9
-  - ID#: 2495375998976
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [1.5, -0.1638989, 13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 13
-  - ID#: 2499670966272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.1676784, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 21
-  - ID#: 2503965933568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.06453308, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 22
-  - ID#: 2508260900864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.339864, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 23
-  - ID#: 2512555868160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [1.5, -0.1459804, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 1
-      z: 24
-  - ID#: 2516850835456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.06827657, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -25
-  - ID#: 2521145802752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.4235548, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -24
-  - ID#: 2525440770048
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.07880654, -3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -4
-  - ID#: 2529735737344
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.3629195, -2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -3
-  - ID#: 2534030704640
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.4905548, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -2
-  - ID#: 2538325671936
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.4785835, -0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: -1
-  - ID#: 2542620639232
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.247087, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 2
-  - ID#: 2546915606528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.006269402, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 3
-  - ID#: 2551210573824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.3895259, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 4
-  - ID#: 2555505541120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.1432933, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 5
-  - ID#: 2559800508416
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.3575186, 6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 6
-  - ID#: 2564095475712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.04934952, 7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 7
-  - ID#: 2568390443008
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [2.5, -0.4518603, 10.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 10
-  - ID#: 2572685410304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.1923776, 11.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 11
-  - ID#: 2576980377600
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [2.5, 0, 15.5]
-      orientation: [-0.9418585, 0, 0.3360099, 0]
-      scale: [1.106605, 1.106605, 1.106605]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 15
-  - ID#: 2581275344896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.1670815, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 22
-  - ID#: 2585570312192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.3599855, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 23
-  - ID#: 2589865279488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [2.5, -0.3493729, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 2
-      z: 24
-  - ID#: 2594160246784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.03272253, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -25
-  - ID#: 2598455214080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.09890492, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -24
-  - ID#: 2602750181376
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [3.5, 0, -6.5]
-      orientation: [-0.04352629, 0, 0.9990523, 0]
-      scale: [1.009162, 1.009162, 1.009162]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -7
-  - ID#: 2607045148672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.2119892, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -6
-  - ID#: 2611340115968
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [3.5, -0.2426878, -4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -5
-  - ID#: 2615635083264
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [3.5, -0.4838475, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -4
-  - ID#: 2619930050560
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [3.5, -0.4787534, -2.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -3
-  - ID#: 2624225017856
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [3.5, -0.4964406, -1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -2
-  - ID#: 2628519985152
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [3.5, -0.09419098, -0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: -1
-  - ID#: 2632814952448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.3049333, 3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 3
-  - ID#: 2637109919744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.4671253, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 4
-  - ID#: 2641404887040
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [3.5, 0, 9.5]
-      orientation: [-0.3612983, 0, 0.9324503, 0]
-      scale: [1.141757, 1.141757, 1.141757]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 9
-  - ID#: 2645699854336
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.4297211, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 21
-  - ID#: 2649994821632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.3054581, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 22
-  - ID#: 2654289788928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.4027447, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 23
-  - ID#: 2658584756224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [3.5, -0.2442009, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 3
-      z: 24
-  - ID#: 2662879723520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.2883607, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -25
-  - ID#: 2667174690816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.2572598, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -24
-  - ID#: 2671469658112
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [4.5, 0, -15.5]
-      orientation: [0.8393729, 0, 0.543556, 0]
-      scale: [1.073506, 1.073506, 1.073506]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -16
-  - ID#: 2675764625408
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [4.5, -0.4001402, -8.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -9
-  - ID#: 2680059592704
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [4.5, -0.1485147, -7.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -8
-  - ID#: 2684354560000
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [4.5, -0.07094317, -6.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -7
-  - ID#: 2688649527296
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [4.5, -0.002391742, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -6
-  - ID#: 2692944494592
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [4.5, -0.2108806, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -5
-  - ID#: 2697239461888
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [4.5, -0.4824443, -3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -4
-  - ID#: 2701534429184
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [4.5, -0.4982307, -2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -3
-  - ID#: 2705829396480
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [4.5, -0.2734407, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -2
-  - ID#: 2710124363776
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [4.5, -0.1392491, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: -1
-  - ID#: 2714419331072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.4893403, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: 4
-  - ID#: 2718714298368
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.1162002, 5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: 5
-  - ID#: 2723009265664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.3563472, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: 22
-  - ID#: 2727304232960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.3734521, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: 23
-  - ID#: 2731599200256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [4.5, -0.2502358, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 4
-      z: 24
-  - ID#: 2735894167552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.1612665, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -25
-  - ID#: 2740189134848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.2355442, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -24
-  - ID#: 2744484102144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.1591161, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -23
-  - ID#: 2748779069440
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [5.5, 0, -17.5]
-      orientation: [0.9825109, 0, 0.186205, 0]
-      scale: [1.285742, 1.285742, 1.285742]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -18
-  - ID#: 2753074036736
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [5.5, -0.340986, -16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -17
-  - ID#: 2757369004032
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.2673605, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -6
-  - ID#: 2761663971328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.02121557, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -5
-  - ID#: 2765958938624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.4359026, -3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: -4
-  - ID#: 2770253905920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.03572273, 3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: 3
-  - ID#: 2774548873216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.4673013, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: 4
-  - ID#: 2778843840512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.2608249, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: 22
-  - ID#: 2783138807808
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.333557, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: 23
-  - ID#: 2787433775104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [5.5, -0.04836502, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 5
-      z: 24
-  - ID#: 2791728742400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.1448447, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -25
-  - ID#: 2796023709696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.4090743, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -24
-  - ID#: 2800318676992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.03276223, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -23
-  - ID#: 2804613644288
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [6.5, -0.4087735, -12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -13
-  - ID#: 2808908611584
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.1159443, -11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -12
-  - ID#: 2813203578880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.3612198, -10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -11
-  - ID#: 2817498546176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.3523619, -9.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -10
-  - ID#: 2821793513472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.07493272, -8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: -9
-  - ID#: 2826088480768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.0975537, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 2
-  - ID#: 2830383448064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.3298026, 3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 3
-  - ID#: 2834678415360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.2111092, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 4
-  - ID#: 2838973382656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.2592975, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 5
-  - ID#: 2843268349952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.4680275, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 6
-  - ID#: 2847563317248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.4864873, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 23
-  - ID#: 2851858284544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [6.5, -0.0711086, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 6
-      z: 24
-  - ID#: 2856153251840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.3244957, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -25
-  - ID#: 2860448219136
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.3215905, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -24
-  - ID#: 2864743186432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.4001653, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -23
-  - ID#: 2869038153728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.2363661, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -22
-  - ID#: 2873333121024
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [7.5, -0.2268988, -15.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -16
-  - ID#: 2877628088320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.2184665, -14.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -15
-  - ID#: 2881923055616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.2161957, -13.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -14
-  - ID#: 2886218022912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.1221598, -12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -13
-  - ID#: 2890512990208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.4126569, -11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -12
-  - ID#: 2894807957504
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [7.5, -0.2529597, -10.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -11
-  - ID#: 2899102924800
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [7.5, 0, -7.5]
-      orientation: [0.9658148, 0, 0.2592332, 0]
-      scale: [1.272083, 1.272083, 1.272083]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: -8
-  - ID#: 2903397892096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.0665855, 2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 2
-  - ID#: 2907692859392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.03825199, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 3
-  - ID#: 2911987826688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.08669431, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 4
-  - ID#: 2916282793984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.356952, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 5
-  - ID#: 2920577761280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.1954689, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 6
-  - ID#: 2924872728576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.3086025, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 23
-  - ID#: 2929167695872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [7.5, -0.4156899, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 24
-  - ID#: 2933462663168
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.09454209, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -25
-  - ID#: 2937757630464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.4016822, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -24
-  - ID#: 2942052597760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.1984909, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -23
-  - ID#: 2946347565056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.03023559, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -22
-  - ID#: 2950642532352
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [8.5, 0, -13.5]
-      orientation: [0.6430613, 0, 0.7658147, 0]
-      scale: [1.119777, 1.119777, 1.119777]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -14
-  - ID#: 2954937499648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.4290496, -12.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -13
-  - ID#: 2959232466944
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [8.5, -0.2634379, -11.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: -12
-  - ID#: 2963527434240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.4544683, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 4
-  - ID#: 2967822401536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.2083997, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 5
-  - ID#: 2972117368832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.3086396, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 6
-  - ID#: 2976412336128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.3284299, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 7
-  - ID#: 2980707303424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.09040935, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 22
-  - ID#: 2985002270720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.3139867, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 23
-  - ID#: 2989297238016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [8.5, -0.2575119, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 24
-  - ID#: 2993592205312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.145992, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -25
-  - ID#: 2997887172608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.4123158, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -24
-  - ID#: 3002182139904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.2158256, -22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -23
-  - ID#: 3006477107200
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [9.5, -0.1796622, -8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -9
-  - ID#: 3010772074496
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [9.5, 0, -7.5]
-      orientation: [0.9988166, 0, 0.04863504, 0]
-      scale: [1.244835, 1.244835, 1.244835]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -8
-  - ID#: 3015067041792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.4920319, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 4
-  - ID#: 3019362009088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.1466941, 5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 5
-  - ID#: 3023656976384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.0835842, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 22
-  - ID#: 3027951943680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.08605891, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 23
-  - ID#: 3032246910976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [9.5, -0.05310817, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 24
-  - ID#: 3036541878272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.2463948, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: -25
-  - ID#: 3040836845568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.1862049, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: -24
-  - ID#: 3045131812864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.09766238, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 22
-  - ID#: 3049426780160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.0990592, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 23
-  - ID#: 3053721747456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.4321537, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 24
-  - ID#: 3058016714752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.2448438, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: -25
-  - ID#: 3062311682048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.1020986, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: -24
-  - ID#: 3066606649344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.1697467, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 21
-  - ID#: 3070901616640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.3081361, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 22
-  - ID#: 3075196583936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.4758152, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 23
-  - ID#: 3079491551232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.4390253, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 24
-  - ID#: 3083786518528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.460166, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: -25
-  - ID#: 3088081485824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.1962345, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: -24
-  - ID#: 3092376453120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.0263385, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 21
-  - ID#: 3096671420416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.4732886, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 22
-  - ID#: 3100966387712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.3689291, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 23
-  - ID#: 3105261355008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.08334913, 24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 24
-  - ID#: 3109556322304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.1345597, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: -25
-  - ID#: 3113851289600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.4859387, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: -24
-  - ID#: 3118146256896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.2114178, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 22
-  - ID#: 3122441224192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.2819825, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 23
-  - ID#: 3126736191488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.2739354, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 24
-  - ID#: 3131031158784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.2991844, -24.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: -25
-  - ID#: 3135326126080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.4713685, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: -24
-  - ID#: 3139621093376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.06561092, 22.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 22
-  - ID#: 3143916060672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.2088721, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 23
-  - ID#: 3148211027968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.2833887, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 24
-  - ID#: 3152505995264
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.4915262, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -25
-  - ID#: 3156800962560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.2771901, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -24
-  - ID#: 3161095929856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.1507275, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -23
-  - ID#: 3165390897152
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [15.5, 0, -17.5]
-      orientation: [0.5608097, 0, 0.8279448, 0]
-      scale: [1.21033, 1.21033, 1.21033]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -18
-  - ID#: 3169685864448
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [15.5, -0.06032446, -16.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -17
-  - ID#: 3173980831744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.3331694, -5.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -6
-  - ID#: 3178275799040
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.3688954, -4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -5
-  - ID#: 3182570766336
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.2695632, -3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: -4
-  - ID#: 3186865733632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.1213618, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 3
-  - ID#: 3191160700928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.3490528, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 4
-  - ID#: 3195455668224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.4114296, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 22
-  - ID#: 3199750635520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.333264, 23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 23
-  - ID#: 3204045602816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [15.5, -0.09273799, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 24
-  - ID#: 3208340570112
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.08906623, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -25
-  - ID#: 3212635537408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.1563385, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -24
-  - ID#: 3216930504704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.0640072, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -23
-  - ID#: 3221225472000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.4408627, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -22
-  - ID#: 3225520439296
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [16.5, -0.4995402, -12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -13
-  - ID#: 3229815406592
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.3371065, -11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -12
-  - ID#: 3234110373888
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.08556053, -10.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -11
-  - ID#: 3238405341184
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.3696488, -9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -10
-  - ID#: 3242700308480
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.01630041, -8.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: -9
-  - ID#: 3246995275776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.03127162, 2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 2
-  - ID#: 3251290243072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.2805999, 3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 3
-  - ID#: 3255585210368
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.06578078, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 4
-  - ID#: 3259880177664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.4409333, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 5
-  - ID#: 3264175144960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.04497645, 6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 6
-  - ID#: 3268470112256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.3345877, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 23
-  - ID#: 3272765079552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [16.5, -0.004157223, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 24
-  - ID#: 3277060046848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.09521663, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -25
-  - ID#: 3281355014144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.2282552, -23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -24
-  - ID#: 3285649981440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.1844583, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -23
-  - ID#: 3289944948736
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.3171517, -21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -22
-  - ID#: 3294239916032
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [17.5, -0.230363, -15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -16
-  - ID#: 3298534883328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.2648815, -14.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -15
-  - ID#: 3302829850624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.490819, -13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -14
-  - ID#: 3307124817920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.2489347, -12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -13
-  - ID#: 3311419785216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.07820248, -11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -12
-  - ID#: 3315714752512
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [17.5, -0.167899, -10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -11
-  - ID#: 3320009719808
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [17.5, 0, -7.5]
-      orientation: [-0.898749, 0, 0.4384635, 0]
-      scale: [1.075847, 1.075847, 1.075847]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: -8
-  - ID#: 3324304687104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.3223823, 2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 2
-  - ID#: 3328599654400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.1168377, 3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 3
-  - ID#: 3332894621696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.1881361, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 4
-  - ID#: 3337189588992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.08658151, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 5
-  - ID#: 3341484556288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.09546185, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 6
-  - ID#: 3345779523584
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.2979905, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 23
-  - ID#: 3350074490880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [17.5, -0.2141265, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 24
-  - ID#: 3354369458176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.3634466, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -25
-  - ID#: 3358664425472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.241011, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -24
-  - ID#: 3362959392768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.4387865, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -23
-  - ID#: 3367254360064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.06030581, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -22
-  - ID#: 3371549327360
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [18.5, 0, -13.5]
-      orientation: [-0.6058321, 0, 0.7955925, 0]
-      scale: [1.176852, 1.176852, 1.176852]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -14
-  - ID#: 3375844294656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.1173828, -12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -13
-  - ID#: 3380139261952
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [18.5, -0.1130938, -11.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: -12
-  - ID#: 3384434229248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.2389979, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 4
-  - ID#: 3388729196544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.1923096, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 5
-  - ID#: 3393024163840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.009105882, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 6
-  - ID#: 3397319131136
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.2914932, 7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 7
-  - ID#: 3401614098432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.3736656, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 22
-  - ID#: 3405909065728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.1259031, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 23
-  - ID#: 3410204033024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [18.5, -0.3273618, 24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 24
-  - ID#: 3414499000320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.1452203, -24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -25
-  - ID#: 3418793967616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.03903347, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -24
-  - ID#: 3423088934912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.3085454, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -23
-  - ID#: 3427383902208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.2363846, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -22
-  - ID#: 3431678869504
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [19.5, -0.1326405, -8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -9
-  - ID#: 3435973836800
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [19.5, 0, -7.5]
-      orientation: [-0.9999387, 0, 0.01107375, 0]
-      scale: [1.247313, 1.247313, 1.247313]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: -8
-  - ID#: 3440268804096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.2660488, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: 4
-  - ID#: 3444563771392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.4913317, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: 5
-  - ID#: 3448858738688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.449718, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: 22
-  - ID#: 3453153705984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.3651244, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: 23
-  - ID#: 3457448673280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [19.5, -0.3864505, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 19
-      z: 24
-  - ID#: 3461743640576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.1719385, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: -25
-  - ID#: 3466038607872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.1018799, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: -24
-  - ID#: 3470333575168
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.2920347, -22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: -23
-  - ID#: 3474628542464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.4535543, -21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: -22
-  - ID#: 3478923509760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.05388451, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: 22
-  - ID#: 3483218477056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.1874063, 23.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: 23
-  - ID#: 3487513444352
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [20.5, -0.4531541, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 20
-      z: 24
-  - ID#: 3491808411648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.4240444, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -25
-  - ID#: 3496103378944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.4398269, -23.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -24
-  - ID#: 3500398346240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.1633496, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -23
-  - ID#: 3504693313536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.4088803, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -22
-  - ID#: 3508988280832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.1633683, -20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -21
-  - ID#: 3513283248128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.130364, -19.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -20
-  - ID#: 3517578215424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.3296053, -18.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -19
-  - ID#: 3521873182720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2971781, -17.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -18
-  - ID#: 3526168150016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2933825, -16.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -17
-  - ID#: 3530463117312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.0112563, -1.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -2
-  - ID#: 3534758084608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.0244916, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: -1
-  - ID#: 3539053051904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2126297, 0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 0
-  - ID#: 3543348019200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.3849828, 1.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 1
-  - ID#: 3547642986496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.1563594, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 2
-  - ID#: 3551937953792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2458761, 3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 3
-  - ID#: 3556232921088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.08074237, 4.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 4
-  - ID#: 3560527888384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.244092, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 5
-  - ID#: 3564822855680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.0893831, 6.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 6
-  - ID#: 3569117822976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2145633, 20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 20
-  - ID#: 3573412790272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.2114428, 21.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 21
-  - ID#: 3577707757568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.1973639, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 22
-  - ID#: 3582002724864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.04711467, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 23
-  - ID#: 3586297692160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [21.5, -0.3882269, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 21
-      z: 24
-  - ID#: 3590592659456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2992618, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -25
-  - ID#: 3594887626752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.4873772, -23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -24
-  - ID#: 3599182594048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2354621, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -23
-  - ID#: 3603477561344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3742526, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -22
-  - ID#: 3607772528640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3479747, -20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -21
-  - ID#: 3612067495936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.317251, -19.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -20
-  - ID#: 3616362463232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3499439, -18.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -19
-  - ID#: 3620657430528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.03609013, -17.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -18
-  - ID#: 3624952397824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3192654, -16.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -17
-  - ID#: 3629247365120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3166817, -15.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -16
-  - ID#: 3633542332416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.01680192, -14.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -15
-  - ID#: 3637837299712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2644603, -13.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -14
-  - ID#: 3642132267008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.03440305, -12.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -13
-  - ID#: 3646427234304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1480838, -5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -6
-  - ID#: 3650722201600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1597999, -4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -5
-  - ID#: 3655017168896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1626639, -3.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -4
-  - ID#: 3659312136192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2654321, -2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -3
-  - ID#: 3663607103488
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.31556, -1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -2
-  - ID#: 3667902070784
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3272229, -0.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: -1
-  - ID#: 3672197038080
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.4972527, 0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 0
-  - ID#: 3676492005376
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2038096, 1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 1
-  - ID#: 3680786972672
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.2580239, 2.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 2
-  - ID#: 3685081939968
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.4099906, 3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 3
-  - ID#: 3689376907264
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.362227, 4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 4
-  - ID#: 3693671874560
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3591795, 5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 5
-  - ID#: 3697966841856
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1227874, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 6
-  - ID#: 3702261809152
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.4843247, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 7
-  - ID#: 3706556776448
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1661696, 8.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 8
-  - ID#: 3710851743744
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.265667, 16.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 16
-  - ID#: 3715146711040
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3743046, 17.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 17
-  - ID#: 3719441678336
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.1625728, 18.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 18
-  - ID#: 3723736645632
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3414832, 19.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 19
-  - ID#: 3728031612928
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.0528146, 20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 20
-  - ID#: 3732326580224
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3406357, 21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 21
-  - ID#: 3736621547520
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3054793, 22.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 22
-  - ID#: 3740916514816
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.03942119, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 23
-  - ID#: 3745211482112
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [22.5, -0.3894011, 24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 22
-      z: 24
-  - ID#: 3749506449408
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2294681, -24.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -25
-  - ID#: 3753801416704
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2117265, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -24
-  - ID#: 3758096384000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3490734, -22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -23
-  - ID#: 3762391351296
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.04541164, -21.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -22
-  - ID#: 3766686318592
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.03394242, -20.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -21
-  - ID#: 3770981285888
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1332358, -19.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -20
-  - ID#: 3775276253184
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.03457003, -18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -19
-  - ID#: 3779571220480
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.07682836, -17.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -18
-  - ID#: 3783866187776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2635214, -16.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -17
-  - ID#: 3788161155072
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1405026, -15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -16
-  - ID#: 3792456122368
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1310244, -14.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -15
-  - ID#: 3796751089664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2200426, -13.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -14
-  - ID#: 3801046056960
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2416876, -12.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -13
-  - ID#: 3805341024256
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2635714, -11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -12
-  - ID#: 3809635991552
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.06540273, -10.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -11
-  - ID#: 3813930958848
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2287122, -9.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -10
-  - ID#: 3818225926144
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.04722038, -8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -9
-  - ID#: 3822520893440
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4376858, -7.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -8
-  - ID#: 3826815860736
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.06019084, -6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -7
-  - ID#: 3831110828032
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2590261, -5.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -6
-  - ID#: 3835405795328
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4849186, -4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -5
-  - ID#: 3839700762624
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4718113, -3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -4
-  - ID#: 3843995729920
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3781408, -2.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -3
-  - ID#: 3848290697216
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3188545, -1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -2
-  - ID#: 3852585664512
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1340882, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: -1
-  - ID#: 3856880631808
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.478847, 0.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 0
-  - ID#: 3861175599104
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.362453, 1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 1
-  - ID#: 3865470566400
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1203535, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 2
-  - ID#: 3869765533696
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2078813, 3.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 3
-  - ID#: 3874060500992
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3380612, 4.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 4
-  - ID#: 3878355468288
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2373592, 5.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 5
-  - ID#: 3882650435584
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1445323, 6.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 6
-  - ID#: 3886945402880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.02772071, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 7
-  - ID#: 3891240370176
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3359041, 8.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 8
-  - ID#: 3895535337472
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3068721, 9.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 9
-  - ID#: 3899830304768
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3475702, 10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 10
-  - ID#: 3904125272064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.2453096, 11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 11
-  - ID#: 3908420239360
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.03399638, 14.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 14
-  - ID#: 3912715206656
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4522374, 15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 15
-  - ID#: 3917010173952
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1273951, 16.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 16
-  - ID#: 3921305141248
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4676071, 17.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 17
-  - ID#: 3925600108544
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.11202, 18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 18
-  - ID#: 3929895075840
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4591383, 19.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 19
-  - ID#: 3934190043136
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3339164, 20.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 20
-  - ID#: 3938485010432
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1519126, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 21
-  - ID#: 3942779977728
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.4221961, 22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 22
-  - ID#: 3947074945024
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.3950509, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 23
-  - ID#: 3951369912320
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [23.5, -0.1722312, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 23
-      z: 24
-  - ID#: 3955664879616
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1131137, -24.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -25
-  - ID#: 3959959846912
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3902598, -23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -24
-  - ID#: 3964254814208
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2244759, -22.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -23
-  - ID#: 3968549781504
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.337666, -21.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -22
-  - ID#: 3972844748800
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2550544, -20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -21
-  - ID#: 3977139716096
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.003357659, -19.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -20
-  - ID#: 3981434683392
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.115316, -18.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -19
-  - ID#: 3985729650688
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3010852, -17.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -18
-  - ID#: 3990024617984
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3559404, -16.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -17
-  - ID#: 3994319585280
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1933856, -15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -16
-  - ID#: 3998614552576
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.4922263, -14.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -15
-  - ID#: 4002909519872
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.4579956, -13.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -14
-  - ID#: 4007204487168
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3276066, -12.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -13
-  - ID#: 4011499454464
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.0005755287, -11.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -12
-  - ID#: 4015794421760
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1363335, -10.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -11
-  - ID#: 4020089389056
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2312246, -9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -10
-  - ID#: 4024384356352
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2345078, -8.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -9
-  - ID#: 4028679323648
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2121745, -7.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -8
-  - ID#: 4032974290944
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.001500603, -6.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -7
-  - ID#: 4037269258240
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2304582, -5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -6
-  - ID#: 4041564225536
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.223212, -4.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -5
-  - ID#: 4045859192832
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3850799, -3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -4
-  - ID#: 4050154160128
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.4854721, -2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -3
-  - ID#: 4054449127424
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1612359, -1.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -2
-  - ID#: 4058744094720
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1523318, -0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: -1
-  - ID#: 4063039062016
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3923697, 0.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 0
-  - ID#: 4067334029312
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1075545, 1.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 1
-  - ID#: 4071628996608
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2356786, 2.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 2
-  - ID#: 4075923963904
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1237925, 3.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 3
-  - ID#: 4080218931200
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.01788137, 4.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 4
-  - ID#: 4084513898496
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.4032255, 5.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 5
-  - ID#: 4088808865792
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.08793721, 6.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 6
-  - ID#: 4093103833088
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2431855, 7.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 7
-  - ID#: 4097398800384
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.360879, 8.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 8
-  - ID#: 4101693767680
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.203751, 9.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 9
-  - ID#: 4105988734976
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.236743, 10.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 10
-  - ID#: 4110283702272
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1078146, 11.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 11
-  - ID#: 4114578669568
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.0763606, 12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 12
-  - ID#: 4118873636864
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.270126, 13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 13
-  - ID#: 4123168604160
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1705623, 14.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 14
-  - ID#: 4127463571456
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3615121, 15.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 15
-  - ID#: 4131758538752
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3036946, 16.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 16
-  - ID#: 4136053506048
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.141847, 17.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 17
-  - ID#: 4140348473344
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.09587263, 18.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 18
-  - ID#: 4144643440640
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.2714311, 19.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 19
-  - ID#: 4148938407936
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3692134, 20.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 20
-  - ID#: 4153233375232
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.3779624, 21.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 21
-  - ID#: 4157528342528
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1214248, 22.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 22
-  - ID#: 4161823309824
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.1659886, 23.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 23
-  - ID#: 4166118277120
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [24.5, -0.4587122, 24.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 24
-      z: 24
-  - ID#: 4170413244416
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.4073618, 13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 13
-  - ID#: 4174708211712
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.0677385, 14.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 14
-  - ID#: 4179003179008
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [12.5, -0.452896, 14.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 14
-  - ID#: 4183298146304
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [13.5, -0.4175043, 12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 12
-  - ID#: 4187593113600
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [14.5, -0.06349341, 15.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 15
-  - ID#: 4191888080896
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.4844339, 15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 15
-  - ID#: 4196183048192
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.4566879, 15.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 15
-  - ID#: 4200478015488
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [12.5, -0.3530231, 15.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 15
-  - ID#: 4204772982784
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [13.5, -0.3986399, 15.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 15
-  - ID#: 4209067950080
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [14.5, 0, 14.5]
-      orientation: [-0.99975, 0, 0.02236243, 0]
-      scale: [1.287252, 1.287252, 1.287252]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 14
-  - ID#: 4213362917376
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [13.5, 0, 13.5]
-      orientation: [-0.9999382, 0, 0.0111169, 0]
-      scale: [1.289467, 1.289467, 1.289467]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 13
-  - ID#: 4217657884672
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [11.5, 0, 13.5]
-      orientation: [-0.9948544, 0, 0.1013153, 0]
-      scale: [1.047284, 1.047284, 1.047284]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 13
-  - ID#: 4221952851968
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [11.5, -0.1509566, 14.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 14
-  - ID#: 4226247819264
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [10.5, 0, 14.5]
-      orientation: [-0.9982396, 0, 0.05931081, 0]
-      scale: [1.28715, 1.28715, 1.28715]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 14
-  - ID#: 4230542786560
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [15.5, 0, 15.5]
-      orientation: [0.9410278, 0, 0.3383293, 0]
-      scale: [1.145613, 1.145613, 1.145613]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 15
-  - ID#: 4234837753856
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [15.5, 0, 14.5]
-      orientation: [-0.805505, 0, 0.592589, 0]
-      scale: [1.240084, 1.240084, 1.240084]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 14
-  - ID#: 4239132721152
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [14.5, 0, 16.5]
-      orientation: [0.5953096, 0, 0.8034964, 0]
-      scale: [1.042566, 1.042566, 1.042566]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 16
-  - ID#: 4243427688448
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [13.5, 0, 16.5]
-      orientation: [0.9998871, 0, 0.01502719, 0]
-      scale: [1.126528, 1.126528, 1.126528]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 16
-  - ID#: 4247722655744
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 16.5]
-      orientation: [0.9382299, 0, 0.3460124, 0]
-      scale: [1.274721, 1.274721, 1.274721]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 16
-  - ID#: 4252017623040
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 12.5]
-      orientation: [-0.4251064, 0, 0.9051434, 0]
-      scale: [1.237662, 1.237662, 1.237662]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 12
-  - ID#: 4256312590336
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [13.5, 0, 11.5]
-      orientation: [-0.9279503, 0, 0.3727039, 0]
-      scale: [1.287848, 1.287848, 1.287848]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 11
-  - ID#: 4260607557632
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [13.5, 0, 10.5]
-      orientation: [-0.01150647, 0, 0.9999338, 0]
-      scale: [1.196722, 1.196722, 1.196722]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 10
-  - ID#: 4264902524928
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [14.5, 0, 13.5]
-      orientation: [-0.8051748, 0, 0.5930375, 0]
-      scale: [1.010713, 1.010713, 1.010713]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 13
-  - ID#: 4269197492224
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [14.5, 0, 12.5]
-      orientation: [0.4220974, 0, 0.9065505, 0]
-      scale: [1.254739, 1.254739, 1.254739]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 12
-  - ID#: 4273492459520
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [16.5, 0, 15.5]
-      orientation: [0.7864353, 0, 0.6176727, 0]
-      scale: [1.280198, 1.280198, 1.280198]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 16
-      z: 15
-  - ID#: 4277787426816
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [11.5, 0, 16.5]
-      orientation: [-0.539428, 0, 0.8420317, 0]
-      scale: [1.203621, 1.203621, 1.203621]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 16
-  - ID#: 4282082394112
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [13.5, 0, 17.5]
-      orientation: [0.3127837, 0, 0.9498244, 0]
-      scale: [1.227322, 1.227322, 1.227322]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 13
-      z: 17
-  - ID#: 4286377361408
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [15.5, 0, 16.5]
-      orientation: [-0.686028, 0, 0.7275751, 0]
-      scale: [1.22294, 1.22294, 1.22294]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 16
-  - ID#: 4290672328704
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [14.5, 0, 17.5]
-      orientation: [0.07921477, 0, 0.9968576, 0]
-      scale: [1.117668, 1.117668, 1.117668]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 14
-      z: 17
-  - ID#: 4294967296000
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.2110438, 16.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 16
-  - ID#: 4299262263296
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [9.5, 0, 15.5]
-      orientation: [-0.469256, 0, 0.8830622, 0]
-      scale: [1.05216, 1.05216, 1.05216]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 15
-  - ID#: 4303557230592
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 17.5]
-      orientation: [0.9894984, 0, 0.1445436, 0]
-      scale: [1.044734, 1.044734, 1.044734]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 17
-  - ID#: 4307852197888
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [11.5, 0, 17.5]
-      orientation: [0.9538023, 0, 0.3004348, 0]
-      scale: [1.298221, 1.298221, 1.298221]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 17
-  - ID#: 4312147165184
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [10.5, 0, 17.5]
-      orientation: [-0.8500988, 0, 0.5266233, 0]
-      scale: [1.246571, 1.246571, 1.246571]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 17
-  - ID#: 4316442132480
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [9.5, 0, 16.5]
-      orientation: [-0.5745647, 0, 0.8184592, 0]
-      scale: [1.037555, 1.037555, 1.037555]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 16
-  - ID#: 4320737099776
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [10.5, -0.1585497, 11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 11
-  - ID#: 4325032067072
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [9.5, -0.381875, 11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 11
-  - ID#: 4329327034368
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [10.5, -0.475111, 10.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 10
-  - ID#: 4333622001664
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [11.5, -0.2452945, 11.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 11
-  - ID#: 4337916968960
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [9.5, 0, 12.5]
-      orientation: [0.9941504, 0, 0.1080045, 0]
-      scale: [1.199082, 1.199082, 1.199082]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 12
-  - ID#: 4342211936256
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [11.5, 0, 12.5]
-      orientation: [0.1912548, 0, 0.9815404, 0]
-      scale: [1.037769, 1.037769, 1.037769]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 12
-  - ID#: 4346506903552
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [10.5, 0, 12.5]
-      orientation: [0.363568, 0, 0.9315677, 0]
-      scale: [1.063063, 1.063063, 1.063063]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 10
-      z: 12
-  - ID#: 4350801870848
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 11.5]
-      orientation: [-0.7407228, 0, 0.6718107, 0]
-      scale: [1.015365, 1.015365, 1.015365]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 11
-  - ID#: 4355096838144
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [9.5, 0, 10.5]
-      orientation: [-0.8000616, 0, 0.5999178, 0]
-      scale: [1.010932, 1.010932, 1.010932]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: 10
-  - ID#: 4359391805440
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [8.5, 0, 11.5]
-      orientation: [0.832563, 0, 0.5539303, 0]
-      scale: [1.122619, 1.122619, 1.122619]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 8
-      z: 11
-  - ID#: 4363686772736
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [11.5, 0, 10.5]
-      orientation: [-0.4436398, 0, 0.8962052, 0]
-      scale: [1.238192, 1.238192, 1.238192]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 11
-      z: 10
-  - ID#: 4367981740032
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [7.5, 0, 11.5]
-      orientation: [0.1701146, 0, 0.9854243, 0]
-      scale: [1.146271, 1.146271, 1.146271]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 7
-      z: 11
-  - ID#: 4372276707328
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 10.5]
-      orientation: [-0.6113292, 0, 0.7913764, 0]
-      scale: [1.276262, 1.276262, 1.276262]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 10
-  - ID#: 4376571674624
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 9.5]
-      orientation: [-0.7174409, 0, 0.6966194, 0]
-      scale: [1.242259, 1.242259, 1.242259]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 9
-  - ID#: 4380866641920
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [12.5, 0, 8.5]
-      orientation: [0.6469958, 0, 0.7624936, 0]
-      scale: [1.211732, 1.211732, 1.211732]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 12
-      z: 8
-  - ID#: 4385161609216
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [15.5, 0, 9.5]
-      orientation: [-0.535038, 0, 0.844828, 0]
-      scale: [1.000846, 1.000846, 1.000846]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 15
-      z: 9
-  - ID#: 4389456576512
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [18.5, 0, 12.5]
-      orientation: [-0.4682019, 0, 0.8836215, 0]
-      scale: [1.213211, 1.213211, 1.213211]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 18
-      z: 12
-  - ID#: 4393751543808
-    NameComponent:
-      name: Tree
-    Transform3DComponent:
-      position: [17.5, 0, 19.5]
-      orientation: [0.8723244, 0, 0.4889275, 0]
-      scale: [1.193188, 1.193188, 1.193188]
-    ModelComponent:
-      mesh: Resources/Models/BetterTree.obj
-      material: Resources/Materials/tree.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 17
-      z: 19
-  - ID#: 4398046511104
-    NameComponent:
-      name: Mithril
-    Transform3DComponent:
-      position: [-3.5, -0.4073618, 23.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: 23
-  - ID#: 4402341478400
-    NameComponent:
-      name: Iron
-    Transform3DComponent:
-      position: [9.5, -0.4073618, -3.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/iron.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: 9
-      z: -4
-  - ID#: 4406636445696
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-3.5, -0.0677385, -12.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -13
-  - ID#: 4410931412992
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-4.5, -0.452896, -11.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -12
-  - ID#: 4415226380288
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-4.5, -0.4175043, -12.5]
-      orientation: [0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -13
-  - ID#: 4419521347584
-    NameComponent:
-      name: Tin
-    Transform3DComponent:
-      position: [-3.5, -0.06349341, -13.5]
-      orientation: [1, 0, 0, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Material/tin.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -4
-      z: -14
-  - ID#: 4423816314880
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-4.5, -0.4844339, -13.5]
-      orientation: [-0.7071068, 0, 0.7071068, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -5
-      z: -14
-  - ID#: 4428111282176
+  - ID#: 4440996184064
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -15458,7 +1088,13015 @@ Entities:
     GridComponent:
       x: -6
       z: -13
-  - ID#: 4432406249472
+  - ID#: 4436701216768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.4844339, -13.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -14
+  - ID#: 335007449088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.452896, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -23
+  - ID#: 339302416384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4175043, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -22
+  - ID#: 343597383680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.06349341, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -21
+  - ID#: 347892350976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4844339, -19.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -20
+  - ID#: 352187318272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4566879, -18.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -19
+  - ID#: 356482285568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.110517, -17.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -18
+  - ID#: 360777252864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3161796, -16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -17
+  - ID#: 365072220160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.1540835, -15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -16
+  - ID#: 369367187456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.0487702, -14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -15
+  - ID#: 373662154752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.2736103, -13.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -14
+  - ID#: 377957122048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.1392491, -12.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -13
+  - ID#: 382252089344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.09419098, -11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -12
+  - ID#: 386547056640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.2734407, -10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -11
+  - ID#: 390842023936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4964406, -9.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -10
+  - ID#: 395136991232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4787534, -8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -9
+  - ID#: 399431958528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4982307, -7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -8
+  - ID#: 403726925824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4824443, -6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -7
+  - ID#: 408021893120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4838475, -5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -6
+  - ID#: 412316860416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.07880654, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -5
+  - ID#: 416611827712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3629195, -3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -4
+  - ID#: 420906795008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4852964, -2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -3
+  - ID#: 425201762304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4905548, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -2
+  - ID#: 429496729600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4785835, -0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: -1
+  - ID#: 433791696896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.05493088, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 0
+  - ID#: 438086664192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.2426878, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 1
+  - ID#: 442381631488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3990529, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 2
+  - ID#: 446676598784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4001402, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 3
+  - ID#: 450971566080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.1485147, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 4
+  - ID#: 455266533376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.07094317, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 5
+  - ID#: 459561500672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.002391742, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 6
+  - ID#: 463856467968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.2108806, 7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 7
+  - ID#: 468151435264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.05623226, 8.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 8
+  - ID#: 472446402560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4578678, 9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 9
+  - ID#: 476741369856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3198817, 10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 10
+  - ID#: 481036337152
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3961037, 11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 11
+  - ID#: 485331304448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4392153, 12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 12
+  - ID#: 489626271744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4797462, 13.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 13
+  - ID#: 493921239040
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.2518314, 14.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 14
+  - ID#: 498216206336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3278703, 15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 15
+  - ID#: 502511173632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3989643, 16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 16
+  - ID#: 506806140928
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.01785584, 17.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 17
+  - ID#: 511101108224
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.180647, 18.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 18
+  - ID#: 515396075520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4245647, 19.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 19
+  - ID#: 519691042816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.1059622, 20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 20
+  - ID#: 523986010112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.4669966, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 21
+  - ID#: 528280977408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-24.5, -0.3406798, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -25
+      z: 22
+  - ID#: 532575944704
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-3.5, -0.4073618, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/mithril.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 7
+  - ID#: 536870912000
+    NameComponent:
+      name: ::TileMap
+    TileMapSingleton:
+      tiles:
+        [-18, 24]: 1309965025280
+        [-25, -4]: 416611827712
+        [-10, 18]: 193273528320
+        [23, -7]: 3839700762624
+        [-12, 20]: 154618822656
+        [-6, 11]: 34359738368
+        [1, -6]: 2465311227904
+        [-13, 22]: 107374182400
+        [-5, 24]: 2207613190144
+        [-17, 9]: 1387274436608
+        [5, 12]: 21474836480
+        [-16, 20]: 77309411328
+        [7, -8]: 2911987826688
+        [-22, -17]: 953482739712
+        [-23, 10]: 876173328384
+        [-24, -15]: 584115552256
+        [-2, -2]: 25769803776
+        [-12, -22]: 1730871820288
+        [-18, 10]: 1288490188800
+        [-6, -2]: 2108828942336
+        [-10, 12]: 253403070464
+        [-3, 14]: 30064771072
+        [-25, 10]: 476741369856
+        [-3, 15]: 51539607552
+        [-8, 18]: 197568495616
+        [-17, 20]: 38654705664
+        [24, 23]: 4174708211712
+        [13, 24]: 3139621093376
+        [-22, 21]: 1009317314560
+        [-10, 16]: 227633266688
+        [-12, 14]: 42949672960
+        [20, -24]: 3478923509760
+        [6, 2]: 2838973382656
+        [-16, 21]: 85899345920
+        [16, -9]: 3255585210368
+        [-14, 20]: 120259084288
+        [-18, 7]: 1284195221504
+        [23, 1]: 3874060500992
+        [-4, 21]: 47244640256
+        [-7, 11]: 55834574848
+        [-19, -7]: 1146756268032
+        [-23, -6]: 807453851648
+        [-8, 11]: 60129542144
+        [-3, 22]: 2254857830400
+        [-5, 19]: 128849018880
+        [-25, -19]: 352187318272
+        [-3, -16]: 4458176053248
+        [-11, -22]: 1795296329728
+        [-10, 11]: 64424509440
+        [-17, -21]: 1331439861760
+        [-11, 18]: 184683593728
+        [-6, 3]: 2130303778816
+        [-9, 11]: 68719476736
+        [-20, 3]: 1086626725888
+        [-18, 21]: 73014444032
+        [-6, 4]: 2134598746112
+        [-15, 19]: 81604378624
+        [-7, 24]: 2065879269376
+        [16, -24]: 3225520439296
+        [5, 7]: 292057776128
+        [-12, 15]: 90194313216
+        [-7, 18]: 201863462912
+        [-4, 15]: 1821066133504
+        [19, 4]: 3453153705984
+        [-23, 6]: 858993459200
+        [10, 14]: 4239132721152
+        [5, -6]: 2770253905920
+        [-18, 5]: 1275605286912
+        [-14, 18]: 94489280512
+        [-2, 22]: 2336462209024
+        [-13, 20]: 158913789952
+        [-4, 12]: 2061584302080
+        [-14, 19]: 98784247808
+        [-24, 23]: 738734374912
+        [-25, -2]: 425201762304
+        [-3, 19]: 103079215104
+        [-17, 21]: 1391569403904
+        [-11, 14]: 240518168576
+        [12, 23]: 3113851289600
+        [-15, 21]: 111669149696
+        [-23, 18]: 889058230272
+        [7, -16]: 2886218022912
+        [-7, 14]: 283467841536
+        [3, -1]: 2641404887040
+        [-10, -24]: 1833951035392
+        [-15, 20]: 115964116992
+        [-25, -21]: 343597383680
+        [-5, 21]: 124554051584
+        [-21, 24]: 1052266987520
+        [-5, 20]: 133143986176
+        [-6, 18]: 206158430208
+        [-8, 20]: 137438953472
+        [-10, 5]: 1855425871872
+        [10, 16]: 4307852197888
+        [-22, -23]: 927712935936
+        [-9, 20]: 141733920768
+        [-25, 24]: 536870912000
+        [5, -3]: 287762808832
+        [-18, 2]: 1262720385024
+        [17, 23]: 3358664425472
+        [-10, 20]: 146028888064
+        [-9, 1]: 1902670512128
+        [-24, -4]: 631360192512
+        [-11, 20]: 150323855360
+        [-13, 19]: 163208757248
+        [4, -3]: 2714419331072
+        [12, -25]: 3096671420416
+        [22, 20]: 3740916514816
+        [-5, -1]: 2177548419072
+        [-13, 18]: 167503724544
+        [1, 5]: 2486786064384
+        [-13, 17]: 171798691840
+        [-17, 3]: 1378684502016
+        [-11, 16]: 231928233984
+        [-24, -16]: 579820584960
+        [-13, 16]: 176093659136
+        [-18, -1]: 1249835483136
+        [-24, 21]: 730144440320
+        [23, -3]: 3856880631808
+        [-12, 16]: 180388626432
+        [15, -5]: 3191160700928
+        [-9, 18]: 188978561024
+        [-24, 19]: 721554505728
+        [-6, 17]: 210453397504
+        [-4, 0]: 2241972928512
+        [-8, 14]: 279172874240
+        [24, -24]: 3972844748800
+        [-22, 4]: 983547510784
+        [-6, 16]: 214748364800
+        [13, 11]: 4269197492224
+        [16, 23]: 3281355014144
+        [-7, 12]: 266287972352
+        [0, 3]: 2409476653056
+        [-9, 12]: 257698037760
+        [14, 23]: 3156800962560
+        [-25, 16]: 502511173632
+        [-11, 15]: 236223201280
+        [-19, 21]: 1198295875584
+        [-8, 16]: 219043332096
+        [-24, -1]: 644245094400
+        [-23, -1]: 828928688128
+        [12, 24]: 3118146256896
+        [22, -22]: 3616362463232
+        [-25, 4]: 450971566080
+        [-9, 16]: 223338299392
+        [-3, 23]: 2306397437952
+        [-16, 0]: 1473173782528
+        [-11, 13]: 244813135872
+        [-11, 12]: 249108103168
+        [-15, 3]: 1541893259264
+        [-4, -1]: 2237677961216
+        [-25, 13]: 489626271744
+        [24, -22]: 3981434683392
+        [-8, 12]: 261993005056
+        [8, 5]: 2980707303424
+        [-19, -24]: 1125281431552
+        [-6, 12]: 270582939648
+        [-9, 14]: 274877906944
+        [-5, 12]: 2143188680704
+        [-3, 16]: 1773821493248
+        [10, -24]: 3053721747456
+        [-19, -1]: 1155346202624
+        [5, -5]: 2774548873216
+        [-6, 15]: 296352743424
+        [11, -25]: 3070901616640
+        [-25, -13]: 377957122048
+        [-6, 14]: 300647710720
+        [10, 17]: 4325032067072
+        [0, -1]: 304942678016
+        [-2, 3]: 309237645312
+        [-13, -8]: 1683627180032
+        [-18, 3]: 1267015352320
+        [-25, -25]: 326417514496
+        [-22, 22]: 1013612281856
+        [-25, -24]: 330712481792
+        [-25, -23]: 335007449088
+        [-24, 6]: 674309865472
+        [-23, -2]: 824633720832
+        [-25, -22]: 339302416384
+        [-24, -14]: 588410519552
+        [-25, -20]: 347892350976
+        [-14, 3]: 1610612736000
+        [-18, -23]: 1224065679360
+        [-25, -18]: 356482285568
+        [18, 7]: 3410204033024
+        [-25, -17]: 360777252864
+        [23, 21]: 3951369912320
+        [-25, -16]: 365072220160
+        [15, 24]: 3216930504704
+        [9, -8]: 3023656976384
+        [-25, -15]: 369367187456
+        [-11, 24]: 1825361100800
+        [-25, -14]: 373662154752
+        [-1, 23]: 2370821947392
+        [-5, 2]: 2190433320960
+        [-18, -3]: 1241245548544
+        [-21, 22]: 1043677052928
+        [-3, 18]: 1627792605184
+        [-24, 11]: 695784701952
+        [-25, -12]: 382252089344
+        [-25, -11]: 386547056640
+        [-5, 22]: 2199023255552
+        [-17, 23]: 1400159338496
+        [-11, -9]: 1799591297024
+        [-25, -10]: 390842023936
+        [-25, -9]: 395136991232
+        [-23, -24]: 751619276800
+        [-25, -8]: 399431958528
+        [18, -22]: 3380139261952
+        [-25, -7]: 403726925824
+        [-19, 3]: 1163936137216
+        [15, 22]: 3208340570112
+        [-25, -6]: 408021893120
+        [-25, -5]: 412316860416
+        [-25, -3]: 420906795008
+        [-15, 4]: 1546188226560
+        [-25, -1]: 429496729600
+        [-25, 0]: 433791696896
+        [-25, 1]: 438086664192
+        [2, 15]: 2589865279488
+        [-25, 2]: 442381631488
+        [-25, 3]: 446676598784
+        [-11, 4]: 1808181231616
+        [-1, -24]: 2353642078208
+        [-25, 5]: 455266533376
+        [-25, 6]: 459561500672
+        [-25, 7]: 463856467968
+        [-25, 8]: 468151435264
+        [-23, 24]: 914828034048
+        [-25, 9]: 472446402560
+        [2, 23]: 2598455214080
+        [-23, 5]: 854698491904
+        [14, 14]: 4221952851968
+        [-25, 11]: 481036337152
+        [13, 14]: 4187593113600
+        [-19, -6]: 1151051235328
+        [-9, 24]: 1932735283200
+        [-25, 12]: 485331304448
+        [-25, 14]: 493921239040
+        [-14, -22]: 1576252997632
+        [-25, 15]: 498216206336
+        [-12, 6]: 1760936591360
+        [-25, 17]: 506806140928
+        [-17, -24]: 1318554959872
+        [7, -13]: 2899102924800
+        [-25, 18]: 511101108224
+        [3, 24]: 2671469658112
+        [-25, 19]: 515396075520
+        [7, -15]: 2890512990208
+        [-9, 0]: 1898375544832
+        [-14, -13]: 1584842932224
+        [-25, 20]: 519691042816
+        [-25, 21]: 523986010112
+        [-8, 22]: 1988569858048
+        [14, 17]: 4303557230592
+        [-25, 22]: 528280977408
+        [-19, 23]: 1206885810176
+        [-12, 4]: 1752346656768
+        [-25, 23]: 532575944704
+        [-23, -20]: 768799145984
+        [-24, -25]: 541165879296
+        [-24, -24]: 545460846592
+        [-18, 6]: 1279900254208
+        [-20, -25]: 1056561954816
+        [-24, -23]: 549755813888
+        [21, -21]: 3521873182720
+        [-20, -7]: 1073741824000
+        [-24, -22]: 554050781184
+        [-24, -21]: 558345748480
+        [-24, -20]: 562640715776
+        [-24, -19]: 566935683072
+        [-18, 4]: 1271310319616
+        [-24, -18]: 571230650368
+        [-19, 5]: 1172526071808
+        [-8, 0]: 1967095021568
+        [-9, -25]: 1872605741056
+        [24, -10]: 4032974290944
+        [-24, -17]: 575525617664
+        [24, -6]: 4050154160128
+        [-24, -13]: 592705486848
+        [-7, -2]: 2022929596416
+        [-24, -12]: 597000454144
+        [-20, 24]: 1116691496960
+        [-24, -11]: 601295421440
+        [19, -9]: 3444563771392
+        [-12, -21]: 1735166787584
+        [-24, -10]: 605590388736
+        [24, -2]: 4067334029312
+        [-8, 24]: 1997159792640
+        [-12, -24]: 1722281885696
+        [-24, -9]: 609885356032
+        [1, -1]: 2469606195200
+        [-3, -15]: 4449586118656
+        [-24, -8]: 614180323328
+        [-9, 2]: 1906965479424
+        [-12, -14]: 1739461754880
+        [-24, -7]: 618475290624
+        [12, 10]: 4385161609216
+        [-24, -6]: 622770257920
+        [-24, -5]: 627065225216
+        [-24, -3]: 635655159808
+        [-6, -1]: 2113123909632
+        [-9, 6]: 1915555414016
+        [-12, -13]: 1743756722176
+        [9, -24]: 3010772074496
+        [-24, -2]: 639950127104
+        [-24, 0]: 648540061696
+        [-11, -23]: 1791001362432
+        [-24, 1]: 652835028992
+        [13, 10]: 4273492459520
+        [-15, -22]: 1511828488192
+        [-6, 0]: 2117418876928
+        [-24, 2]: 657129996288
+        [-4, 16]: 1864015806464
+        [11, 11]: 4346506903552
+        [-24, 3]: 661424963584
+        [-24, 4]: 665719930880
+        [-20, 9]: 1090921693184
+        [-24, 5]: 670014898176
+        [-16, -6]: 1447403978752
+        [-24, 7]: 678604832768
+        [-24, 8]: 682899800064
+        [-24, 9]: 687194767360
+        [-21, 23]: 1047972020224
+        [24, 3]: 4088808865792
+        [-24, 10]: 691489734656
+        [-24, 12]: 700079669248
+        [-2, 24]: 2345052143616
+        [-24, 13]: 704374636544
+        [-16, -23]: 1417339207680
+        [-24, 16]: 708669603840
+        [-24, 17]: 712964571136
+        [-13, -14]: 1666447310848
+        [-24, 18]: 717259538432
+        [23, -14]: 3809635991552
+        [-24, 20]: 725849473024
+        [24, 15]: 4140348473344
+        [-24, 22]: 734439407616
+        [15, -4]: 3195455668224
+        [-20, 21]: 1103806595072
+        [-24, 24]: 743029342208
+        [7, -22]: 2881923055616
+        [-23, -25]: 747324309504
+        [-22, 20]: 1005022347264
+        [-9, -23]: 1881195675648
+        [-23, -23]: 755914244096
+        [-23, -22]: 760209211392
+        [-11, -25]: 1782411427840
+        [-7, -1]: 2027224563712
+        [-23, -21]: 764504178688
+        [-12, 5]: 1756641624064
+        [-23, -19]: 773094113280
+        [-23, -18]: 777389080576
+        [-23, -17]: 781684047872
+        [3, 23]: 2667174690816
+        [-23, -16]: 785979015168
+        [-23, -15]: 790273982464
+        [-13, -22]: 1649267441664
+        [-17, 24]: 1404454305792
+        [-8, 3]: 1979979923456
+        [-23, -14]: 794568949760
+        [-7, -25]: 2001454759936
+        [-13, -24]: 1640677507072
+        [-23, -13]: 798863917056
+        [-19, -21]: 1138166333440
+        [-23, -12]: 803158884352
+        [-9, -1]: 1894080577536
+        [-23, -5]: 811748818944
+        [-17, -6]: 1340029796352
+        [22, -21]: 3620657430528
+        [-23, -4]: 816043786240
+        [-9, 22]: 1924145348608
+        [-23, -3]: 820338753536
+        [-15, 24]: 1559073128448
+        [-3, 17]: 1709396983808
+        [-23, 0]: 833223655424
+        [0, -25]: 2379411881984
+        [19, 5]: 3457448673280
+        [-19, 2]: 1159641169920
+        [6, 6]: 2856153251840
+        [-23, 1]: 837518622720
+        [24, 14]: 4136053506048
+        [14, 12]: 4282082394112
+        [-22, -25]: 919123001344
+        [-23, 2]: 841813590016
+        [-23, 3]: 846108557312
+        [24, 12]: 4127463571456
+        [16, 6]: 3277060046848
+        [-23, 4]: 850403524608
+        [16, 3]: 3264175144960
+        [-23, 7]: 863288426496
+        [16, 2]: 3259880177664
+        [-7, 4]: 2048699400192
+        [21, -20]: 3526168150016
+        [16, 15]: 4286377361408
+        [-23, 8]: 867583393792
+        [-23, 9]: 871878361088
+        [-3, -3]: 2293512536064
+        [24, 6]: 4101693767680
+        [-23, 11]: 880468295680
+        [-23, 17]: 884763262976
+        [-14, 5]: 1619202670592
+        [1, 13]: 2508260900864
+        [-23, 19]: 893353197568
+        [14, 22]: 3152505995264
+        [-23, 20]: 897648164864
+        [-7, 0]: 2031519531008
+        [-22, -18]: 949187772416
+        [-23, 21]: 901943132160
+        [-7, 2]: 2040109465600
+        [6, 23]: 2860448219136
+        [-23, 22]: 906238099456
+        [-16, -5]: 1451698946048
+        [-23, 23]: 910533066752
+        [-22, -24]: 923417968640
+        [-22, -22]: 932007903232
+        [-22, -21]: 936302870528
+        [-16, 24]: 1494648619008
+        [-22, -20]: 940597837824
+        [-22, -19]: 944892805120
+        [-22, -16]: 957777707008
+        [-22, -2]: 962072674304
+        [7, -24]: 2873333121024
+        [18, 24]: 3423088934912
+        [-20, 23]: 1112396529664
+        [-22, -1]: 966367641600
+        [-22, 0]: 970662608896
+        [18, -25]: 3367254360064
+        [-20, -24]: 1060856922112
+        [-22, 1]: 974957576192
+        [-5, -25]: 2151778615296
+        [23, 22]: 3955664879616
+        [-22, 3]: 979252543488
+        [-9, 5]: 1911260446720
+        [-14, -12]: 1589137899520
+        [-22, 5]: 987842478080
+        [12, 13]: 4183298146304
+        [0, 23]: 2435246456832
+        [-22, 6]: 992137445376
+        [-15, -21]: 1516123455488
+        [-14, 2]: 1606317768704
+        [-1, 24]: 2375116914688
+        [-22, 8]: 996432412672
+        [-22, 9]: 1000727379968
+        [-22, 23]: 1017907249152
+        [-9, -24]: 1876900708352
+        [-15, -5]: 1533303324672
+        [-18, -2]: 1245540515840
+        [-22, 24]: 1022202216448
+        [-5, -21]: 2168958484480
+        [5, -25]: 2748779069440
+        [-21, -25]: 1026497183744
+        [-17, -1]: 1361504632832
+        [-21, -24]: 1030792151040
+        [-21, -23]: 1035087118336
+        [-5, -2]: 2173253451776
+        [16, -12]: 3242700308480
+        [-21, -22]: 1039382085632
+        [1, 4]: 2482491097088
+        [-20, -23]: 1065151889408
+        [-20, -22]: 1069446856704
+        [9, -23]: 3015067041792
+        [-20, -6]: 1078036791296
+        [-20, -5]: 1082331758592
+        [7, -25]: 2869038153728
+        [-20, 10]: 1095216660480
+        [-19, -8]: 1142461300736
+        [-20, 11]: 1099511627776
+        [-20, 22]: 1108101562368
+        [-14, -10]: 1597727834112
+        [-19, -25]: 1120986464256
+        [-19, -23]: 1129576398848
+        [-6, 2]: 2126008811520
+        [-19, -22]: 1133871366144
+        [-19, 4]: 1168231104512
+        [-19, 6]: 1176821039104
+        [-4, -21]: 2229088026624
+        [10, 10]: 4342211936256
+        [-19, 7]: 1181116006400
+        [24, -16]: 4007204487168
+        [-19, 8]: 1185410973696
+        [-19, 9]: 1189705940992
+        [-16, 22]: 1486058684416
+        [-19, 13]: 1194000908288
+        [-13, 24]: 1713691951104
+        [-19, 22]: 1202590842880
+        [-19, 24]: 1211180777472
+        [-18, -25]: 1215475744768
+        [-18, -24]: 1219770712064
+        [7, -14]: 2894807957504
+        [-18, -22]: 1228360646656
+        [-18, -21]: 1232655613952
+        [-18, -4]: 1236950581248
+        [-4, 22]: 2203318222848
+        [-18, 0]: 1254130450432
+        [-5, 3]: 2194728288256
+        [-18, 1]: 1258425417728
+        [-18, 11]: 1292785156096
+        [-18, 15]: 1297080123392
+        [-18, 22]: 1301375090688
+        [13, 17]: 4294967296000
+        [-18, 23]: 1305670057984
+        [23, 17]: 3934190043136
+        [-17, -25]: 1314259992576
+        [-17, -23]: 1322849927168
+        [-16, -8]: 1438814044160
+        [24, 24]: 4179003179008
+        [-17, -22]: 1327144894464
+        [19, 23]: 3466038607872
+        [-17, -7]: 1335734829056
+        [-17, -5]: 1344324763648
+        [24, -3]: 4063039062016
+        [-17, -4]: 1348619730944
+        [-17, -3]: 1352914698240
+        [-17, -2]: 1357209665536
+        [-8, 1]: 1971389988864
+        [-17, 0]: 1365799600128
+        [-17, 1]: 1370094567424
+        [24, 0]: 4075923963904
+        [4, -2]: 2718714298368
+        [10, 23]: 3062311682048
+        [-17, 2]: 1374389534720
+        [-17, 4]: 1382979469312
+        [-2, -6]: 2332167241728
+        [-13, -12]: 1675037245440
+        [24, 17]: 4148938407936
+        [-17, 22]: 1395864371200
+        [4, -9]: 2688649527296
+        [-16, -25]: 1408749273088
+        [24, 8]: 4110283702272
+        [-16, -24]: 1413044240384
+        [2, 3]: 2559800508416
+        [-10, -25]: 1829656068096
+        [-16, -22]: 1421634174976
+        [-16, -21]: 1425929142272
+        [17, -11]: 3328599654400
+        [-13, -11]: 1679332212736
+        [24, 16]: 4144643440640
+        [-16, -16]: 1430224109568
+        [-4, -24]: 2216203124736
+        [-16, -9]: 1434519076864
+        [15, -6]: 3186865733632
+        [21, -22]: 3517578215424
+        [17, -25]: 3289944948736
+        [-16, -7]: 1443109011456
+        [-4, -15]: 4453881085952
+        [-16, -4]: 1455993913344
+        [-8, -21]: 1954210119680
+        [23, -6]: 3843995729920
+        [-16, -3]: 1460288880640
+        [-16, -2]: 1464583847936
+        [-16, -1]: 1468878815232
+        [-7, 22]: 2057289334784
+        [-16, 4]: 1477468749824
+        [-16, 5]: 1481763717120
+        [-16, 23]: 1490353651712
+        [22, -17]: 3637837299712
+        [-15, -25]: 1498943586304
+        [1, -24]: 2448131358720
+        [14, -25]: 3143916060672
+        [-13, 4]: 1696512081920
+        [-15, -24]: 1503238553600
+        [18, 6]: 3405909065728
+        [-14, 4]: 1614907703296
+        [-15, -23]: 1507533520896
+        [8, -22]: 2959232466944
+        [3, -4]: 2628519985152
+        [-15, -18]: 1520418422784
+        [-14, 6]: 1623497637888
+        [-15, -17]: 1524713390080
+        [-4, 14]: 1928440315904
+        [-15, -6]: 1529008357376
+        [-10, 24]: 1868310773760
+        [-15, -4]: 1537598291968
+        [-15, 22]: 1550483193856
+        [-8, -1]: 1962800054272
+        [-15, 23]: 1554778161152
+        [-7, -22]: 2014339661824
+        [-14, -25]: 1563368095744
+        [-14, -24]: 1567663063040
+        [13, 12]: 4196183048192
+        [-8, -23]: 1945620185088
+        [-2, -22]: 2327872274432
+        [22, -16]: 3642132267008
+        [-14, -23]: 1571958030336
+        [-14, -21]: 1580547964928
+        [22, -4]: 3667902070784
+        [-14, -11]: 1593432866816
+        [-14, -9]: 1602022801408
+        [-5, 1]: 2186138353664
+        [23, -10]: 3826815860736
+        [22, 17]: 3728031612928
+        [-14, 24]: 1632087572480
+        [-13, -25]: 1636382539776
+        [23, 0]: 3869765533696
+        [-7, 5]: 2052994367488
+        [-9, -22]: 1885490642944
+        [-4, -23]: 2220498092032
+        [-13, -23]: 1644972474368
+        [-13, -21]: 1653562408960
+        [-13, -16]: 1657857376256
+        [22, -2]: 3676492005376
+        [24, 21]: 4166118277120
+        [-8, -22]: 1949915152384
+        [-1, -22]: 2362232012800
+        [24, 20]: 4161823309824
+        [-13, -15]: 1662152343552
+        [-13, -13]: 1670742278144
+        [24, 10]: 4118873636864
+        [-13, 2]: 1687922147328
+        [-13, 3]: 1692217114624
+        [-13, 5]: 1700807049216
+        [23, -24]: 3766686318592
+        [-13, 6]: 1705102016512
+        [-12, -25]: 1717986918400
+        [15, 4]: 3204045602816
+        [-12, -23]: 1726576852992
+        [5, -4]: 2778843840512
+        [-12, -12]: 1748051689472
+        [-8, -25]: 1937030250496
+        [19, 22]: 3461743640576
+        [-12, 7]: 1765231558656
+        [-12, 22]: 1769526525952
+        [-10, -3]: 1846835937280
+        [21, -1]: 3547642986496
+        [-12, 24]: 1778116460544
+        [-11, -24]: 1786706395136
+        [-11, -8]: 1803886264320
+        [-11, 5]: 1812476198912
+        [-8, 2]: 1975684956160
+        [-11, 22]: 1816771166208
+        [-10, -23]: 1838246002688
+        [-2, -25]: 2314987372544
+        [-10, -22]: 1842540969984
+        [-4, 13]: 1992864825344
+        [4, 22]: 2735894167552
+        [-10, 1]: 1851130904576
+        [12, 12]: 4264902524928
+        [15, 16]: 4299262263296
+        [-10, 22]: 1859720839168
+        [-9, -7]: 1889785610240
+        [-5, 18]: 1919850381312
+        [-8, -24]: 1941325217792
+        [4, -24]: 2680059592704
+        [22, 2]: 3693671874560
+        [-8, -4]: 1958505086976
+        [-7, 20]: 1984274890752
+        [0, 11]: 2422361554944
+        [-7, -24]: 2005749727232
+        [-7, -23]: 2010044694528
+        [22, -14]: 3650722201600
+        [-7, -21]: 2018634629120
+        [2, 7]: 2576980377600
+        [-7, 1]: 2035814498304
+        [-7, 3]: 2044404432896
+        [24, -5]: 4054449127424
+        [-6, -25]: 2070174236672
+        [-3, -25]: 2263447764992
+        [-6, -24]: 2074469203968
+        [-6, -23]: 2078764171264
+        [-6, -22]: 2083059138560
+        [23, -4]: 3852585664512
+        [-6, -21]: 2087354105856
+        [-6, -6]: 2091649073152
+        [-6, -5]: 2095944040448
+        [-6, -4]: 2100239007744
+        [16, -11]: 3246995275776
+        [-6, -3]: 2104533975040
+        [22, 21]: 3745211482112
+        [-6, 1]: 2121713844224
+        [-6, 22]: 2138893713408
+        [-6, 24]: 2147483648000
+        [-3, -24]: 2267742732288
+        [-5, -24]: 2156073582592
+        [-5, -23]: 2160368549888
+        [22, 6]: 3710851743744
+        [2, -3]: 2542620639232
+        [-5, -22]: 2164663517184
+        [-1, -23]: 2357937045504
+        [16, -23]: 3229815406592
+        [-5, 0]: 2181843386368
+        [8, -25]: 2946347565056
+        [-4, -25]: 2211908157440
+        [-4, -22]: 2224793059328
+        [-4, -4]: 2233382993920
+        [-4, 1]: 2246267895808
+        [-4, 2]: 2250562863104
+        [-4, 24]: 2259152797696
+        [23, 20]: 3947074945024
+        [8, 6]: 2985002270720
+        [23, -25]: 3762391351296
+        [-3, -23]: 2272037699584
+        [-3, -22]: 2276332666880
+        [-3, -21]: 2280627634176
+        [-3, -5]: 2284922601472
+        [-3, -4]: 2289217568768
+        [22, 16]: 3723736645632
+        [-3, -1]: 2297807503360
+        [-3, 1]: 2302102470656
+        [5, -24]: 2753074036736
+        [2, -2]: 2546915606528
+        [24, 4]: 4093103833088
+        [-3, 24]: 2310692405248
+        [-2, -24]: 2319282339840
+        [-2, -23]: 2323577307136
+        [-2, 23]: 2340757176320
+        [-1, -25]: 2349347110912
+        [17, -23]: 3298534883328
+        [22, 23]: 3753801416704
+        [6, 3]: 2843268349952
+        [-1, 22]: 2366526980096
+        [0, -24]: 2383706849280
+        [8, -14]: 2963527434240
+        [7, -23]: 2877628088320
+        [22, 4]: 3702261809152
+        [0, -23]: 2388001816576
+        [21, 4]: 3569117822976
+        [9, -9]: 3019362009088
+        [0, -22]: 2392296783872
+        [0, -7]: 2396591751168
+        [0, -6]: 2400886718464
+        [16, -10]: 3251290243072
+        [22, -20]: 3624952397824
+        [0, -5]: 2405181685760
+        [17, -24]: 3294239916032
+        [0, 9]: 2413771620352
+        [0, 10]: 2418066587648
+        [0, 21]: 2426656522240
+        [0, 22]: 2430951489536
+        [0, 24]: 2439541424128
+        [14, 24]: 3161095929856
+        [2, -4]: 2538325671936
+        [4, -4]: 2710124363776
+        [1, -25]: 2443836391424
+        [17, -13]: 3320009719808
+        [1, -23]: 2452426326016
+        [1, -8]: 2456721293312
+        [1, -7]: 2461016260608
+        [1, 2]: 2473901162496
+        [1, 3]: 2478196129792
+        [21, -23]: 3513283248128
+        [13, -25]: 3122441224192
+        [1, 6]: 2491081031680
+        [21, -19]: 3530463117312
+        [1, 7]: 2495375998976
+        [1, 8]: 2499670966272
+        [22, 24]: 3758096384000
+        [1, 9]: 2503965933568
+        [1, 21]: 2512555868160
+        [1, 22]: 2516850835456
+        [8, 7]: 2989297238016
+        [1, 23]: 2521145802752
+        [1, 24]: 2525440770048
+        [2, -25]: 2529735737344
+        [2, -24]: 2534030704640
+        [16, 24]: 3285649981440
+        [24, -19]: 3994319585280
+        [2, -1]: 2551210573824
+        [2, 2]: 2555505541120
+        [2, 4]: 2564095475712
+        [2, 5]: 2568390443008
+        [2, 6]: 2572685410304
+        [2, 10]: 2581275344896
+        [24, 22]: 4170413244416
+        [2, 11]: 2585570312192
+        [2, 22]: 2594160246784
+        [23, -18]: 3792456122368
+        [21, -18]: 3534758084608
+        [2, 24]: 2602750181376
+        [3, -25]: 2607045148672
+        [3, -24]: 2611340115968
+        [9, 15]: 4312147165184
+        [17, 5]: 3350074490880
+        [3, -7]: 2615635083264
+        [3, -6]: 2619930050560
+        [3, -5]: 2624225017856
+        [10, 22]: 3058016714752
+        [3, -3]: 2632814952448
+        [3, -2]: 2637109919744
+        [3, 3]: 2645699854336
+        [7, 6]: 2933462663168
+        [22, -5]: 3663607103488
+        [3, 4]: 2649994821632
+        [3, 9]: 2654289788928
+        [3, 21]: 2658584756224
+        [3, 22]: 2662879723520
+        [4, -25]: 2675764625408
+        [19, 24]: 3470333575168
+        [4, -16]: 2684354560000
+        [4, -8]: 2692944494592
+        [22, 18]: 3732326580224
+        [4, -7]: 2697239461888
+        [4, -6]: 2701534429184
+        [4, -5]: 2705829396480
+        [4, -1]: 2723009265664
+        [4, 4]: 2727304232960
+        [4, 5]: 2731599200256
+        [22, -3]: 3672197038080
+        [4, 23]: 2740189134848
+        [21, 21]: 3586297692160
+        [4, 24]: 2744484102144
+        [5, -23]: 2757369004032
+        [5, -18]: 2761663971328
+        [5, -17]: 2765958938624
+        [20, -23]: 3483218477056
+        [5, 3]: 2783138807808
+        [5, 4]: 2787433775104
+        [5, 22]: 2791728742400
+        [5, 23]: 2796023709696
+        [5, 24]: 2800318676992
+        [6, 24]: 2864743186432
+        [6, -25]: 2804613644288
+        [6, -24]: 2808908611584
+        [8, -12]: 2972117368832
+        [6, -23]: 2813203578880
+        [12, 21]: 3105261355008
+        [6, -13]: 2817498546176
+        [6, -12]: 2821793513472
+        [6, -11]: 2826088480768
+        [15, -23]: 3173980831744
+        [6, -10]: 2830383448064
+        [6, -9]: 2834678415360
+        [6, 4]: 2847563317248
+        [6, 5]: 2851858284544
+        [23, -2]: 3861175599104
+        [11, 24]: 3092376453120
+        [7, -12]: 2903397892096
+        [7, -11]: 2907692859392
+        [7, 2]: 2916282793984
+        [7, 3]: 2920577761280
+        [15, 9]: 4398046511104
+        [23, 23]: 3959959846912
+        [7, 4]: 2924872728576
+        [7, 5]: 2929167695872
+        [24, 5]: 4097398800384
+        [7, 23]: 2937757630464
+        [7, 24]: 2942052597760
+        [8, -24]: 2950642532352
+        [11, 15]: 4204772982784
+        [8, -23]: 2954937499648
+        [8, -13]: 2967822401536
+        [8, 4]: 2976412336128
+        [8, 22]: 2993592205312
+        [23, -9]: 3831110828032
+        [22, 22]: 3749506449408
+        [-6, -13]: 4440996184064
+        [8, 23]: 2997887172608
+        [8, 24]: 3002182139904
+        [9, -25]: 3006477107200
+        [24, -8]: 4041564225536
+        [9, 4]: 3027951943680
+        [9, 5]: 3032246910976
+        [9, 22]: 3036541878272
+        [9, 23]: 3040836845568
+        [9, 24]: 3045131812864
+        [23, 3]: 3882650435584
+        [10, -25]: 3049426780160
+        [10, 24]: 3066606649344
+        [11, -24]: 3075196583936
+        [11, 21]: 3079491551232
+        [11, 22]: 3083786518528
+        [11, 23]: 3088081485824
+        [12, -24]: 3100966387712
+        [12, 22]: 3109556322304
+        [15, -18]: 3178275799040
+        [13, -24]: 3126736191488
+        [13, 22]: 3131031158784
+        [13, 23]: 3135326126080
+        [14, -24]: 3148211027968
+        [15, -25]: 3165390897152
+        [21, 0]: 3551937953792
+        [10, 15]: 4209067950080
+        [15, -24]: 3169685864448
+        [15, -17]: 3182570766336
+        [24, -18]: 3998614552576
+        [15, 3]: 3199750635520
+        [15, 23]: 3212635537408
+        [16, -25]: 3221225472000
+        [16, -22]: 3234110373888
+        [16, -13]: 3238405341184
+        [23, -5]: 3848290697216
+        [16, 4]: 3268470112256
+        [17, 3]: 3341484556288
+        [16, 5]: 3272765079552
+        [17, 2]: 3337189588992
+        [17, -22]: 3302829850624
+        [17, -16]: 3307124817920
+        [24, -15]: 4011499454464
+        [17, -15]: 3311419785216
+        [17, -14]: 3315714752512
+        [19, -8]: 3448858738688
+        [17, -12]: 3324304687104
+        [17, -8]: 3332894621696
+        [17, 4]: 3345779523584
+        [13, 13]: 4226247819264
+        [19, -25]: 3427383902208
+        [17, 6]: 3354369458176
+        [17, 24]: 3362959392768
+        [18, -24]: 3371549327360
+        [18, -23]: 3375844294656
+        [18, -14]: 3384434229248
+        [23, -20]: 3783866187776
+        [18, -13]: 3388729196544
+        [18, -12]: 3393024163840
+        [18, 4]: 3397319131136
+        [18, 5]: 3401614098432
+        [18, 22]: 3414499000320
+        [18, 23]: 3418793967616
+        [19, -24]: 3431678869504
+        [24, -25]: 3968549781504
+        [19, -23]: 3435973836800
+        [19, -22]: 3440268804096
+        [20, -25]: 3474628542464
+        [20, -22]: 3487513444352
+        [20, 22]: 3491808411648
+        [12, 8]: 4393751543808
+        [20, 23]: 3496103378944
+        [20, 24]: 3500398346240
+        [21, -25]: 3504693313536
+        [23, -19]: 3788161155072
+        [21, -24]: 3508988280832
+        [21, -17]: 3539053051904
+        [23, 19]: 3942779977728
+        [21, -2]: 3543348019200
+        [21, 1]: 3556232921088
+        [21, 2]: 3560527888384
+        [21, 3]: 3564822855680
+        [21, 5]: 3573412790272
+        [21, 6]: 3577707757568
+        [21, 20]: 3582002724864
+        [21, 22]: 3590592659456
+        [22, -19]: 3629247365120
+        [21, 23]: 3594887626752
+        [21, 24]: 3599182594048
+        [22, -25]: 3603477561344
+        [22, -24]: 3607772528640
+        [22, -23]: 3612067495936
+        [22, -18]: 3633542332416
+        [22, -15]: 3646427234304
+        [22, -13]: 3655017168896
+        [22, -6]: 3659312136192
+        [22, -1]: 3680786972672
+        [22, 0]: 3685081939968
+        [22, 1]: 3689376907264
+        [22, 3]: 3697966841856
+        [22, 5]: 3706556776448
+        [22, 7]: 3715146711040
+        [22, 8]: 3719441678336
+        [-4, 23]: 4410931412992
+        [22, 19]: 3736621547520
+        [23, -23]: 3770981285888
+        [23, -22]: 3775276253184
+        [12, 9]: 4389456576512
+        [23, -21]: 3779571220480
+        [23, -17]: 3796751089664
+        [23, -16]: 3801046056960
+        [23, -15]: 3805341024256
+        [23, -13]: 3813930958848
+        [23, -12]: 3818225926144
+        [23, -11]: 3822520893440
+        [23, -8]: 3835405795328
+        [23, -1]: 3865470566400
+        [23, 2]: 3878355468288
+        [24, -13]: 4020089389056
+        [23, 4]: 3886945402880
+        [23, 5]: 3891240370176
+        [23, 6]: 3895535337472
+        [23, 7]: 3899830304768
+        [23, 8]: 3904125272064
+        [23, 9]: 3908420239360
+        [23, 10]: 3912715206656
+        [23, 11]: 3917010173952
+        [9, 16]: 4329327034368
+        [23, 14]: 3921305141248
+        [23, 15]: 3925600108544
+        [23, 16]: 3929895075840
+        [23, 18]: 3938485010432
+        [23, 24]: 3964254814208
+        [24, -23]: 3977139716096
+        [24, -21]: 3985729650688
+        [24, -20]: 3990024617984
+        [24, -17]: 4002909519872
+        [24, -14]: 4015794421760
+        [24, -12]: 4024384356352
+        [24, -11]: 4028679323648
+        [24, -9]: 4037269258240
+        [24, -7]: 4045859192832
+        [24, -4]: 4058744094720
+        [24, -1]: 4071628996608
+        [24, 1]: 4080218931200
+        [24, 2]: 4084513898496
+        [24, 7]: 4105988734976
+        [24, 9]: 4114578669568
+        [24, 11]: 4123168604160
+        [24, 13]: 4131758538752
+        [24, 18]: 4153233375232
+        [24, 19]: 4157528342528
+        [12, 14]: 4191888080896
+        [14, 15]: 4200478015488
+        [12, 15]: 4213362917376
+        [13, 15]: 4217657884672
+        [11, 13]: 4230542786560
+        [11, 14]: 4234837753856
+        [15, 15]: 4243427688448
+        [15, 14]: 4247722655744
+        [14, 16]: 4252017623040
+        [13, 16]: 4256312590336
+        [12, 16]: 4260607557632
+        [14, 13]: 4277787426816
+        [11, 16]: 4290672328704
+        [12, 17]: 4316442132480
+        [11, 17]: 4320737099776
+        [10, 11]: 4333622001664
+        [9, 11]: 4337916968960
+        [9, 12]: 4350801870848
+        [9, 10]: 4367981740032
+        [11, 12]: 4355096838144
+        [10, 12]: 4359391805440
+        [12, 11]: 4363686772736
+        [8, 11]: 4372276707328
+        [11, 10]: 4376571674624
+        [7, 11]: 4380866641920
+        [18, 12]: 4402341478400
+        [17, 19]: 4406636445696
+        [9, -4]: 4415226380288
+        [-4, -13]: 4419521347584
+        [-5, -12]: 4423816314880
+        [-5, -13]: 4428111282176
+        [-4, -14]: 4432406249472
+        [-5, -14]: 4436701216768
+        [-4, -12]: 4445291151360
+        [-5, -11]: 4462471020544
+        [-4, 7]: 4466765987840
+  - ID#: 541165879296
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3788701, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -25
+  - ID#: 545460846592
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3703236, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -24
+  - ID#: 549755813888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3715662, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -23
+  - ID#: 554050781184
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2373793, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -22
+  - ID#: 558345748480
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1961135, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -21
+  - ID#: 562640715776
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2110438, -19.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -20
+  - ID#: 566935683072
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3277389, -18.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -19
+  - ID#: 571230650368
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.08693258, -17.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -18
+  - ID#: 575525617664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.08559334, -16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -17
+  - ID#: 579820584960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1509566, -15.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -16
+  - ID#: 584115552256
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3530231, -14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -15
+  - ID#: 588410519552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3986399, -13.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -14
+  - ID#: 592705486848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.01591642, -12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -13
+  - ID#: 597000454144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1582752, -11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -12
+  - ID#: 601295421440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1384615, -10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -11
+  - ID#: 605590388736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.4362144, -9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -10
+  - ID#: 609885356032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.02308569, -8.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -9
+  - ID#: 614180323328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.07455699, -7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -8
+  - ID#: 618475290624
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.04856589, -6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -7
+  - ID#: 622770257920
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.4970343, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -6
+  - ID#: 627065225216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.4117289, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -5
+  - ID#: 631360192512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.4109516, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -4
+  - ID#: 635655159808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3474143, -2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -3
+  - ID#: 639950127104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.06259138, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -2
+  - ID#: 644245094400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1585497, -0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: -1
+  - ID#: 648540061696
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.381875, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 0
+  - ID#: 652835028992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.475111, 1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 1
+  - ID#: 657129996288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2452945, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 2
+  - ID#: 661424963584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.01722304, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 3
+  - ID#: 665719930880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3318028, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 4
+  - ID#: 670014898176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2193722, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 5
+  - ID#: 674309865472
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.06294832, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 6
+  - ID#: 678604832768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1907792, 7.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 7
+  - ID#: 682899800064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.1051045, 8.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 8
+  - ID#: 687194767360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3827584, 9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 9
+  - ID#: 691489734656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.02560821, 10.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 10
+  - ID#: 695784701952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3976, 11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 11
+  - ID#: 700079669248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.01822063, 12.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 12
+  - ID#: 704374636544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.0934363, 13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 13
+  - ID#: 708669603840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2043656, 16.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 16
+  - ID#: 712964571136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2448822, 17.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 17
+  - ID#: 717259538432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2289946, 18.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 18
+  - ID#: 721554505728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2227931, 19.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 19
+  - ID#: 725849473024
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.2437845, 20.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 20
+  - ID#: 730144440320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3231565, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 21
+  - ID#: 734439407616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3969875, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 22
+  - ID#: 738734374912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.3546824, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 23
+  - ID#: 743029342208
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-23.5, -0.4604374, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -24
+      z: 24
+  - ID#: 747324309504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3773433, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -25
+  - ID#: 751619276800
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4037655, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -24
+  - ID#: 755914244096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.1380125, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -23
+  - ID#: 760209211392
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3528871, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -22
+  - ID#: 764504178688
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3398513, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -21
+  - ID#: 768799145984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.001409216, -19.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -20
+  - ID#: 773094113280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.327549, -18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -19
+  - ID#: 777389080576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3553519, -17.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -18
+  - ID#: 781684047872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.08130587, -16.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -17
+  - ID#: 785979015168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3219805, -15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -16
+  - ID#: 790273982464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.05949884, -14.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -15
+  - ID#: 794568949760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2280164, -13.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -14
+  - ID#: 798863917056
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.249182, -12.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -13
+  - ID#: 803158884352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3869586, -11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -12
+  - ID#: 807453851648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.479872, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -6
+  - ID#: 811748818944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2868773, -4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -5
+  - ID#: 816043786240
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.1701929, -3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -4
+  - ID#: 820338753536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4383787, -2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -3
+  - ID#: 824633720832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2926339, -1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -2
+  - ID#: 828928688128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4040878, -0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: -1
+  - ID#: 833223655424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.111906, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 0
+  - ID#: 837518622720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.008886948, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 1
+  - ID#: 841813590016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3756335, 2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 2
+  - ID#: 846108557312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.410623, 3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 3
+  - ID#: 850403524608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.1275476, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 4
+  - ID#: 854698491904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4104204, 5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 5
+  - ID#: 858993459200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2529785, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 6
+  - ID#: 863288426496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.470037, 7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 7
+  - ID#: 867583393792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3495384, 8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 8
+  - ID#: 871878361088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2063333, 9.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 9
+  - ID#: 876173328384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4454516, 10.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 10
+  - ID#: 880468295680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2115826, 11.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 11
+  - ID#: 884763262976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.4796457, 17.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 17
+  - ID#: 889058230272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2904783, 18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 18
+  - ID#: 893353197568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.2736078, 19.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 19
+  - ID#: 897648164864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.07902879, 20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 20
+  - ID#: 901943132160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.06931222, 21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 21
+  - ID#: 906238099456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.3808656, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 22
+  - ID#: 910533066752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.074647, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 23
+  - ID#: 914828034048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-22.5, -0.115078, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -23
+      z: 24
+  - ID#: 919123001344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1287541, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -25
+  - ID#: 923417968640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4048673, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -24
+  - ID#: 927712935936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4203586, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -23
+  - ID#: 932007903232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4942608, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -22
+  - ID#: 936302870528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1271411, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -21
+  - ID#: 940597837824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1662241, -19.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -20
+  - ID#: 944892805120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4071424, -18.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -19
+  - ID#: 949187772416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1499159, -17.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -18
+  - ID#: 953482739712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1217625, -16.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -17
+  - ID#: 957777707008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.006769563, -15.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -16
+  - ID#: 962072674304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4646318, -1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -2
+  - ID#: 966367641600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1086189, -0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: -1
+  - ID#: 970662608896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1749919, 0.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 0
+  - ID#: 974957576192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4536824, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 1
+  - ID#: 979252543488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.09829763, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 3
+  - ID#: 983547510784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4242339, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 4
+  - ID#: 987842478080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1255419, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 5
+  - ID#: 992137445376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4775088, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 6
+  - ID#: 996432412672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.3080224, 8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 8
+  - ID#: 1000727379968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.3894489, 9.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 9
+  - ID#: 1005022347264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.2366444, 20.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 20
+  - ID#: 1009317314560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4937298, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 21
+  - ID#: 1013612281856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.1758298, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 22
+  - ID#: 1017907249152
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.03379769, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 23
+  - ID#: 1022202216448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-21.5, -0.4154143, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -22
+      z: 24
+  - ID#: 1026497183744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.3967988, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: -25
+  - ID#: 1030792151040
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.292632, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: -24
+  - ID#: 1035087118336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.2972518, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: -23
+  - ID#: 1039382085632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.2748618, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: -22
+  - ID#: 1043677052928
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.3663993, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: 22
+  - ID#: 1047972020224
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.4585968, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: 23
+  - ID#: 1052266987520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-20.5, -0.3476164, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -21
+      z: 24
+  - ID#: 1056561954816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.1429195, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -25
+  - ID#: 1060856922112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.3399099, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -24
+  - ID#: 1065151889408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.3786001, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -23
+  - ID#: 1069446856704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.1961602, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -22
+  - ID#: 1073741824000
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-19.5, 0, -6.5]
+      orientation: [-0.7153419, 0, 0.6987746, 0]
+      scale: [1.168467, 1.168467, 1.168467]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -7
+  - ID#: 1078036791296
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.1902229, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -6
+  - ID#: 1082331758592
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.104034, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: -5
+  - ID#: 1086626725888
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-19.5, 0, 3.5]
+      orientation: [-0.2114594, 0, 0.9773868, 0]
+      scale: [1.158211, 1.158211, 1.158211]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 3
+  - ID#: 1090921693184
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-19.5, -0.03792715, 9.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 9
+  - ID#: 1095216660480
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-19.5, -0.2021043, 10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 10
+  - ID#: 1099511627776
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-19.5, 0, 11.5]
+      orientation: [0.985671, 0, 0.168679, 0]
+      scale: [1.105829, 1.105829, 1.105829]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 11
+  - ID#: 1103806595072
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.2653988, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 21
+  - ID#: 1108101562368
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.2964119, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 22
+  - ID#: 1112396529664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.3895836, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 23
+  - ID#: 1116691496960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-19.5, -0.1781726, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -20
+      z: 24
+  - ID#: 1120986464256
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.4670053, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -25
+  - ID#: 1125281431552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.4824832, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -24
+  - ID#: 1129576398848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.0649531, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -23
+  - ID#: 1133871366144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.07721921, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -22
+  - ID#: 1138166333440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.2844118, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -21
+  - ID#: 1142461300736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.1974541, -7.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -8
+  - ID#: 1146756268032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.2346953, -6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -7
+  - ID#: 1151051235328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.193648, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -6
+  - ID#: 1155346202624
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-18.5, 0, -0.5]
+      orientation: [0.999301, 0, 0.03738274, 0]
+      scale: [1.218086, 1.218086, 1.218086]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: -1
+  - ID#: 1159641169920
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.1685613, 2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 2
+  - ID#: 1163936137216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.1942849, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 3
+  - ID#: 1168231104512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.08109115, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 4
+  - ID#: 1172526071808
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-18.5, -0.4637464, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 5
+  - ID#: 1176821039104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.3971423, 6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 6
+  - ID#: 1181116006400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.2180588, 7.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 7
+  - ID#: 1185410973696
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-18.5, -0.1556075, 8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 8
+  - ID#: 1189705940992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.4313391, 9.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 9
+  - ID#: 1194000908288
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-18.5, -0.2642666, 13.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 13
+  - ID#: 1198295875584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.31018, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 21
+  - ID#: 1202590842880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.08282436, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 22
+  - ID#: 1206885810176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.05977359, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 23
+  - ID#: 1211180777472
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-18.5, -0.300991, 24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -19
+      z: 24
+  - ID#: 1215475744768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.2359784, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -25
+  - ID#: 1219770712064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.1314856, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -24
+  - ID#: 1224065679360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.1701099, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -23
+  - ID#: 1228360646656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.3270395, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -22
+  - ID#: 1232655613952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.264921, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -21
+  - ID#: 1236950581248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.3446073, -3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -4
+  - ID#: 1241245548544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.3580503, -2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -3
+  - ID#: 1245540515840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.3740758, -1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -2
+  - ID#: 1249835483136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.4941897, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: -1
+  - ID#: 1254130450432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.2252708, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 0
+  - ID#: 1258425417728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.3602467, 1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 1
+  - ID#: 1262720385024
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-17.5, -0.04191069, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 2
+  - ID#: 1267015352320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.4562888, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 3
+  - ID#: 1271310319616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.1144885, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 4
+  - ID#: 1275605286912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.2527493, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 5
+  - ID#: 1279900254208
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-17.5, -0.4566687, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 6
+  - ID#: 1284195221504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.2791344, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 7
+  - ID#: 1288490188800
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-17.5, -0.07618901, 10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 10
+  - ID#: 1292785156096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.251595, 11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 11
+  - ID#: 1297080123392
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-17.5, 0, 15.5]
+      orientation: [-0.8539785, 0, 0.5203084, 0]
+      scale: [1.138742, 1.138742, 1.138742]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 15
+  - ID#: 1301375090688
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.2691712, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 22
+  - ID#: 1305670057984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.273296, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 23
+  - ID#: 1309965025280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-17.5, -0.4980673, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -18
+      z: 24
+  - ID#: 1314259992576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.2237922, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -25
+  - ID#: 1318554959872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.03908776, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -24
+  - ID#: 1322849927168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4272255, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -23
+  - ID#: 1327144894464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.2213391, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -22
+  - ID#: 1331439861760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.3021157, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -21
+  - ID#: 1335734829056
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-16.5, 0, -6.5]
+      orientation: [0.9443907, 0, 0.3288254, 0]
+      scale: [1.149563, 1.149563, 1.149563]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -7
+  - ID#: 1340029796352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.480949, -5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -6
+  - ID#: 1344324763648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4899628, -4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -5
+  - ID#: 1348619730944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.002317113, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -4
+  - ID#: 1352914698240
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.01715866, -2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -3
+  - ID#: 1357209665536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.3874552, -1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -2
+  - ID#: 1361504632832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.488501, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: -1
+  - ID#: 1365799600128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4086516, 0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 0
+  - ID#: 1370094567424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.1815932, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 1
+  - ID#: 1374389534720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4343474, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 2
+  - ID#: 1378684502016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.3397599, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 3
+  - ID#: 1382979469312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.04221793, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 4
+  - ID#: 1387274436608
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-16.5, 0, 9.5]
+      orientation: [0.4645019, 0, 0.8855721, 0]
+      scale: [1.119935, 1.119935, 1.119935]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 9
+  - ID#: 1391569403904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4279376, 21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 21
+  - ID#: 1395864371200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.1299352, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 22
+  - ID#: 1400159338496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.02252977, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 23
+  - ID#: 1404454305792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-16.5, -0.4000342, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -17
+      z: 24
+  - ID#: 1408749273088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.3300597, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -25
+  - ID#: 1413044240384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.2157069, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -24
+  - ID#: 1417339207680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.3749705, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -23
+  - ID#: 1421634174976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.4553238, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -22
+  - ID#: 1425929142272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.06649802, -20.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -21
+  - ID#: 1430224109568
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-15.5, 0, -15.5]
+      orientation: [0.8412046, 0, 0.540717, 0]
+      scale: [1.294708, 1.294708, 1.294708]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -16
+  - ID#: 1434519076864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.1319015, -8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -9
+  - ID#: 1438814044160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.04767759, -7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -8
+  - ID#: 1443109011456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.07276949, -6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -7
+  - ID#: 1447403978752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.1413366, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -6
+  - ID#: 1451698946048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.06803428, -4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -5
+  - ID#: 1455993913344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.4010557, -3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -4
+  - ID#: 1460288880640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.4346461, -2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -3
+  - ID#: 1464583847936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.03877851, -1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -2
+  - ID#: 1468878815232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.2898523, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: -1
+  - ID#: 1473173782528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.3136922, 0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 0
+  - ID#: 1477468749824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.2749301, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 4
+  - ID#: 1481763717120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.004046956, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 5
+  - ID#: 1486058684416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.0724774, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 22
+  - ID#: 1490353651712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.3401435, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 23
+  - ID#: 1494648619008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-15.5, -0.4265155, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -16
+      z: 24
+  - ID#: 1498943586304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.2669666, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -25
+  - ID#: 1503238553600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.3110276, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -24
+  - ID#: 1507533520896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.2193334, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -23
+  - ID#: 1511828488192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.1754762, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -22
+  - ID#: 1516123455488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.0997756, -20.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -21
+  - ID#: 1520418422784
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-14.5, 0, -17.5]
+      orientation: [-0.04161245, 0, 0.9991338, 0]
+      scale: [1.0414, 1.0414, 1.0414]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -18
+  - ID#: 1524713390080
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-14.5, -0.200904, -16.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -17
+  - ID#: 1529008357376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.1911665, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -6
+  - ID#: 1533303324672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.03798334, -4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -5
+  - ID#: 1537598291968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.3812107, -3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: -4
+  - ID#: 1541893259264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.1199581, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: 3
+  - ID#: 1546188226560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.02023556, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: 4
+  - ID#: 1550483193856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.06165947, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: 22
+  - ID#: 1554778161152
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.126478, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: 23
+  - ID#: 1559073128448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-14.5, -0.0919539, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -15
+      z: 24
+  - ID#: 1563368095744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.2523855, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -25
+  - ID#: 1567663063040
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.1199763, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -24
+  - ID#: 1571958030336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4113025, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -23
+  - ID#: 1576252997632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.2086335, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -22
+  - ID#: 1580547964928
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4908616, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -21
+  - ID#: 1584842932224
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-13.5, -0.02482721, -12.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -13
+  - ID#: 1589137899520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4117277, -11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -12
+  - ID#: 1593432866816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4513581, -10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -11
+  - ID#: 1597727834112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.1509137, -9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -10
+  - ID#: 1602022801408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4723936, -8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: -9
+  - ID#: 1606317768704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.02397214, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 2
+  - ID#: 1610612736000
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.245432, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 3
+  - ID#: 1614907703296
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.1239238, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 4
+  - ID#: 1619202670592
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.2446263, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 5
+  - ID#: 1623497637888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.2720281, 6.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 6
+  - ID#: 1627792605184
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.3986399, 18.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 18
+  - ID#: 1632087572480
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-13.5, -0.4438631, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -14
+      z: 24
+  - ID#: 1636382539776
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.4500269, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -25
+  - ID#: 1640677507072
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.1719198, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -24
+  - ID#: 1644972474368
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.1846234, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -23
+  - ID#: 1649267441664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.01663428, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -22
+  - ID#: 1653562408960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.05560138, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -21
+  - ID#: 1657857376256
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-12.5, -0.08143606, -15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -16
+  - ID#: 1662152343552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.390126, -14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -15
+  - ID#: 1666447310848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.438682, -13.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -14
+  - ID#: 1670742278144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.1948694, -12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -13
+  - ID#: 1675037245440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.1051509, -11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -12
+  - ID#: 1679332212736
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-12.5, -0.1208456, -10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -11
+  - ID#: 1683627180032
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-12.5, 0, -7.5]
+      orientation: [0.6547996, 0, 0.7558026, 0]
+      scale: [1.121174, 1.121174, 1.121174]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: -8
+  - ID#: 1687922147328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.246221, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 2
+  - ID#: 1692217114624
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.04822727, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 3
+  - ID#: 1696512081920
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.11171, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 4
+  - ID#: 1700807049216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.06598665, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 5
+  - ID#: 1705102016512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.2451507, 6.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 6
+  - ID#: 1709396983808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.3530231, 17.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 17
+  - ID#: 1713691951104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-12.5, -0.4774717, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -13
+      z: 24
+  - ID#: 1717986918400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.4780673, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -25
+  - ID#: 1722281885696
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.3259843, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -24
+  - ID#: 1726576852992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.2876043, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -23
+  - ID#: 1730871820288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.3787518, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -22
+  - ID#: 1735166787584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.02988977, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -21
+  - ID#: 1739461754880
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-11.5, 0, -13.5]
+      orientation: [0.2020314, 0, 0.9793791, 0]
+      scale: [1.070434, 1.070434, 1.070434]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -14
+  - ID#: 1743756722176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.2764406, -12.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -13
+  - ID#: 1748051689472
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-11.5, -0.1765793, -11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: -12
+  - ID#: 1752346656768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.02657628, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 4
+  - ID#: 1756641624064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.410597, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 5
+  - ID#: 1760936591360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.1612554, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 6
+  - ID#: 1765231558656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.007701721, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 7
+  - ID#: 1769526525952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.2024907, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 22
+  - ID#: 1773821493248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1509566, 16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 16
+  - ID#: 1778116460544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-11.5, -0.4542168, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -12
+      z: 24
+  - ID#: 1782411427840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.08449502, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -25
+  - ID#: 1786706395136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.4045686, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -24
+  - ID#: 1791001362432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.3245578, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -23
+  - ID#: 1795296329728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.1291479, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -22
+  - ID#: 1799591297024
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-10.5, -0.3658612, -8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -9
+  - ID#: 1803886264320
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-10.5, 0, -7.5]
+      orientation: [0.917946, 0, 0.3967054, 0]
+      scale: [1.194324, 1.194324, 1.194324]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: -8
+  - ID#: 1808181231616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.2466634, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: 4
+  - ID#: 1812476198912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.2254619, 5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: 5
+  - ID#: 1816771166208
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.1892502, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: 22
+  - ID#: 1821066133504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.08693258, 15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 15
+  - ID#: 1825361100800
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-10.5, -0.359235, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -11
+      z: 24
+  - ID#: 1829656068096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.1481604, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: -25
+  - ID#: 1833951035392
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.1439025, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: -24
+  - ID#: 1838246002688
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.3723464, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: -23
+  - ID#: 1842540969984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.3117178, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: -22
+  - ID#: 1846835937280
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-9.5, 0, -2.5]
+      orientation: [0.8289214, 0, 0.5593651, 0]
+      scale: [1.243562, 1.243562, 1.243562]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: -3
+  - ID#: 1851130904576
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-9.5, -0.3433877, 1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: 1
+  - ID#: 1855425871872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.156254, 5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: 5
+  - ID#: 1859720839168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.09175558, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: 22
+  - ID#: 1864015806464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.08559334, 16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 16
+  - ID#: 1868310773760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-9.5, -0.1842423, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -10
+      z: 24
+  - ID#: 1872605741056
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.1719649, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -25
+  - ID#: 1876900708352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.3128093, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -24
+  - ID#: 1881195675648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.4078845, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -23
+  - ID#: 1885490642944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.3901137, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -22
+  - ID#: 1889785610240
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-8.5, 0, -6.5]
+      orientation: [-0.5071069, 0, 0.8618832, 0]
+      scale: [1.024338, 1.024338, 1.024338]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -7
+  - ID#: 1894080577536
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-8.5, -0.1897094, -0.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: -1
+  - ID#: 1898375544832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.464693, 0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 0
+  - ID#: 1902670512128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.2292484, 1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 1
+  - ID#: 1906965479424
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-8.5, -0.3161796, 2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 2
+  - ID#: 1911260446720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.151807, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 5
+  - ID#: 1915555414016
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-8.5, -0.2433958, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 6
+  - ID#: 1919850381312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.3989643, 18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 18
+  - ID#: 1924145348608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.2179293, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 22
+  - ID#: 1928440315904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.3277389, 14.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 14
+  - ID#: 1932735283200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-8.5, -0.2233919, 24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -9
+      z: 24
+  - ID#: 1937030250496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.3778949, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -25
+  - ID#: 1941325217792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.1531747, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -24
+  - ID#: 1945620185088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.05403096, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -23
+  - ID#: 1949915152384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.2542543, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -22
+  - ID#: 1954210119680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.1967949, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -21
+  - ID#: 1958505086976
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-7.5, 0, -3.5]
+      orientation: [-0.03383341, 0, 0.9994275, 0]
+      scale: [1.261056, 1.261056, 1.261056]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -4
+  - ID#: 1962800054272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.4088139, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: -1
+  - ID#: 1967095021568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.1804304, 0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 0
+  - ID#: 1971389988864
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-7.5, -0.06349341, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 1
+  - ID#: 1975684956160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.4585589, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 2
+  - ID#: 1979979923456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.3221591, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 3
+  - ID#: 1984274890752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.3278703, 20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 20
+  - ID#: 1988569858048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.1893047, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 22
+  - ID#: 1992864825344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.2110438, 13.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 13
+  - ID#: 1997159792640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-7.5, -0.4057902, 24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -8
+      z: 24
+  - ID#: 2001454759936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.09993643, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -25
+  - ID#: 2005749727232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.2664128, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -24
+  - ID#: 2010044694528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.4744625, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -23
+  - ID#: 2014339661824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.1753636, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -22
+  - ID#: 2018634629120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.495055, -20.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -21
+  - ID#: 2022929596416
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-6.5, -0.4695008, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -2
+  - ID#: 2027224563712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.120038, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: -1
+  - ID#: 2031519531008
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-6.5, -0.4844339, 0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 0
+  - ID#: 2035814498304
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-6.5, -0.4073618, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 1
+  - ID#: 2040109465600
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-6.5, -0.4175043, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 2
+  - ID#: 2044404432896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.1943076, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 3
+  - ID#: 2048699400192
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-6.5, -0.3112375, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 4
+  - ID#: 2052994367488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.3898447, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 5
+  - ID#: 2057289334784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.2935224, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 22
+  - ID#: 2061584302080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.1961135, 12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 12
+  - ID#: 2065879269376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-6.5, -0.1038711, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -7
+      z: 24
+  - ID#: 2070174236672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.270069, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -25
+  - ID#: 2074469203968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.1506232, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -24
+  - ID#: 2078764171264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.009225422, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -23
+  - ID#: 2083059138560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.2354617, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -22
+  - ID#: 2087354105856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.4500916, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -21
+  - ID#: 2091649073152
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-5.5, 0, -5.5]
+      orientation: [0.749096, 0, 0.6624615, 0]
+      scale: [1.058349, 1.058349, 1.058349]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -6
+  - ID#: 2095944040448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.4221544, -4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -5
+  - ID#: 2100239007744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.4429991, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -4
+  - ID#: 2104533975040
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.09738214, -2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -3
+  - ID#: 2108828942336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.2206117, -1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -2
+  - ID#: 2113123909632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.1129609, -0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: -1
+  - ID#: 2117418876928
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-5.5, -0.452896, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 0
+  - ID#: 2121713844224
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-5.5, -0.0677385, 1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 1
+  - ID#: 2126008811520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.1197512, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 2
+  - ID#: 2130303778816
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-5.5, -0.1138321, 3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 3
+  - ID#: 2134598746112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.3998266, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 4
+  - ID#: 2138893713408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.2178493, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 22
+  - ID#: 2143188680704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.2373793, 12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 12
+  - ID#: 2147483648000
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-5.5, -0.3715662, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -6
+      z: 24
+  - ID#: 2151778615296
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.04491158, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -25
+  - ID#: 2156073582592
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.4616898, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -24
+  - ID#: 2160368549888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.3222753, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -23
+  - ID#: 2164663517184
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.2151037, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -22
+  - ID#: 2168958484480
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.3165318, -20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -21
+  - ID#: 2173253451776
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.09240816, -1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -2
+  - ID#: 2177548419072
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-4.5, -0.110517, -0.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -1
+  - ID#: 2181843386368
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-4.5, -0.4566879, 0.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 0
+  - ID#: 2186138353664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.3633272, 1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 1
+  - ID#: 2190433320960
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-4.5, -0.1540835, 2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 2
+  - ID#: 2194728288256
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [-4.5, -0.2736103, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 3
+  - ID#: 2199023255552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.219435, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 22
+  - ID#: 2203318222848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.3788701, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 22
+  - ID#: 2207613190144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-4.5, -0.05555961, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: 24
+  - ID#: 2211908157440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.3536608, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -25
+  - ID#: 2216203124736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.1290323, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -24
+  - ID#: 2220498092032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.08116426, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -23
+  - ID#: 2224793059328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.2043599, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -22
+  - ID#: 2229088026624
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.06686819, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -21
+  - ID#: 2233382993920
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-3.5, 0, -3.5]
+      orientation: [-0.2937282, 0, 0.955889, 0]
+      scale: [1.134867, 1.134867, 1.134867]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -4
+  - ID#: 2237677961216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.1311059, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -1
+  - ID#: 2241972928512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.02102706, 0.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 0
+  - ID#: 2246267895808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.3014216, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 1
+  - ID#: 2250562863104
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-3.5, -0.3986821, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 2
+  - ID#: 2254857830400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1993693, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 22
+  - ID#: 2259152797696
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.0837779, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 24
+  - ID#: 2263447764992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1108734, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -25
+  - ID#: 2267742732288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.4156072, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -24
+  - ID#: 2272037699584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.05870883, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -23
+  - ID#: 2276332666880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1624818, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -22
+  - ID#: 2280627634176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1483379, -20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -21
+  - ID#: 2284922601472
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-2.5, -0.3278899, -4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -5
+  - ID#: 2289217568768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.1593892, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -4
+  - ID#: 2293512536064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.210095, -2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -3
+  - ID#: 2297807503360
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-2.5, 0, -0.5]
+      orientation: [0.2359899, 0, 0.9717555, 0]
+      scale: [1.234573, 1.234573, 1.234573]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -1
+  - ID#: 2302102470656
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-2.5, -0.2539291, 1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 1
+  - ID#: 2306397437952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.05659627, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 23
+  - ID#: 2310692405248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.04275789, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: 24
+  - ID#: 2314987372544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.4967674, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: -25
+  - ID#: 2319282339840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.1312411, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: -24
+  - ID#: 2323577307136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.09078649, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: -23
+  - ID#: 2327872274432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.4005073, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: -22
+  - ID#: 2332167241728
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [-1.5, 0, -5.5]
+      orientation: [-0.7352417, 0, 0.6778049, 0]
+      scale: [1.008766, 1.008766, 1.008766]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: -6
+  - ID#: 2336462209024
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.1329603, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: 22
+  - ID#: 2340757176320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.4644271, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: 23
+  - ID#: 2345052143616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-1.5, -0.1220691, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -2
+      z: 24
+  - ID#: 2349347110912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.3651654, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: -25
+  - ID#: 2353642078208
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.05036924, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: -24
+  - ID#: 2357937045504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.2443045, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: -23
+  - ID#: 2362232012800
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.172164, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: -22
+  - ID#: 2366526980096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.2892625, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: 22
+  - ID#: 2370821947392
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.1408137, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: 23
+  - ID#: 2375116914688
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-0.5, -0.1186418, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -1
+      z: 24
+  - ID#: 2379411881984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.4843202, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -25
+  - ID#: 2383706849280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.2294244, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -24
+  - ID#: 2388001816576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.1068864, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -23
+  - ID#: 2392296783872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.4815443, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -22
+  - ID#: 2396591751168
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [0.5, 0, -6.5]
+      orientation: [-0.3266748, 0, 0.9451368, 0]
+      scale: [1.164042, 1.164042, 1.164042]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -7
+  - ID#: 2400886718464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.1132757, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -6
+  - ID#: 2405181685760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.2605679, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: -5
+  - ID#: 2409476653056
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [0.5, 0, 3.5]
+      orientation: [0.8272474, 0, 0.5618377, 0]
+      scale: [1.069478, 1.069478, 1.069478]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 3
+  - ID#: 2413771620352
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [0.5, -0.2007857, 9.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 9
+  - ID#: 2418066587648
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [0.5, -0.2444489, 10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 10
+  - ID#: 2422361554944
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [0.5, 0, 11.5]
+      orientation: [0.2690491, 0, 0.9631265, 0]
+      scale: [1.187218, 1.187218, 1.187218]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 11
+  - ID#: 2426656522240
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.08507614, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 21
+  - ID#: 2430951489536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.3395678, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 22
+  - ID#: 2435246456832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.1495259, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 23
+  - ID#: 2439541424128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [0.5, -0.1977576, 24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 0
+      z: 24
+  - ID#: 2443836391424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.3182343, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -25
+  - ID#: 2448131358720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.1837183, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -24
+  - ID#: 2452426326016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.07578708, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -23
+  - ID#: 2456721293312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.493991, -7.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -8
+  - ID#: 2461016260608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.3846216, -6.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -7
+  - ID#: 2465311227904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.01886943, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -6
+  - ID#: 2469606195200
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [1.5, 0, -0.5]
+      orientation: [-0.9342938, 0, 0.356504, 0]
+      scale: [1.26555, 1.26555, 1.26555]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: -1
+  - ID#: 2473901162496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.4796108, 2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 2
+  - ID#: 2478196129792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.4566434, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 3
+  - ID#: 2482491097088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.009033135, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 4
+  - ID#: 2486786064384
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [1.5, -0.3980919, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 5
+  - ID#: 2491081031680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.2914232, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 6
+  - ID#: 2495375998976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.04935614, 7.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 7
+  - ID#: 2499670966272
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [1.5, -0.3834271, 8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 8
+  - ID#: 2503965933568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.1309356, 9.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 9
+  - ID#: 2508260900864
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [1.5, -0.1638989, 13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 13
+  - ID#: 2512555868160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.1676784, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 21
+  - ID#: 2516850835456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.06453308, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 22
+  - ID#: 2521145802752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.339864, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 23
+  - ID#: 2525440770048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [1.5, -0.1459804, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 1
+      z: 24
+  - ID#: 2529735737344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.06827657, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -25
+  - ID#: 2534030704640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.4235548, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -24
+  - ID#: 2538325671936
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.07880654, -3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -4
+  - ID#: 2542620639232
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.3629195, -2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -3
+  - ID#: 2546915606528
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.4905548, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -2
+  - ID#: 2551210573824
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.4785835, -0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: -1
+  - ID#: 2555505541120
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.247087, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 2
+  - ID#: 2559800508416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.006269402, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 3
+  - ID#: 2564095475712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.3895259, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 4
+  - ID#: 2568390443008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.1432933, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 5
+  - ID#: 2572685410304
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.3575186, 6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 6
+  - ID#: 2576980377600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.04934952, 7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 7
+  - ID#: 2581275344896
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [2.5, -0.4518603, 10.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 10
+  - ID#: 2585570312192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.1923776, 11.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 11
+  - ID#: 2589865279488
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [2.5, 0, 15.5]
+      orientation: [-0.9418585, 0, 0.3360099, 0]
+      scale: [1.106605, 1.106605, 1.106605]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 15
+  - ID#: 2594160246784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.1670815, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 22
+  - ID#: 2598455214080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.3599855, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 23
+  - ID#: 2602750181376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [2.5, -0.3493729, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 2
+      z: 24
+  - ID#: 2607045148672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.03272253, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -25
+  - ID#: 2611340115968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.09890492, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -24
+  - ID#: 2615635083264
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [3.5, 0, -6.5]
+      orientation: [-0.04352629, 0, 0.9990523, 0]
+      scale: [1.009162, 1.009162, 1.009162]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -7
+  - ID#: 2619930050560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.2119892, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -6
+  - ID#: 2624225017856
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [3.5, -0.2426878, -4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -5
+  - ID#: 2628519985152
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [3.5, -0.4838475, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -4
+  - ID#: 2632814952448
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [3.5, -0.4787534, -2.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -3
+  - ID#: 2637109919744
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [3.5, -0.4964406, -1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -2
+  - ID#: 2641404887040
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [3.5, -0.09419098, -0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: -1
+  - ID#: 2645699854336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.3049333, 3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 3
+  - ID#: 2649994821632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.4671253, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 4
+  - ID#: 2654289788928
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [3.5, 0, 9.5]
+      orientation: [-0.3612983, 0, 0.9324503, 0]
+      scale: [1.141757, 1.141757, 1.141757]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 9
+  - ID#: 2658584756224
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.4297211, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 21
+  - ID#: 2662879723520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.3054581, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 22
+  - ID#: 2667174690816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.4027447, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 23
+  - ID#: 2671469658112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [3.5, -0.2442009, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 3
+      z: 24
+  - ID#: 2675764625408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.2883607, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -25
+  - ID#: 2680059592704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.2572598, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -24
+  - ID#: 2684354560000
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [4.5, 0, -15.5]
+      orientation: [0.8393729, 0, 0.543556, 0]
+      scale: [1.073506, 1.073506, 1.073506]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -16
+  - ID#: 2688649527296
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [4.5, -0.4001402, -8.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -9
+  - ID#: 2692944494592
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [4.5, -0.1485147, -7.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -8
+  - ID#: 2697239461888
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [4.5, -0.07094317, -6.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -7
+  - ID#: 2701534429184
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [4.5, -0.002391742, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -6
+  - ID#: 2705829396480
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [4.5, -0.2108806, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -5
+  - ID#: 2710124363776
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [4.5, -0.4824443, -3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -4
+  - ID#: 2714419331072
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [4.5, -0.4982307, -2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -3
+  - ID#: 2718714298368
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [4.5, -0.2734407, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -2
+  - ID#: 2723009265664
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [4.5, -0.1392491, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: -1
+  - ID#: 2727304232960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.4893403, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: 4
+  - ID#: 2731599200256
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.1162002, 5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: 5
+  - ID#: 2735894167552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.3563472, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: 22
+  - ID#: 2740189134848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.3734521, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: 23
+  - ID#: 2744484102144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [4.5, -0.2502358, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 4
+      z: 24
+  - ID#: 2748779069440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.1612665, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -25
+  - ID#: 2753074036736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.2355442, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -24
+  - ID#: 2757369004032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.1591161, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -23
+  - ID#: 2761663971328
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [5.5, 0, -17.5]
+      orientation: [0.9825109, 0, 0.186205, 0]
+      scale: [1.285742, 1.285742, 1.285742]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -18
+  - ID#: 2765958938624
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [5.5, -0.340986, -16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -17
+  - ID#: 2770253905920
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.2673605, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -6
+  - ID#: 2774548873216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.02121557, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -5
+  - ID#: 2778843840512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.4359026, -3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: -4
+  - ID#: 2783138807808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.03572273, 3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: 3
+  - ID#: 2787433775104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.4673013, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: 4
+  - ID#: 2791728742400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.2608249, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: 22
+  - ID#: 2796023709696
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.333557, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: 23
+  - ID#: 2800318676992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [5.5, -0.04836502, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 5
+      z: 24
+  - ID#: 2804613644288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.1448447, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -25
+  - ID#: 2808908611584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.4090743, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -24
+  - ID#: 2813203578880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.03276223, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -23
+  - ID#: 2817498546176
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [6.5, -0.4087735, -12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -13
+  - ID#: 2821793513472
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.1159443, -11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -12
+  - ID#: 2826088480768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.3612198, -10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -11
+  - ID#: 2830383448064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.3523619, -9.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -10
+  - ID#: 2834678415360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.07493272, -8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: -9
+  - ID#: 2838973382656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.0975537, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 2
+  - ID#: 2843268349952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.3298026, 3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 3
+  - ID#: 2847563317248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.2111092, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 4
+  - ID#: 2851858284544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.2592975, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 5
+  - ID#: 2856153251840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.4680275, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 6
+  - ID#: 2860448219136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.4864873, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 23
+  - ID#: 2864743186432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [6.5, -0.0711086, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 6
+      z: 24
+  - ID#: 2869038153728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.3244957, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -25
+  - ID#: 2873333121024
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.3215905, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -24
+  - ID#: 2877628088320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.4001653, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -23
+  - ID#: 2881923055616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.2363661, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -22
+  - ID#: 2886218022912
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [7.5, -0.2268988, -15.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -16
+  - ID#: 2890512990208
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.2184665, -14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -15
+  - ID#: 2894807957504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.2161957, -13.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -14
+  - ID#: 2899102924800
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.1221598, -12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -13
+  - ID#: 2903397892096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.4126569, -11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -12
+  - ID#: 2907692859392
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [7.5, -0.2529597, -10.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -11
+  - ID#: 2911987826688
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [7.5, 0, -7.5]
+      orientation: [0.9658148, 0, 0.2592332, 0]
+      scale: [1.272083, 1.272083, 1.272083]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: -8
+  - ID#: 2916282793984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.0665855, 2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 2
+  - ID#: 2920577761280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.03825199, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 3
+  - ID#: 2924872728576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.08669431, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 4
+  - ID#: 2929167695872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.356952, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 5
+  - ID#: 2933462663168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.1954689, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 6
+  - ID#: 2937757630464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.3086025, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 23
+  - ID#: 2942052597760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [7.5, -0.4156899, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 24
+  - ID#: 2946347565056
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.09454209, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -25
+  - ID#: 2950642532352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.4016822, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -24
+  - ID#: 2954937499648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.1984909, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -23
+  - ID#: 2959232466944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.03023559, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -22
+  - ID#: 2963527434240
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [8.5, 0, -13.5]
+      orientation: [0.6430613, 0, 0.7658147, 0]
+      scale: [1.119777, 1.119777, 1.119777]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -14
+  - ID#: 2967822401536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.4290496, -12.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -13
+  - ID#: 2972117368832
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [8.5, -0.2634379, -11.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: -12
+  - ID#: 2976412336128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.4544683, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 4
+  - ID#: 2980707303424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.2083997, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 5
+  - ID#: 2985002270720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.3086396, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 6
+  - ID#: 2989297238016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.3284299, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 7
+  - ID#: 2993592205312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.09040935, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 22
+  - ID#: 2997887172608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.3139867, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 23
+  - ID#: 3002182139904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [8.5, -0.2575119, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 24
+  - ID#: 3006477107200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.145992, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -25
+  - ID#: 3010772074496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.4123158, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -24
+  - ID#: 3015067041792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.2158256, -22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -23
+  - ID#: 3019362009088
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [9.5, -0.1796622, -8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -9
+  - ID#: 3023656976384
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [9.5, 0, -7.5]
+      orientation: [0.9988166, 0, 0.04863504, 0]
+      scale: [1.244835, 1.244835, 1.244835]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -8
+  - ID#: 3027951943680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.4920319, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 4
+  - ID#: 3032246910976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.1466941, 5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 5
+  - ID#: 3036541878272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.0835842, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 22
+  - ID#: 3040836845568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.08605891, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 23
+  - ID#: 3045131812864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [9.5, -0.05310817, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 24
+  - ID#: 3049426780160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.2463948, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: -25
+  - ID#: 3053721747456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.1862049, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: -24
+  - ID#: 3058016714752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.09766238, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 22
+  - ID#: 3062311682048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.0990592, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 23
+  - ID#: 3066606649344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.4321537, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 24
+  - ID#: 3070901616640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.2448438, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: -25
+  - ID#: 3075196583936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.1020986, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: -24
+  - ID#: 3079491551232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.1697467, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 21
+  - ID#: 3083786518528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.3081361, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 22
+  - ID#: 3088081485824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.4758152, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 23
+  - ID#: 3092376453120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.4390253, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 24
+  - ID#: 3096671420416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.460166, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: -25
+  - ID#: 3100966387712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.1962345, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: -24
+  - ID#: 3105261355008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.0263385, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 21
+  - ID#: 3109556322304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.4732886, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 22
+  - ID#: 3113851289600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.3689291, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 23
+  - ID#: 3118146256896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.08334913, 24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 24
+  - ID#: 3122441224192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.1345597, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: -25
+  - ID#: 3126736191488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.4859387, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: -24
+  - ID#: 3131031158784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.2114178, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 22
+  - ID#: 3135326126080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.2819825, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 23
+  - ID#: 3139621093376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.2739354, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 24
+  - ID#: 3143916060672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.2991844, -24.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: -25
+  - ID#: 3148211027968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.4713685, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: -24
+  - ID#: 3152505995264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.06561092, 22.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 22
+  - ID#: 3156800962560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.2088721, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 23
+  - ID#: 3161095929856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.2833887, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 24
+  - ID#: 3165390897152
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.4915262, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -25
+  - ID#: 3169685864448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.2771901, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -24
+  - ID#: 3173980831744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.1507275, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -23
+  - ID#: 3178275799040
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [15.5, 0, -17.5]
+      orientation: [0.5608097, 0, 0.8279448, 0]
+      scale: [1.21033, 1.21033, 1.21033]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -18
+  - ID#: 3182570766336
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [15.5, -0.06032446, -16.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -17
+  - ID#: 3186865733632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.3331694, -5.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -6
+  - ID#: 3191160700928
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.3688954, -4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -5
+  - ID#: 3195455668224
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.2695632, -3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: -4
+  - ID#: 3199750635520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.1213618, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 3
+  - ID#: 3204045602816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.3490528, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 4
+  - ID#: 3208340570112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.4114296, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 22
+  - ID#: 3212635537408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.333264, 23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 23
+  - ID#: 3216930504704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [15.5, -0.09273799, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 24
+  - ID#: 3221225472000
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.08906623, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -25
+  - ID#: 3225520439296
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.1563385, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -24
+  - ID#: 3229815406592
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.0640072, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -23
+  - ID#: 3234110373888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.4408627, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -22
+  - ID#: 3238405341184
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [16.5, -0.4995402, -12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -13
+  - ID#: 3242700308480
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.3371065, -11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -12
+  - ID#: 3246995275776
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.08556053, -10.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -11
+  - ID#: 3251290243072
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.3696488, -9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -10
+  - ID#: 3255585210368
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.01630041, -8.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: -9
+  - ID#: 3259880177664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.03127162, 2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 2
+  - ID#: 3264175144960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.2805999, 3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 3
+  - ID#: 3268470112256
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.06578078, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 4
+  - ID#: 3272765079552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.4409333, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 5
+  - ID#: 3277060046848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.04497645, 6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 6
+  - ID#: 3281355014144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.3345877, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 23
+  - ID#: 3285649981440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [16.5, -0.004157223, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 24
+  - ID#: 3289944948736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.09521663, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -25
+  - ID#: 3294239916032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.2282552, -23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -24
+  - ID#: 3298534883328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.1844583, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -23
+  - ID#: 3302829850624
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.3171517, -21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -22
+  - ID#: 3307124817920
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [17.5, -0.230363, -15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -16
+  - ID#: 3311419785216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.2648815, -14.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -15
+  - ID#: 3315714752512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.490819, -13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -14
+  - ID#: 3320009719808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.2489347, -12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -13
+  - ID#: 3324304687104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.07820248, -11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -12
+  - ID#: 3328599654400
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [17.5, -0.167899, -10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -11
+  - ID#: 3332894621696
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [17.5, 0, -7.5]
+      orientation: [-0.898749, 0, 0.4384635, 0]
+      scale: [1.075847, 1.075847, 1.075847]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: -8
+  - ID#: 3337189588992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.3223823, 2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 2
+  - ID#: 3341484556288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.1168377, 3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 3
+  - ID#: 3345779523584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.1881361, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 4
+  - ID#: 3350074490880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.08658151, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 5
+  - ID#: 3354369458176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.09546185, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 6
+  - ID#: 3358664425472
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.2979905, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 23
+  - ID#: 3362959392768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [17.5, -0.2141265, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 24
+  - ID#: 3367254360064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.3634466, -24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -25
+  - ID#: 3371549327360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.241011, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -24
+  - ID#: 3375844294656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.4387865, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -23
+  - ID#: 3380139261952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.06030581, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -22
+  - ID#: 3384434229248
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [18.5, 0, -13.5]
+      orientation: [-0.6058321, 0, 0.7955925, 0]
+      scale: [1.176852, 1.176852, 1.176852]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -14
+  - ID#: 3388729196544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.1173828, -12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -13
+  - ID#: 3393024163840
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [18.5, -0.1130938, -11.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: -12
+  - ID#: 3397319131136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.2389979, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 4
+  - ID#: 3401614098432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.1923096, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 5
+  - ID#: 3405909065728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.009105882, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 6
+  - ID#: 3410204033024
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.2914932, 7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 7
+  - ID#: 3414499000320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.3736656, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 22
+  - ID#: 3418793967616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.1259031, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 23
+  - ID#: 3423088934912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [18.5, -0.3273618, 24.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 24
+  - ID#: 3427383902208
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.1452203, -24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -25
+  - ID#: 3431678869504
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.03903347, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -24
+  - ID#: 3435973836800
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.3085454, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -23
+  - ID#: 3440268804096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.2363846, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -22
+  - ID#: 3444563771392
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [19.5, -0.1326405, -8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -9
+  - ID#: 3448858738688
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [19.5, 0, -7.5]
+      orientation: [-0.9999387, 0, 0.01107375, 0]
+      scale: [1.247313, 1.247313, 1.247313]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: -8
+  - ID#: 3453153705984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.2660488, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: 4
+  - ID#: 3457448673280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.4913317, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: 5
+  - ID#: 3461743640576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.449718, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: 22
+  - ID#: 3466038607872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.3651244, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: 23
+  - ID#: 3470333575168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [19.5, -0.3864505, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 19
+      z: 24
+  - ID#: 3474628542464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.1719385, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: -25
+  - ID#: 3478923509760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.1018799, -23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: -24
+  - ID#: 3483218477056
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.2920347, -22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: -23
+  - ID#: 3487513444352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.4535543, -21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: -22
+  - ID#: 3491808411648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.05388451, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: 22
+  - ID#: 3496103378944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.1874063, 23.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: 23
+  - ID#: 3500398346240
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [20.5, -0.4531541, 24.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 20
+      z: 24
+  - ID#: 3504693313536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.4240444, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -25
+  - ID#: 3508988280832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.4398269, -23.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -24
+  - ID#: 3513283248128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.1633496, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -23
+  - ID#: 3517578215424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.4088803, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -22
+  - ID#: 3521873182720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.1633683, -20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -21
+  - ID#: 3526168150016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.130364, -19.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -20
+  - ID#: 3530463117312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.3296053, -18.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -19
+  - ID#: 3534758084608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2971781, -17.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -18
+  - ID#: 3539053051904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2933825, -16.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -17
+  - ID#: 3543348019200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.0112563, -1.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -2
+  - ID#: 3547642986496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.0244916, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: -1
+  - ID#: 3551937953792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2126297, 0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 0
+  - ID#: 3556232921088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.3849828, 1.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 1
+  - ID#: 3560527888384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.1563594, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 2
+  - ID#: 3564822855680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2458761, 3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 3
+  - ID#: 3569117822976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.08074237, 4.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 4
+  - ID#: 3573412790272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.244092, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 5
+  - ID#: 3577707757568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.0893831, 6.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 6
+  - ID#: 3582002724864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2145633, 20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 20
+  - ID#: 3586297692160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.2114428, 21.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 21
+  - ID#: 3590592659456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.1973639, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 22
+  - ID#: 3594887626752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.04711467, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 23
+  - ID#: 3599182594048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [21.5, -0.3882269, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 21
+      z: 24
+  - ID#: 3603477561344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2992618, -24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -25
+  - ID#: 3607772528640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.4873772, -23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -24
+  - ID#: 3612067495936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2354621, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -23
+  - ID#: 3616362463232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3742526, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -22
+  - ID#: 3620657430528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3479747, -20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -21
+  - ID#: 3624952397824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.317251, -19.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -20
+  - ID#: 3629247365120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3499439, -18.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -19
+  - ID#: 3633542332416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.03609013, -17.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -18
+  - ID#: 3637837299712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3192654, -16.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -17
+  - ID#: 3642132267008
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3166817, -15.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -16
+  - ID#: 3646427234304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.01680192, -14.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -15
+  - ID#: 3650722201600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2644603, -13.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -14
+  - ID#: 3655017168896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.03440305, -12.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -13
+  - ID#: 3659312136192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1480838, -5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -6
+  - ID#: 3663607103488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1597999, -4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -5
+  - ID#: 3667902070784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1626639, -3.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -4
+  - ID#: 3672197038080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2654321, -2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -3
+  - ID#: 3676492005376
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.31556, -1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -2
+  - ID#: 3680786972672
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3272229, -0.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: -1
+  - ID#: 3685081939968
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.4972527, 0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 0
+  - ID#: 3689376907264
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2038096, 1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 1
+  - ID#: 3693671874560
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.2580239, 2.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 2
+  - ID#: 3697966841856
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.4099906, 3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 3
+  - ID#: 3702261809152
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.362227, 4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 4
+  - ID#: 3706556776448
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3591795, 5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 5
+  - ID#: 3710851743744
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1227874, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 6
+  - ID#: 3715146711040
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.4843247, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 7
+  - ID#: 3719441678336
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1661696, 8.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 8
+  - ID#: 3723736645632
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.265667, 16.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 16
+  - ID#: 3728031612928
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3743046, 17.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 17
+  - ID#: 3732326580224
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.1625728, 18.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 18
+  - ID#: 3736621547520
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3414832, 19.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 19
+  - ID#: 3740916514816
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.0528146, 20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 20
+  - ID#: 3745211482112
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3406357, 21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 21
+  - ID#: 3749506449408
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3054793, 22.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 22
+  - ID#: 3753801416704
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.03942119, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 23
+  - ID#: 3758096384000
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [22.5, -0.3894011, 24.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 22
+      z: 24
+  - ID#: 4445291151360
     NameComponent:
       name: Rock
     Transform3DComponent:
@@ -15473,26 +14111,11 @@ Entities:
     GridComponent:
       x: -4
       z: -12
-  - ID#: 4436701216768
+  - ID#: 3766686318592
     NameComponent:
       name: Rock
     Transform3DComponent:
-      position: [-2.5, -0.3161796, -14.5]
-      orientation: [-4.371139e-08, 0, 1, 0]
-      scale: [1.1, 1.1, 1.1]
-    ModelComponent:
-      mesh: Resources/Models/Rock.obj
-      material: Resources/Materials/rock.yaml
-    SelectComponent:
-      {}
-    GridComponent:
-      x: -3
-      z: -15
-  - ID#: 4440996184064
-    NameComponent:
-      name: Rock
-    Transform3DComponent:
-      position: [-3.5, -0.1540835, -14.5]
+      position: [23.5, -0.2117265, -23.5]
       orientation: [-0.7071068, 0, 0.7071068, 0]
       scale: [1.1, 1.1, 1.1]
     ModelComponent:
@@ -15501,9 +14124,684 @@ Entities:
     SelectComponent:
       {}
     GridComponent:
-      x: -4
+      x: 23
+      z: -24
+  - ID#: 3770981285888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3490734, -22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -23
+  - ID#: 3775276253184
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.04541164, -21.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -22
+  - ID#: 3779571220480
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.03394242, -20.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -21
+  - ID#: 3783866187776
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1332358, -19.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -20
+  - ID#: 3788161155072
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.03457003, -18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -19
+  - ID#: 3792456122368
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.07682836, -17.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -18
+  - ID#: 3796751089664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2635214, -16.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -17
+  - ID#: 3801046056960
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1405026, -15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -16
+  - ID#: 3805341024256
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1310244, -14.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
       z: -15
-  - ID#: 4445291151360
+  - ID#: 3809635991552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2200426, -13.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -14
+  - ID#: 3813930958848
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2416876, -12.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -13
+  - ID#: 3818225926144
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2635714, -11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -12
+  - ID#: 3822520893440
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.06540273, -10.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -11
+  - ID#: 3826815860736
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2287122, -9.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -10
+  - ID#: 3831110828032
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.04722038, -8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -9
+  - ID#: 3835405795328
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4376858, -7.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -8
+  - ID#: 3839700762624
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.06019084, -6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -7
+  - ID#: 3843995729920
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2590261, -5.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -6
+  - ID#: 3848290697216
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4849186, -4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -5
+  - ID#: 3852585664512
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4718113, -3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -4
+  - ID#: 3856880631808
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3781408, -2.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -3
+  - ID#: 3861175599104
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3188545, -1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -2
+  - ID#: 3865470566400
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1340882, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: -1
+  - ID#: 3869765533696
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.478847, 0.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 0
+  - ID#: 3874060500992
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.362453, 1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 1
+  - ID#: 3878355468288
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1203535, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 2
+  - ID#: 3882650435584
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2078813, 3.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 3
+  - ID#: 3886945402880
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3380612, 4.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 4
+  - ID#: 3891240370176
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2373592, 5.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 5
+  - ID#: 3895535337472
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1445323, 6.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 6
+  - ID#: 3899830304768
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.02772071, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 7
+  - ID#: 3904125272064
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3359041, 8.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 8
+  - ID#: 3908420239360
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3068721, 9.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 9
+  - ID#: 3912715206656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3475702, 10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 10
+  - ID#: 3917010173952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.2453096, 11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 11
+  - ID#: 3921305141248
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.03399638, 14.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 14
+  - ID#: 3925600108544
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4522374, 15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 15
+  - ID#: 3929895075840
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1273951, 16.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 16
+  - ID#: 3934190043136
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4676071, 17.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 17
+  - ID#: 3938485010432
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.11202, 18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 18
+  - ID#: 3942779977728
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4591383, 19.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 19
+  - ID#: 3947074945024
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3339164, 20.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 20
+  - ID#: 3951369912320
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.1519126, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 21
+  - ID#: 3955664879616
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.4221961, 22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 22
+  - ID#: 3959959846912
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [23.5, -0.3950509, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 23
+      z: 23
+  - ID#: 4458176053248
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -15518,7 +14816,742 @@ Entities:
     GridComponent:
       x: -3
       z: -16
+  - ID#: 4453881085952
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-3.5, -0.1540835, -14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -15
   - ID#: 4449586118656
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [-2.5, -0.3161796, -14.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -3
+      z: -15
+  - ID#: 3977139716096
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2244759, -22.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -23
+  - ID#: 3981434683392
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.337666, -21.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -22
+  - ID#: 3985729650688
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2550544, -20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -21
+  - ID#: 3990024617984
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.003357659, -19.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -20
+  - ID#: 3994319585280
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.115316, -18.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -19
+  - ID#: 3998614552576
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3010852, -17.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -18
+  - ID#: 4002909519872
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3559404, -16.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -17
+  - ID#: 4007204487168
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1933856, -15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -16
+  - ID#: 4011499454464
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.4922263, -14.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -15
+  - ID#: 4015794421760
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.4579956, -13.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -14
+  - ID#: 4020089389056
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3276066, -12.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -13
+  - ID#: 4024384356352
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.0005755287, -11.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -12
+  - ID#: 4028679323648
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1363335, -10.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -11
+  - ID#: 4032974290944
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2312246, -9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -10
+  - ID#: 4037269258240
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2345078, -8.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -9
+  - ID#: 4041564225536
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2121745, -7.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -8
+  - ID#: 4045859192832
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.001500603, -6.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -7
+  - ID#: 4050154160128
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2304582, -5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -6
+  - ID#: 4054449127424
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.223212, -4.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -5
+  - ID#: 4058744094720
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3850799, -3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -4
+  - ID#: 4063039062016
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.4854721, -2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -3
+  - ID#: 4067334029312
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1612359, -1.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -2
+  - ID#: 4071628996608
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1523318, -0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: -1
+  - ID#: 4075923963904
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3923697, 0.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 0
+  - ID#: 4080218931200
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1075545, 1.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 1
+  - ID#: 4084513898496
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2356786, 2.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 2
+  - ID#: 4088808865792
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1237925, 3.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 3
+  - ID#: 4093103833088
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.01788137, 4.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 4
+  - ID#: 4097398800384
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.4032255, 5.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 5
+  - ID#: 4101693767680
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.08793721, 6.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 6
+  - ID#: 4105988734976
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2431855, 7.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 7
+  - ID#: 4110283702272
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.360879, 8.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 8
+  - ID#: 4114578669568
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.203751, 9.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 9
+  - ID#: 4118873636864
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.236743, 10.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 10
+  - ID#: 4123168604160
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1078146, 11.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 11
+  - ID#: 4127463571456
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.0763606, 12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 12
+  - ID#: 4131758538752
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.270126, 13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 13
+  - ID#: 4136053506048
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1705623, 14.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 14
+  - ID#: 4140348473344
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3615121, 15.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 15
+  - ID#: 4144643440640
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3036946, 16.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 16
+  - ID#: 4148938407936
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.141847, 17.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 17
+  - ID#: 4153233375232
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.09587263, 18.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 18
+  - ID#: 4157528342528
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.2714311, 19.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 19
+  - ID#: 4161823309824
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3692134, 20.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 20
+  - ID#: 4166118277120
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.3779624, 21.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 21
+  - ID#: 4170413244416
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1214248, 22.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 22
+  - ID#: 4174708211712
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [24.5, -0.1659886, 23.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 24
+      z: 23
+  - ID#: 4462471020544
     NameComponent:
       name: Tree
     Transform3DComponent:
@@ -15533,3 +15566,888 @@ Entities:
     GridComponent:
       x: -5
       z: -11
+  - ID#: 4183298146304
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.4073618, 13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 13
+  - ID#: 4187593113600
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.0677385, 14.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 14
+  - ID#: 4191888080896
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [12.5, -0.452896, 14.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 14
+  - ID#: 4196183048192
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [13.5, -0.4175043, 12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 12
+  - ID#: 4200478015488
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [14.5, -0.06349341, 15.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 15
+  - ID#: 4204772982784
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.4844339, 15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 15
+  - ID#: 4209067950080
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.4566879, 15.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 15
+  - ID#: 4213362917376
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [12.5, -0.3530231, 15.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 15
+  - ID#: 4217657884672
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [13.5, -0.3986399, 15.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 15
+  - ID#: 4221952851968
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [14.5, 0, 14.5]
+      orientation: [-0.99975, 0, 0.02236243, 0]
+      scale: [1.287252, 1.287252, 1.287252]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 14
+  - ID#: 4226247819264
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [13.5, 0, 13.5]
+      orientation: [-0.9999382, 0, 0.0111169, 0]
+      scale: [1.289467, 1.289467, 1.289467]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 13
+  - ID#: 4230542786560
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [11.5, 0, 13.5]
+      orientation: [-0.9948544, 0, 0.1013153, 0]
+      scale: [1.047284, 1.047284, 1.047284]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 13
+  - ID#: 4234837753856
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [11.5, -0.1509566, 14.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 14
+  - ID#: 4239132721152
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [10.5, 0, 14.5]
+      orientation: [-0.9982396, 0, 0.05931081, 0]
+      scale: [1.28715, 1.28715, 1.28715]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 14
+  - ID#: 4243427688448
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [15.5, 0, 15.5]
+      orientation: [0.9410278, 0, 0.3383293, 0]
+      scale: [1.145613, 1.145613, 1.145613]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 15
+  - ID#: 4247722655744
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [15.5, 0, 14.5]
+      orientation: [-0.805505, 0, 0.592589, 0]
+      scale: [1.240084, 1.240084, 1.240084]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 14
+  - ID#: 4252017623040
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [14.5, 0, 16.5]
+      orientation: [0.5953096, 0, 0.8034964, 0]
+      scale: [1.042566, 1.042566, 1.042566]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 16
+  - ID#: 4256312590336
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [13.5, 0, 16.5]
+      orientation: [0.9998871, 0, 0.01502719, 0]
+      scale: [1.126528, 1.126528, 1.126528]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 16
+  - ID#: 4260607557632
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 16.5]
+      orientation: [0.9382299, 0, 0.3460124, 0]
+      scale: [1.274721, 1.274721, 1.274721]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 16
+  - ID#: 4264902524928
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 12.5]
+      orientation: [-0.4251064, 0, 0.9051434, 0]
+      scale: [1.237662, 1.237662, 1.237662]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 12
+  - ID#: 4269197492224
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [13.5, 0, 11.5]
+      orientation: [-0.9279503, 0, 0.3727039, 0]
+      scale: [1.287848, 1.287848, 1.287848]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 11
+  - ID#: 4273492459520
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [13.5, 0, 10.5]
+      orientation: [-0.01150647, 0, 0.9999338, 0]
+      scale: [1.196722, 1.196722, 1.196722]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 10
+  - ID#: 4277787426816
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [14.5, 0, 13.5]
+      orientation: [-0.8051748, 0, 0.5930375, 0]
+      scale: [1.010713, 1.010713, 1.010713]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 13
+  - ID#: 4282082394112
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [14.5, 0, 12.5]
+      orientation: [0.4220974, 0, 0.9065505, 0]
+      scale: [1.254739, 1.254739, 1.254739]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 12
+  - ID#: 4286377361408
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [16.5, 0, 15.5]
+      orientation: [0.7864353, 0, 0.6176727, 0]
+      scale: [1.280198, 1.280198, 1.280198]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 16
+      z: 15
+  - ID#: 4290672328704
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [11.5, 0, 16.5]
+      orientation: [-0.539428, 0, 0.8420317, 0]
+      scale: [1.203621, 1.203621, 1.203621]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 16
+  - ID#: 4294967296000
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [13.5, 0, 17.5]
+      orientation: [0.3127837, 0, 0.9498244, 0]
+      scale: [1.227322, 1.227322, 1.227322]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 13
+      z: 17
+  - ID#: 4299262263296
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [15.5, 0, 16.5]
+      orientation: [-0.686028, 0, 0.7275751, 0]
+      scale: [1.22294, 1.22294, 1.22294]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 16
+  - ID#: 4303557230592
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [14.5, 0, 17.5]
+      orientation: [0.07921477, 0, 0.9968576, 0]
+      scale: [1.117668, 1.117668, 1.117668]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 14
+      z: 17
+  - ID#: 4307852197888
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.2110438, 16.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 16
+  - ID#: 4312147165184
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [9.5, 0, 15.5]
+      orientation: [-0.469256, 0, 0.8830622, 0]
+      scale: [1.05216, 1.05216, 1.05216]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 15
+  - ID#: 4316442132480
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 17.5]
+      orientation: [0.9894984, 0, 0.1445436, 0]
+      scale: [1.044734, 1.044734, 1.044734]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 17
+  - ID#: 4320737099776
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [11.5, 0, 17.5]
+      orientation: [0.9538023, 0, 0.3004348, 0]
+      scale: [1.298221, 1.298221, 1.298221]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 17
+  - ID#: 4325032067072
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [10.5, 0, 17.5]
+      orientation: [-0.8500988, 0, 0.5266233, 0]
+      scale: [1.246571, 1.246571, 1.246571]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 17
+  - ID#: 4329327034368
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [9.5, 0, 16.5]
+      orientation: [-0.5745647, 0, 0.8184592, 0]
+      scale: [1.037555, 1.037555, 1.037555]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 16
+  - ID#: 4333622001664
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [10.5, -0.1585497, 11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 11
+  - ID#: 4337916968960
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [9.5, -0.381875, 11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 11
+  - ID#: 4342211936256
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [10.5, -0.475111, 10.5]
+      orientation: [-0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 10
+  - ID#: 4346506903552
+    NameComponent:
+      name: Rock
+    Transform3DComponent:
+      position: [11.5, -0.2452945, 11.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 11
+  - ID#: 4350801870848
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [9.5, 0, 12.5]
+      orientation: [0.9941504, 0, 0.1080045, 0]
+      scale: [1.199082, 1.199082, 1.199082]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 12
+  - ID#: 4355096838144
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [11.5, 0, 12.5]
+      orientation: [0.1912548, 0, 0.9815404, 0]
+      scale: [1.037769, 1.037769, 1.037769]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 12
+  - ID#: 4359391805440
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [10.5, 0, 12.5]
+      orientation: [0.363568, 0, 0.9315677, 0]
+      scale: [1.063063, 1.063063, 1.063063]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 10
+      z: 12
+  - ID#: 4363686772736
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 11.5]
+      orientation: [-0.7407228, 0, 0.6718107, 0]
+      scale: [1.015365, 1.015365, 1.015365]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 11
+  - ID#: 4367981740032
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [9.5, 0, 10.5]
+      orientation: [-0.8000616, 0, 0.5999178, 0]
+      scale: [1.010932, 1.010932, 1.010932]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: 10
+  - ID#: 4372276707328
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [8.5, 0, 11.5]
+      orientation: [0.832563, 0, 0.5539303, 0]
+      scale: [1.122619, 1.122619, 1.122619]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 8
+      z: 11
+  - ID#: 4376571674624
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [11.5, 0, 10.5]
+      orientation: [-0.4436398, 0, 0.8962052, 0]
+      scale: [1.238192, 1.238192, 1.238192]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 11
+      z: 10
+  - ID#: 4380866641920
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [7.5, 0, 11.5]
+      orientation: [0.1701146, 0, 0.9854243, 0]
+      scale: [1.146271, 1.146271, 1.146271]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 7
+      z: 11
+  - ID#: 4385161609216
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 10.5]
+      orientation: [-0.6113292, 0, 0.7913764, 0]
+      scale: [1.276262, 1.276262, 1.276262]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 10
+  - ID#: 4389456576512
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 9.5]
+      orientation: [-0.7174409, 0, 0.6966194, 0]
+      scale: [1.242259, 1.242259, 1.242259]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 9
+  - ID#: 4393751543808
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [12.5, 0, 8.5]
+      orientation: [0.6469958, 0, 0.7624936, 0]
+      scale: [1.211732, 1.211732, 1.211732]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 12
+      z: 8
+  - ID#: 4398046511104
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [15.5, 0, 9.5]
+      orientation: [-0.535038, 0, 0.844828, 0]
+      scale: [1.000846, 1.000846, 1.000846]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 15
+      z: 9
+  - ID#: 4402341478400
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [18.5, 0, 12.5]
+      orientation: [-0.4682019, 0, 0.8836215, 0]
+      scale: [1.213211, 1.213211, 1.213211]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 18
+      z: 12
+  - ID#: 4406636445696
+    NameComponent:
+      name: Tree
+    Transform3DComponent:
+      position: [17.5, 0, 19.5]
+      orientation: [0.8723244, 0, 0.4889275, 0]
+      scale: [1.193188, 1.193188, 1.193188]
+    ModelComponent:
+      mesh: Resources/Models/BetterTree.obj
+      material: Resources/Materials/tree.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 17
+      z: 19
+  - ID#: 4410931412992
+    NameComponent:
+      name: Mithril
+    Transform3DComponent:
+      position: [-3.5, -0.4073618, 23.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/rock.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: 23
+  - ID#: 4415226380288
+    NameComponent:
+      name: Iron
+    Transform3DComponent:
+      position: [9.5, -0.4073618, -3.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Materials/iron.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: 9
+      z: -4
+  - ID#: 4419521347584
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-3.5, -0.0677385, -12.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -13
+  - ID#: 4423816314880
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-4.5, -0.452896, -11.5]
+      orientation: [-4.371139e-08, 0, 1, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -12
+  - ID#: 4428111282176
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-4.5, -0.4175043, -12.5]
+      orientation: [0.7071068, 0, 0.7071068, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -5
+      z: -13
+  - ID#: 4432406249472
+    NameComponent:
+      name: Tin
+    Transform3DComponent:
+      position: [-3.5, -0.06349341, -13.5]
+      orientation: [1, 0, 0, 0]
+      scale: [1.1, 1.1, 1.1]
+    ModelComponent:
+      mesh: Resources/Models/Rock.obj
+      material: Resources/Material/tin.yaml
+    SelectComponent:
+      {}
+    GridComponent:
+      x: -4
+      z: -14

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -29,9 +29,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 12
   - ID#: 25769803776
     NameComponent:
       name: Tree
@@ -44,9 +41,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -2
   - ID#: 30064771072
     NameComponent:
       name: Tree
@@ -59,9 +53,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 14
   - ID#: 34359738368
     NameComponent:
       name: Tree
@@ -74,9 +65,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 11
   - ID#: 38654705664
     NameComponent:
       name: Tree
@@ -89,9 +77,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 20
   - ID#: 42949672960
     NameComponent:
       name: Tree
@@ -104,9 +89,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 14
   - ID#: 47244640256
     NameComponent:
       name: Tree
@@ -119,9 +101,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 21
   - ID#: 51539607552
     NameComponent:
       name: Rock
@@ -134,9 +113,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 15
   - ID#: 55834574848
     NameComponent:
       name: Rock
@@ -149,9 +125,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 11
   - ID#: 60129542144
     NameComponent:
       name: Rock
@@ -164,9 +137,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 11
   - ID#: 64424509440
     NameComponent:
       name: Rock
@@ -179,9 +149,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 11
   - ID#: 68719476736
     NameComponent:
       name: Rock
@@ -194,9 +161,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 11
   - ID#: 73014444032
     NameComponent:
       name: Rock
@@ -209,9 +173,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 21
   - ID#: 77309411328
     NameComponent:
       name: Rock
@@ -224,9 +185,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 20
   - ID#: 81604378624
     NameComponent:
       name: Rock
@@ -239,9 +197,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 19
   - ID#: 85899345920
     NameComponent:
       name: Rock
@@ -254,9 +209,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 21
   - ID#: 90194313216
     NameComponent:
       name: Rock
@@ -269,9 +221,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 15
   - ID#: 94489280512
     NameComponent:
       name: Rock
@@ -284,9 +233,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 18
   - ID#: 98784247808
     NameComponent:
       name: Rock
@@ -299,9 +245,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 19
   - ID#: 103079215104
     NameComponent:
       name: Rock
@@ -314,9 +257,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 19
   - ID#: 107374182400
     NameComponent:
       name: Rock
@@ -329,9 +269,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 22
   - ID#: 111669149696
     NameComponent:
       name: Rock
@@ -344,9 +281,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 21
   - ID#: 115964116992
     NameComponent:
       name: Rock
@@ -359,9 +293,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 20
   - ID#: 120259084288
     NameComponent:
       name: Rock
@@ -374,9 +305,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 20
   - ID#: 124554051584
     NameComponent:
       name: Rock
@@ -389,9 +317,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 21
   - ID#: 128849018880
     NameComponent:
       name: Rock
@@ -404,9 +329,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 19
   - ID#: 133143986176
     NameComponent:
       name: Rock
@@ -419,9 +341,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 20
   - ID#: 137438953472
     NameComponent:
       name: Rock
@@ -434,9 +353,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 20
   - ID#: 141733920768
     NameComponent:
       name: Rock
@@ -449,9 +365,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 20
   - ID#: 146028888064
     NameComponent:
       name: Rock
@@ -464,9 +377,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 20
   - ID#: 150323855360
     NameComponent:
       name: Rock
@@ -479,9 +389,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 20
   - ID#: 154618822656
     NameComponent:
       name: Rock
@@ -494,9 +401,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 20
   - ID#: 158913789952
     NameComponent:
       name: Rock
@@ -509,9 +413,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 20
   - ID#: 163208757248
     NameComponent:
       name: Rock
@@ -524,9 +425,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 19
   - ID#: 167503724544
     NameComponent:
       name: Rock
@@ -539,9 +437,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 18
   - ID#: 171798691840
     NameComponent:
       name: Rock
@@ -554,9 +449,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 17
   - ID#: 176093659136
     NameComponent:
       name: Rock
@@ -569,9 +461,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 16
   - ID#: 180388626432
     NameComponent:
       name: Rock
@@ -584,9 +473,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 16
   - ID#: 184683593728
     NameComponent:
       name: Rock
@@ -599,9 +485,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 18
   - ID#: 188978561024
     NameComponent:
       name: Rock
@@ -614,9 +497,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 18
   - ID#: 193273528320
     NameComponent:
       name: Rock
@@ -629,9 +509,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 18
   - ID#: 197568495616
     NameComponent:
       name: Rock
@@ -644,9 +521,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 18
   - ID#: 201863462912
     NameComponent:
       name: Rock
@@ -659,9 +533,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 18
   - ID#: 206158430208
     NameComponent:
       name: Rock
@@ -674,9 +545,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 18
   - ID#: 210453397504
     NameComponent:
       name: Rock
@@ -689,9 +557,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 17
   - ID#: 214748364800
     NameComponent:
       name: Rock
@@ -704,9 +569,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 16
   - ID#: 219043332096
     NameComponent:
       name: Rock
@@ -719,9 +581,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 16
   - ID#: 223338299392
     NameComponent:
       name: Rock
@@ -734,9 +593,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 16
   - ID#: 227633266688
     NameComponent:
       name: Rock
@@ -749,9 +605,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 16
   - ID#: 231928233984
     NameComponent:
       name: Rock
@@ -764,9 +617,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 16
   - ID#: 236223201280
     NameComponent:
       name: Rock
@@ -779,9 +629,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 15
   - ID#: 240518168576
     NameComponent:
       name: Rock
@@ -794,9 +641,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 14
   - ID#: 244813135872
     NameComponent:
       name: Rock
@@ -809,9 +653,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 13
   - ID#: 249108103168
     NameComponent:
       name: Rock
@@ -824,9 +665,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 12
   - ID#: 253403070464
     NameComponent:
       name: Rock
@@ -839,9 +677,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 12
   - ID#: 257698037760
     NameComponent:
       name: Rock
@@ -854,9 +689,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 12
   - ID#: 261993005056
     NameComponent:
       name: Rock
@@ -869,9 +701,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 12
   - ID#: 266287972352
     NameComponent:
       name: Rock
@@ -884,9 +713,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 12
   - ID#: 270582939648
     NameComponent:
       name: Rock
@@ -899,9 +725,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 12
   - ID#: 274877906944
     NameComponent:
       name: Rock
@@ -914,9 +737,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 14
   - ID#: 279172874240
     NameComponent:
       name: Rock
@@ -929,9 +749,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 14
   - ID#: 283467841536
     NameComponent:
       name: Rock
@@ -944,9 +761,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 14
   - ID#: 287762808832
     NameComponent:
       name: Mithril
@@ -959,9 +773,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -3
   - ID#: 292057776128
     NameComponent:
       name: Mithril
@@ -974,9 +785,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 7
   - ID#: 296352743424
     NameComponent:
       name: Rock
@@ -989,9 +797,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 15
   - ID#: 300647710720
     NameComponent:
       name: Rock
@@ -1004,9 +809,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 14
   - ID#: 304942678016
     NameComponent:
       name: Tree
@@ -1019,9 +821,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -1
   - ID#: 309237645312
     NameComponent:
       name: Mithril
@@ -1034,9 +833,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: 3
   - ID#: 313532612608
     NameComponent:
       name: Worker
@@ -1085,9 +881,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -13
   - ID#: 330712481792
     NameComponent:
       name: Rock
@@ -1100,9 +893,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -14
   - ID#: 335007449088
     NameComponent:
       name: Rock
@@ -1115,9 +905,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -23
   - ID#: 339302416384
     NameComponent:
       name: Rock
@@ -1130,9 +917,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -22
   - ID#: 343597383680
     NameComponent:
       name: Rock
@@ -1145,9 +929,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -21
   - ID#: 347892350976
     NameComponent:
       name: Rock
@@ -1160,9 +941,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -20
   - ID#: 352187318272
     NameComponent:
       name: Rock
@@ -1175,9 +953,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -19
   - ID#: 356482285568
     NameComponent:
       name: Rock
@@ -1190,9 +965,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -18
   - ID#: 360777252864
     NameComponent:
       name: Rock
@@ -1205,9 +977,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -17
   - ID#: 365072220160
     NameComponent:
       name: Rock
@@ -1220,9 +989,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -16
   - ID#: 369367187456
     NameComponent:
       name: Rock
@@ -1235,9 +1001,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -15
   - ID#: 373662154752
     NameComponent:
       name: Rock
@@ -1250,9 +1013,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -14
   - ID#: 377957122048
     NameComponent:
       name: Rock
@@ -1265,9 +1025,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -13
   - ID#: 382252089344
     NameComponent:
       name: Rock
@@ -1280,9 +1037,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -12
   - ID#: 386547056640
     NameComponent:
       name: Rock
@@ -1295,9 +1049,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -11
   - ID#: 390842023936
     NameComponent:
       name: Rock
@@ -1310,9 +1061,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -10
   - ID#: 395136991232
     NameComponent:
       name: Rock
@@ -1325,9 +1073,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -9
   - ID#: 399431958528
     NameComponent:
       name: Rock
@@ -1340,9 +1085,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -8
   - ID#: 403726925824
     NameComponent:
       name: Rock
@@ -1355,9 +1097,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -7
   - ID#: 408021893120
     NameComponent:
       name: Rock
@@ -1370,9 +1109,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -6
   - ID#: 412316860416
     NameComponent:
       name: Rock
@@ -1385,9 +1121,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -5
   - ID#: 416611827712
     NameComponent:
       name: Rock
@@ -1400,9 +1133,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -4
   - ID#: 420906795008
     NameComponent:
       name: Rock
@@ -1415,9 +1145,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -3
   - ID#: 425201762304
     NameComponent:
       name: Rock
@@ -1430,9 +1157,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -2
   - ID#: 429496729600
     NameComponent:
       name: Rock
@@ -1445,9 +1169,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: -1
   - ID#: 433791696896
     NameComponent:
       name: Rock
@@ -1460,9 +1181,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 0
   - ID#: 438086664192
     NameComponent:
       name: Rock
@@ -1475,9 +1193,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 1
   - ID#: 442381631488
     NameComponent:
       name: Rock
@@ -1490,9 +1205,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 2
   - ID#: 446676598784
     NameComponent:
       name: Rock
@@ -1505,9 +1217,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 3
   - ID#: 450971566080
     NameComponent:
       name: Rock
@@ -1520,9 +1229,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 4
   - ID#: 455266533376
     NameComponent:
       name: Rock
@@ -1535,9 +1241,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 5
   - ID#: 459561500672
     NameComponent:
       name: Rock
@@ -1550,9 +1253,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 6
   - ID#: 463856467968
     NameComponent:
       name: Rock
@@ -1565,9 +1265,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 7
   - ID#: 468151435264
     NameComponent:
       name: Rock
@@ -1580,9 +1277,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 8
   - ID#: 472446402560
     NameComponent:
       name: Rock
@@ -1595,9 +1289,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 9
   - ID#: 476741369856
     NameComponent:
       name: Rock
@@ -1610,9 +1301,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 10
   - ID#: 481036337152
     NameComponent:
       name: Rock
@@ -1625,9 +1313,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 11
   - ID#: 485331304448
     NameComponent:
       name: Rock
@@ -1640,9 +1325,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 12
   - ID#: 489626271744
     NameComponent:
       name: Rock
@@ -1655,9 +1337,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 13
   - ID#: 493921239040
     NameComponent:
       name: Rock
@@ -1670,9 +1349,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 14
   - ID#: 498216206336
     NameComponent:
       name: Rock
@@ -1685,9 +1361,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 15
   - ID#: 502511173632
     NameComponent:
       name: Rock
@@ -1700,9 +1373,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 16
   - ID#: 506806140928
     NameComponent:
       name: Rock
@@ -1715,9 +1385,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 17
   - ID#: 511101108224
     NameComponent:
       name: Rock
@@ -1730,9 +1397,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 18
   - ID#: 515396075520
     NameComponent:
       name: Rock
@@ -1745,9 +1409,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 19
   - ID#: 519691042816
     NameComponent:
       name: Rock
@@ -1760,9 +1421,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 20
   - ID#: 523986010112
     NameComponent:
       name: Rock
@@ -1775,9 +1433,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 21
   - ID#: 528280977408
     NameComponent:
       name: Rock
@@ -1790,9 +1445,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -25
-      z: 22
   - ID#: 532575944704
     NameComponent:
       name: Mithril
@@ -1805,9 +1457,6 @@ Entities:
       material: Resources/Materials/mithril.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 7
   - ID#: 536870912000
     NameComponent:
       name: ::TileMap
@@ -2852,9 +2501,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -25
   - ID#: 545460846592
     NameComponent:
       name: Rock
@@ -2867,9 +2513,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -24
   - ID#: 549755813888
     NameComponent:
       name: Rock
@@ -2882,9 +2525,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -23
   - ID#: 554050781184
     NameComponent:
       name: Rock
@@ -2897,9 +2537,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -22
   - ID#: 558345748480
     NameComponent:
       name: Rock
@@ -2912,9 +2549,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -21
   - ID#: 562640715776
     NameComponent:
       name: Rock
@@ -2927,9 +2561,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -20
   - ID#: 566935683072
     NameComponent:
       name: Rock
@@ -2942,9 +2573,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -19
   - ID#: 571230650368
     NameComponent:
       name: Rock
@@ -2957,9 +2585,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -18
   - ID#: 575525617664
     NameComponent:
       name: Rock
@@ -2972,9 +2597,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -17
   - ID#: 579820584960
     NameComponent:
       name: Rock
@@ -2987,9 +2609,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -16
   - ID#: 584115552256
     NameComponent:
       name: Rock
@@ -3002,9 +2621,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -15
   - ID#: 588410519552
     NameComponent:
       name: Rock
@@ -3017,9 +2633,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -14
   - ID#: 592705486848
     NameComponent:
       name: Rock
@@ -3032,9 +2645,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -13
   - ID#: 597000454144
     NameComponent:
       name: Rock
@@ -3047,9 +2657,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -12
   - ID#: 601295421440
     NameComponent:
       name: Rock
@@ -3062,9 +2669,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -11
   - ID#: 605590388736
     NameComponent:
       name: Rock
@@ -3077,9 +2681,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -10
   - ID#: 609885356032
     NameComponent:
       name: Rock
@@ -3092,9 +2693,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -9
   - ID#: 614180323328
     NameComponent:
       name: Rock
@@ -3107,9 +2705,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -8
   - ID#: 618475290624
     NameComponent:
       name: Rock
@@ -3122,9 +2717,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -7
   - ID#: 622770257920
     NameComponent:
       name: Rock
@@ -3137,9 +2729,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -6
   - ID#: 627065225216
     NameComponent:
       name: Rock
@@ -3152,9 +2741,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -5
   - ID#: 631360192512
     NameComponent:
       name: Rock
@@ -3167,9 +2753,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -4
   - ID#: 635655159808
     NameComponent:
       name: Rock
@@ -3182,9 +2765,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -3
   - ID#: 639950127104
     NameComponent:
       name: Rock
@@ -3197,9 +2777,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -2
   - ID#: 644245094400
     NameComponent:
       name: Rock
@@ -3212,9 +2789,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: -1
   - ID#: 648540061696
     NameComponent:
       name: Rock
@@ -3227,9 +2801,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 0
   - ID#: 652835028992
     NameComponent:
       name: Rock
@@ -3242,9 +2813,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 1
   - ID#: 657129996288
     NameComponent:
       name: Rock
@@ -3257,9 +2825,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 2
   - ID#: 661424963584
     NameComponent:
       name: Rock
@@ -3272,9 +2837,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 3
   - ID#: 665719930880
     NameComponent:
       name: Rock
@@ -3287,9 +2849,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 4
   - ID#: 670014898176
     NameComponent:
       name: Rock
@@ -3302,9 +2861,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 5
   - ID#: 674309865472
     NameComponent:
       name: Rock
@@ -3317,9 +2873,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 6
   - ID#: 678604832768
     NameComponent:
       name: Rock
@@ -3332,9 +2885,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 7
   - ID#: 682899800064
     NameComponent:
       name: Rock
@@ -3347,9 +2897,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 8
   - ID#: 687194767360
     NameComponent:
       name: Rock
@@ -3362,9 +2909,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 9
   - ID#: 691489734656
     NameComponent:
       name: Rock
@@ -3377,9 +2921,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 10
   - ID#: 695784701952
     NameComponent:
       name: Rock
@@ -3392,9 +2933,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 11
   - ID#: 700079669248
     NameComponent:
       name: Rock
@@ -3407,9 +2945,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 12
   - ID#: 704374636544
     NameComponent:
       name: Rock
@@ -3422,9 +2957,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 13
   - ID#: 708669603840
     NameComponent:
       name: Rock
@@ -3437,9 +2969,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 16
   - ID#: 712964571136
     NameComponent:
       name: Rock
@@ -3452,9 +2981,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 17
   - ID#: 717259538432
     NameComponent:
       name: Rock
@@ -3467,9 +2993,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 18
   - ID#: 721554505728
     NameComponent:
       name: Rock
@@ -3482,9 +3005,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 19
   - ID#: 725849473024
     NameComponent:
       name: Rock
@@ -3497,9 +3017,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 20
   - ID#: 730144440320
     NameComponent:
       name: Rock
@@ -3512,9 +3029,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 21
   - ID#: 734439407616
     NameComponent:
       name: Rock
@@ -3527,9 +3041,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 22
   - ID#: 738734374912
     NameComponent:
       name: Rock
@@ -3542,9 +3053,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 23
   - ID#: 743029342208
     NameComponent:
       name: Rock
@@ -3557,9 +3065,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -24
-      z: 24
   - ID#: 747324309504
     NameComponent:
       name: Rock
@@ -3572,9 +3077,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -25
   - ID#: 751619276800
     NameComponent:
       name: Rock
@@ -3587,9 +3089,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -24
   - ID#: 755914244096
     NameComponent:
       name: Rock
@@ -3602,9 +3101,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -23
   - ID#: 760209211392
     NameComponent:
       name: Rock
@@ -3617,9 +3113,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -22
   - ID#: 764504178688
     NameComponent:
       name: Rock
@@ -3632,9 +3125,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -21
   - ID#: 768799145984
     NameComponent:
       name: Rock
@@ -3647,9 +3137,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -20
   - ID#: 773094113280
     NameComponent:
       name: Rock
@@ -3662,9 +3149,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -19
   - ID#: 777389080576
     NameComponent:
       name: Rock
@@ -3677,9 +3161,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -18
   - ID#: 781684047872
     NameComponent:
       name: Rock
@@ -3692,9 +3173,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -17
   - ID#: 785979015168
     NameComponent:
       name: Rock
@@ -3707,9 +3185,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -16
   - ID#: 790273982464
     NameComponent:
       name: Rock
@@ -3722,9 +3197,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -15
   - ID#: 794568949760
     NameComponent:
       name: Rock
@@ -3737,9 +3209,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -14
   - ID#: 798863917056
     NameComponent:
       name: Rock
@@ -3752,9 +3221,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -13
   - ID#: 803158884352
     NameComponent:
       name: Rock
@@ -3767,9 +3233,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -12
   - ID#: 807453851648
     NameComponent:
       name: Rock
@@ -3782,9 +3245,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -6
   - ID#: 811748818944
     NameComponent:
       name: Rock
@@ -3797,9 +3257,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -5
   - ID#: 816043786240
     NameComponent:
       name: Rock
@@ -3812,9 +3269,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -4
   - ID#: 820338753536
     NameComponent:
       name: Rock
@@ -3827,9 +3281,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -3
   - ID#: 824633720832
     NameComponent:
       name: Rock
@@ -3842,9 +3293,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -2
   - ID#: 828928688128
     NameComponent:
       name: Rock
@@ -3857,9 +3305,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: -1
   - ID#: 833223655424
     NameComponent:
       name: Rock
@@ -3872,9 +3317,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 0
   - ID#: 837518622720
     NameComponent:
       name: Rock
@@ -3887,9 +3329,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 1
   - ID#: 841813590016
     NameComponent:
       name: Rock
@@ -3902,9 +3341,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 2
   - ID#: 846108557312
     NameComponent:
       name: Rock
@@ -3917,9 +3353,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 3
   - ID#: 850403524608
     NameComponent:
       name: Rock
@@ -3932,9 +3365,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 4
   - ID#: 854698491904
     NameComponent:
       name: Rock
@@ -3947,9 +3377,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 5
   - ID#: 858993459200
     NameComponent:
       name: Rock
@@ -3962,9 +3389,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 6
   - ID#: 863288426496
     NameComponent:
       name: Rock
@@ -3977,9 +3401,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 7
   - ID#: 867583393792
     NameComponent:
       name: Rock
@@ -3992,9 +3413,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 8
   - ID#: 871878361088
     NameComponent:
       name: Rock
@@ -4007,9 +3425,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 9
   - ID#: 876173328384
     NameComponent:
       name: Rock
@@ -4022,9 +3437,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 10
   - ID#: 880468295680
     NameComponent:
       name: Rock
@@ -4037,9 +3449,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 11
   - ID#: 884763262976
     NameComponent:
       name: Rock
@@ -4052,9 +3461,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 17
   - ID#: 889058230272
     NameComponent:
       name: Rock
@@ -4067,9 +3473,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 18
   - ID#: 893353197568
     NameComponent:
       name: Rock
@@ -4082,9 +3485,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 19
   - ID#: 897648164864
     NameComponent:
       name: Rock
@@ -4097,9 +3497,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 20
   - ID#: 901943132160
     NameComponent:
       name: Rock
@@ -4112,9 +3509,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 21
   - ID#: 906238099456
     NameComponent:
       name: Rock
@@ -4127,9 +3521,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 22
   - ID#: 910533066752
     NameComponent:
       name: Rock
@@ -4142,9 +3533,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 23
   - ID#: 914828034048
     NameComponent:
       name: Rock
@@ -4157,9 +3545,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -23
-      z: 24
   - ID#: 919123001344
     NameComponent:
       name: Rock
@@ -4172,9 +3557,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -25
   - ID#: 923417968640
     NameComponent:
       name: Rock
@@ -4187,9 +3569,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -24
   - ID#: 927712935936
     NameComponent:
       name: Rock
@@ -4202,9 +3581,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -23
   - ID#: 932007903232
     NameComponent:
       name: Rock
@@ -4217,9 +3593,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -22
   - ID#: 936302870528
     NameComponent:
       name: Rock
@@ -4232,9 +3605,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -21
   - ID#: 940597837824
     NameComponent:
       name: Rock
@@ -4247,9 +3617,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -20
   - ID#: 944892805120
     NameComponent:
       name: Rock
@@ -4262,9 +3629,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -19
   - ID#: 949187772416
     NameComponent:
       name: Rock
@@ -4277,9 +3641,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -18
   - ID#: 953482739712
     NameComponent:
       name: Rock
@@ -4292,9 +3653,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -17
   - ID#: 957777707008
     NameComponent:
       name: Rock
@@ -4307,9 +3665,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -16
   - ID#: 962072674304
     NameComponent:
       name: Rock
@@ -4322,9 +3677,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -2
   - ID#: 966367641600
     NameComponent:
       name: Rock
@@ -4337,9 +3689,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: -1
   - ID#: 970662608896
     NameComponent:
       name: Rock
@@ -4352,9 +3701,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 0
   - ID#: 974957576192
     NameComponent:
       name: Rock
@@ -4367,9 +3713,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 1
   - ID#: 979252543488
     NameComponent:
       name: Rock
@@ -4382,9 +3725,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 3
   - ID#: 983547510784
     NameComponent:
       name: Rock
@@ -4397,9 +3737,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 4
   - ID#: 987842478080
     NameComponent:
       name: Rock
@@ -4412,9 +3749,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 5
   - ID#: 992137445376
     NameComponent:
       name: Rock
@@ -4427,9 +3761,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 6
   - ID#: 996432412672
     NameComponent:
       name: Rock
@@ -4442,9 +3773,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 8
   - ID#: 1000727379968
     NameComponent:
       name: Rock
@@ -4457,9 +3785,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 9
   - ID#: 1005022347264
     NameComponent:
       name: Rock
@@ -4472,9 +3797,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 20
   - ID#: 1009317314560
     NameComponent:
       name: Rock
@@ -4487,9 +3809,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 21
   - ID#: 1013612281856
     NameComponent:
       name: Rock
@@ -4502,9 +3821,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 22
   - ID#: 1017907249152
     NameComponent:
       name: Rock
@@ -4517,9 +3833,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 23
   - ID#: 1022202216448
     NameComponent:
       name: Rock
@@ -4532,9 +3845,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -22
-      z: 24
   - ID#: 1026497183744
     NameComponent:
       name: Rock
@@ -4547,9 +3857,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: -25
   - ID#: 1030792151040
     NameComponent:
       name: Rock
@@ -4562,9 +3869,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: -24
   - ID#: 1035087118336
     NameComponent:
       name: Rock
@@ -4577,9 +3881,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: -23
   - ID#: 1039382085632
     NameComponent:
       name: Rock
@@ -4592,9 +3893,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: -22
   - ID#: 1043677052928
     NameComponent:
       name: Rock
@@ -4607,9 +3905,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: 22
   - ID#: 1047972020224
     NameComponent:
       name: Rock
@@ -4622,9 +3917,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: 23
   - ID#: 1052266987520
     NameComponent:
       name: Rock
@@ -4637,9 +3929,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -21
-      z: 24
   - ID#: 1056561954816
     NameComponent:
       name: Rock
@@ -4652,9 +3941,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -25
   - ID#: 1060856922112
     NameComponent:
       name: Rock
@@ -4667,9 +3953,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -24
   - ID#: 1065151889408
     NameComponent:
       name: Rock
@@ -4682,9 +3965,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -23
   - ID#: 1069446856704
     NameComponent:
       name: Rock
@@ -4697,9 +3977,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -22
   - ID#: 1073741824000
     NameComponent:
       name: Tree
@@ -4712,9 +3989,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -7
   - ID#: 1078036791296
     NameComponent:
       name: Rock
@@ -4727,9 +4001,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -6
   - ID#: 1082331758592
     NameComponent:
       name: Rock
@@ -4742,9 +4013,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: -5
   - ID#: 1086626725888
     NameComponent:
       name: Tree
@@ -4757,9 +4025,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 3
   - ID#: 1090921693184
     NameComponent:
       name: Mithril
@@ -4772,9 +4037,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 9
   - ID#: 1095216660480
     NameComponent:
       name: Mithril
@@ -4787,9 +4049,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 10
   - ID#: 1099511627776
     NameComponent:
       name: Tree
@@ -4802,9 +4061,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 11
   - ID#: 1103806595072
     NameComponent:
       name: Rock
@@ -4817,9 +4073,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 21
   - ID#: 1108101562368
     NameComponent:
       name: Rock
@@ -4832,9 +4085,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 22
   - ID#: 1112396529664
     NameComponent:
       name: Rock
@@ -4847,9 +4097,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 23
   - ID#: 1116691496960
     NameComponent:
       name: Rock
@@ -4862,9 +4109,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -20
-      z: 24
   - ID#: 1120986464256
     NameComponent:
       name: Rock
@@ -4877,9 +4121,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -25
   - ID#: 1125281431552
     NameComponent:
       name: Rock
@@ -4892,9 +4133,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -24
   - ID#: 1129576398848
     NameComponent:
       name: Rock
@@ -4907,9 +4145,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -23
   - ID#: 1133871366144
     NameComponent:
       name: Rock
@@ -4922,9 +4157,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -22
   - ID#: 1138166333440
     NameComponent:
       name: Rock
@@ -4937,9 +4169,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -21
   - ID#: 1142461300736
     NameComponent:
       name: Rock
@@ -4952,9 +4181,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -8
   - ID#: 1146756268032
     NameComponent:
       name: Rock
@@ -4967,9 +4193,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -7
   - ID#: 1151051235328
     NameComponent:
       name: Rock
@@ -4982,9 +4205,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -6
   - ID#: 1155346202624
     NameComponent:
       name: Tree
@@ -4997,9 +4217,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: -1
   - ID#: 1159641169920
     NameComponent:
       name: Rock
@@ -5012,9 +4229,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 2
   - ID#: 1163936137216
     NameComponent:
       name: Rock
@@ -5027,9 +4241,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 3
   - ID#: 1168231104512
     NameComponent:
       name: Rock
@@ -5042,9 +4253,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 4
   - ID#: 1172526071808
     NameComponent:
       name: Mithril
@@ -5057,9 +4265,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 5
   - ID#: 1176821039104
     NameComponent:
       name: Rock
@@ -5072,9 +4277,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 6
   - ID#: 1181116006400
     NameComponent:
       name: Rock
@@ -5087,9 +4289,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 7
   - ID#: 1185410973696
     NameComponent:
       name: Mithril
@@ -5102,9 +4301,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 8
   - ID#: 1189705940992
     NameComponent:
       name: Rock
@@ -5117,9 +4313,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 9
   - ID#: 1194000908288
     NameComponent:
       name: Mithril
@@ -5132,9 +4325,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 13
   - ID#: 1198295875584
     NameComponent:
       name: Rock
@@ -5147,9 +4337,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 21
   - ID#: 1202590842880
     NameComponent:
       name: Rock
@@ -5162,9 +4349,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 22
   - ID#: 1206885810176
     NameComponent:
       name: Rock
@@ -5177,9 +4361,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 23
   - ID#: 1211180777472
     NameComponent:
       name: Rock
@@ -5192,9 +4373,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -19
-      z: 24
   - ID#: 1215475744768
     NameComponent:
       name: Rock
@@ -5207,9 +4385,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -25
   - ID#: 1219770712064
     NameComponent:
       name: Rock
@@ -5222,9 +4397,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -24
   - ID#: 1224065679360
     NameComponent:
       name: Rock
@@ -5237,9 +4409,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -23
   - ID#: 1228360646656
     NameComponent:
       name: Rock
@@ -5252,9 +4421,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -22
   - ID#: 1232655613952
     NameComponent:
       name: Rock
@@ -5267,9 +4433,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -21
   - ID#: 1236950581248
     NameComponent:
       name: Rock
@@ -5282,9 +4445,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -4
   - ID#: 1241245548544
     NameComponent:
       name: Rock
@@ -5297,9 +4457,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -3
   - ID#: 1245540515840
     NameComponent:
       name: Rock
@@ -5312,9 +4469,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -2
   - ID#: 1249835483136
     NameComponent:
       name: Rock
@@ -5327,9 +4481,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: -1
   - ID#: 1254130450432
     NameComponent:
       name: Rock
@@ -5342,9 +4493,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 0
   - ID#: 1258425417728
     NameComponent:
       name: Rock
@@ -5357,9 +4505,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 1
   - ID#: 1262720385024
     NameComponent:
       name: Mithril
@@ -5372,9 +4517,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 2
   - ID#: 1267015352320
     NameComponent:
       name: Rock
@@ -5387,9 +4529,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 3
   - ID#: 1271310319616
     NameComponent:
       name: Rock
@@ -5402,9 +4541,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 4
   - ID#: 1275605286912
     NameComponent:
       name: Rock
@@ -5417,9 +4553,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 5
   - ID#: 1279900254208
     NameComponent:
       name: Mithril
@@ -5432,9 +4565,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 6
   - ID#: 1284195221504
     NameComponent:
       name: Rock
@@ -5447,9 +4577,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 7
   - ID#: 1288490188800
     NameComponent:
       name: Mithril
@@ -5462,9 +4589,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 10
   - ID#: 1292785156096
     NameComponent:
       name: Rock
@@ -5477,9 +4601,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 11
   - ID#: 1297080123392
     NameComponent:
       name: Tree
@@ -5492,9 +4613,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 15
   - ID#: 1301375090688
     NameComponent:
       name: Rock
@@ -5507,9 +4625,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 22
   - ID#: 1305670057984
     NameComponent:
       name: Rock
@@ -5522,9 +4637,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 23
   - ID#: 1309965025280
     NameComponent:
       name: Rock
@@ -5537,9 +4649,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -18
-      z: 24
   - ID#: 1314259992576
     NameComponent:
       name: Rock
@@ -5552,9 +4661,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -25
   - ID#: 1318554959872
     NameComponent:
       name: Rock
@@ -5567,9 +4673,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -24
   - ID#: 1322849927168
     NameComponent:
       name: Rock
@@ -5582,9 +4685,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -23
   - ID#: 1327144894464
     NameComponent:
       name: Rock
@@ -5597,9 +4697,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -22
   - ID#: 1331439861760
     NameComponent:
       name: Rock
@@ -5612,9 +4709,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -21
   - ID#: 1335734829056
     NameComponent:
       name: Tree
@@ -5627,9 +4721,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -7
   - ID#: 1340029796352
     NameComponent:
       name: Rock
@@ -5642,9 +4733,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -6
   - ID#: 1344324763648
     NameComponent:
       name: Rock
@@ -5657,9 +4745,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -5
   - ID#: 1348619730944
     NameComponent:
       name: Rock
@@ -5672,9 +4757,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -4
   - ID#: 1352914698240
     NameComponent:
       name: Rock
@@ -5687,9 +4769,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -3
   - ID#: 1357209665536
     NameComponent:
       name: Rock
@@ -5702,9 +4781,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -2
   - ID#: 1361504632832
     NameComponent:
       name: Rock
@@ -5717,9 +4793,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: -1
   - ID#: 1365799600128
     NameComponent:
       name: Rock
@@ -5732,9 +4805,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 0
   - ID#: 1370094567424
     NameComponent:
       name: Rock
@@ -5747,9 +4817,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 1
   - ID#: 1374389534720
     NameComponent:
       name: Rock
@@ -5762,9 +4829,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 2
   - ID#: 1378684502016
     NameComponent:
       name: Rock
@@ -5777,9 +4841,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 3
   - ID#: 1382979469312
     NameComponent:
       name: Rock
@@ -5792,9 +4853,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 4
   - ID#: 1387274436608
     NameComponent:
       name: Tree
@@ -5807,9 +4865,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 9
   - ID#: 1391569403904
     NameComponent:
       name: Rock
@@ -5822,9 +4877,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 21
   - ID#: 1395864371200
     NameComponent:
       name: Rock
@@ -5837,9 +4889,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 22
   - ID#: 1400159338496
     NameComponent:
       name: Rock
@@ -5852,9 +4901,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 23
   - ID#: 1404454305792
     NameComponent:
       name: Rock
@@ -5867,9 +4913,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -17
-      z: 24
   - ID#: 1408749273088
     NameComponent:
       name: Rock
@@ -5882,9 +4925,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -25
   - ID#: 1413044240384
     NameComponent:
       name: Rock
@@ -5897,9 +4937,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -24
   - ID#: 1417339207680
     NameComponent:
       name: Rock
@@ -5912,9 +4949,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -23
   - ID#: 1421634174976
     NameComponent:
       name: Rock
@@ -5927,9 +4961,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -22
   - ID#: 1425929142272
     NameComponent:
       name: Rock
@@ -5942,9 +4973,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -21
   - ID#: 1430224109568
     NameComponent:
       name: Tree
@@ -5957,9 +4985,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -16
   - ID#: 1434519076864
     NameComponent:
       name: Rock
@@ -5972,9 +4997,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -9
   - ID#: 1438814044160
     NameComponent:
       name: Rock
@@ -5987,9 +5009,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -8
   - ID#: 1443109011456
     NameComponent:
       name: Rock
@@ -6002,9 +5021,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -7
   - ID#: 1447403978752
     NameComponent:
       name: Rock
@@ -6017,9 +5033,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -6
   - ID#: 1451698946048
     NameComponent:
       name: Rock
@@ -6032,9 +5045,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -5
   - ID#: 1455993913344
     NameComponent:
       name: Rock
@@ -6047,9 +5057,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -4
   - ID#: 1460288880640
     NameComponent:
       name: Rock
@@ -6062,9 +5069,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -3
   - ID#: 1464583847936
     NameComponent:
       name: Rock
@@ -6077,9 +5081,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -2
   - ID#: 1468878815232
     NameComponent:
       name: Rock
@@ -6092,9 +5093,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: -1
   - ID#: 1473173782528
     NameComponent:
       name: Rock
@@ -6107,9 +5105,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 0
   - ID#: 1477468749824
     NameComponent:
       name: Rock
@@ -6122,9 +5117,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 4
   - ID#: 1481763717120
     NameComponent:
       name: Rock
@@ -6137,9 +5129,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 5
   - ID#: 1486058684416
     NameComponent:
       name: Rock
@@ -6152,9 +5141,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 22
   - ID#: 1490353651712
     NameComponent:
       name: Rock
@@ -6167,9 +5153,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 23
   - ID#: 1494648619008
     NameComponent:
       name: Rock
@@ -6182,9 +5165,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -16
-      z: 24
   - ID#: 1498943586304
     NameComponent:
       name: Rock
@@ -6197,9 +5177,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -25
   - ID#: 1503238553600
     NameComponent:
       name: Rock
@@ -6212,9 +5189,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -24
   - ID#: 1507533520896
     NameComponent:
       name: Rock
@@ -6227,9 +5201,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -23
   - ID#: 1511828488192
     NameComponent:
       name: Rock
@@ -6242,9 +5213,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -22
   - ID#: 1516123455488
     NameComponent:
       name: Rock
@@ -6257,9 +5225,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -21
   - ID#: 1520418422784
     NameComponent:
       name: Tree
@@ -6272,9 +5237,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -18
   - ID#: 1524713390080
     NameComponent:
       name: Iron
@@ -6287,9 +5249,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -17
   - ID#: 1529008357376
     NameComponent:
       name: Rock
@@ -6302,9 +5261,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -6
   - ID#: 1533303324672
     NameComponent:
       name: Rock
@@ -6317,9 +5273,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -5
   - ID#: 1537598291968
     NameComponent:
       name: Rock
@@ -6332,9 +5285,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: -4
   - ID#: 1541893259264
     NameComponent:
       name: Rock
@@ -6347,9 +5297,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 3
   - ID#: 1546188226560
     NameComponent:
       name: Rock
@@ -6362,9 +5309,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 4
   - ID#: 1550483193856
     NameComponent:
       name: Rock
@@ -6377,9 +5321,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 22
   - ID#: 1554778161152
     NameComponent:
       name: Rock
@@ -6392,9 +5333,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 23
   - ID#: 1559073128448
     NameComponent:
       name: Rock
@@ -6407,9 +5345,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -15
-      z: 24
   - ID#: 1563368095744
     NameComponent:
       name: Rock
@@ -6422,9 +5357,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -25
   - ID#: 1567663063040
     NameComponent:
       name: Rock
@@ -6437,9 +5369,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -24
   - ID#: 1571958030336
     NameComponent:
       name: Rock
@@ -6452,9 +5381,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -23
   - ID#: 1576252997632
     NameComponent:
       name: Rock
@@ -6467,9 +5393,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -22
   - ID#: 1580547964928
     NameComponent:
       name: Rock
@@ -6482,9 +5405,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -21
   - ID#: 1584842932224
     NameComponent:
       name: Iron
@@ -6497,9 +5417,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -13
   - ID#: 1589137899520
     NameComponent:
       name: Rock
@@ -6512,9 +5429,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -12
   - ID#: 1593432866816
     NameComponent:
       name: Rock
@@ -6527,9 +5441,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -11
   - ID#: 1597727834112
     NameComponent:
       name: Rock
@@ -6542,9 +5453,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -10
   - ID#: 1602022801408
     NameComponent:
       name: Rock
@@ -6557,9 +5465,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: -9
   - ID#: 1606317768704
     NameComponent:
       name: Rock
@@ -6572,9 +5477,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 2
   - ID#: 1610612736000
     NameComponent:
       name: Rock
@@ -6587,9 +5489,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 3
   - ID#: 1614907703296
     NameComponent:
       name: Rock
@@ -6602,9 +5501,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 4
   - ID#: 1619202670592
     NameComponent:
       name: Rock
@@ -6617,9 +5513,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 5
   - ID#: 1623497637888
     NameComponent:
       name: Rock
@@ -6632,9 +5525,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 6
   - ID#: 1627792605184
     NameComponent:
       name: Rock
@@ -6647,9 +5537,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 18
   - ID#: 1632087572480
     NameComponent:
       name: Rock
@@ -6662,9 +5549,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -14
-      z: 24
   - ID#: 1636382539776
     NameComponent:
       name: Rock
@@ -6677,9 +5561,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -25
   - ID#: 1640677507072
     NameComponent:
       name: Rock
@@ -6692,9 +5573,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -24
   - ID#: 1644972474368
     NameComponent:
       name: Rock
@@ -6707,9 +5585,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -23
   - ID#: 1649267441664
     NameComponent:
       name: Rock
@@ -6722,9 +5597,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -22
   - ID#: 1653562408960
     NameComponent:
       name: Rock
@@ -6737,9 +5609,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -21
   - ID#: 1657857376256
     NameComponent:
       name: Iron
@@ -6752,9 +5621,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -16
   - ID#: 1662152343552
     NameComponent:
       name: Rock
@@ -6767,9 +5633,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -15
   - ID#: 1666447310848
     NameComponent:
       name: Rock
@@ -6782,9 +5645,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -14
   - ID#: 1670742278144
     NameComponent:
       name: Rock
@@ -6797,9 +5657,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -13
   - ID#: 1675037245440
     NameComponent:
       name: Rock
@@ -6812,9 +5669,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -12
   - ID#: 1679332212736
     NameComponent:
       name: Iron
@@ -6827,9 +5681,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -11
   - ID#: 1683627180032
     NameComponent:
       name: Tree
@@ -6842,9 +5693,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: -8
   - ID#: 1687922147328
     NameComponent:
       name: Rock
@@ -6857,9 +5705,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 2
   - ID#: 1692217114624
     NameComponent:
       name: Rock
@@ -6872,9 +5717,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 3
   - ID#: 1696512081920
     NameComponent:
       name: Rock
@@ -6887,9 +5729,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 4
   - ID#: 1700807049216
     NameComponent:
       name: Rock
@@ -6902,9 +5741,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 5
   - ID#: 1705102016512
     NameComponent:
       name: Rock
@@ -6917,9 +5753,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 6
   - ID#: 1709396983808
     NameComponent:
       name: Rock
@@ -6932,9 +5765,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 17
   - ID#: 1713691951104
     NameComponent:
       name: Rock
@@ -6947,9 +5777,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -13
-      z: 24
   - ID#: 1717986918400
     NameComponent:
       name: Rock
@@ -6962,9 +5789,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -25
   - ID#: 1722281885696
     NameComponent:
       name: Rock
@@ -6977,9 +5801,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -24
   - ID#: 1726576852992
     NameComponent:
       name: Rock
@@ -6992,9 +5813,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -23
   - ID#: 1730871820288
     NameComponent:
       name: Rock
@@ -7007,9 +5825,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -22
   - ID#: 1735166787584
     NameComponent:
       name: Rock
@@ -7022,9 +5837,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -21
   - ID#: 1739461754880
     NameComponent:
       name: Tree
@@ -7037,9 +5849,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -14
   - ID#: 1743756722176
     NameComponent:
       name: Rock
@@ -7052,9 +5861,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -13
   - ID#: 1748051689472
     NameComponent:
       name: Iron
@@ -7067,9 +5873,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: -12
   - ID#: 1752346656768
     NameComponent:
       name: Rock
@@ -7082,9 +5885,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 4
   - ID#: 1756641624064
     NameComponent:
       name: Rock
@@ -7097,9 +5897,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 5
   - ID#: 1760936591360
     NameComponent:
       name: Rock
@@ -7112,9 +5909,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 6
   - ID#: 1765231558656
     NameComponent:
       name: Rock
@@ -7127,9 +5921,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 7
   - ID#: 1769526525952
     NameComponent:
       name: Rock
@@ -7142,9 +5933,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 22
   - ID#: 1773821493248
     NameComponent:
       name: Rock
@@ -7157,9 +5945,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 16
   - ID#: 1778116460544
     NameComponent:
       name: Rock
@@ -7172,9 +5957,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -12
-      z: 24
   - ID#: 1782411427840
     NameComponent:
       name: Rock
@@ -7187,9 +5969,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -25
   - ID#: 1786706395136
     NameComponent:
       name: Rock
@@ -7202,9 +5981,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -24
   - ID#: 1791001362432
     NameComponent:
       name: Rock
@@ -7217,9 +5993,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -23
   - ID#: 1795296329728
     NameComponent:
       name: Rock
@@ -7232,9 +6005,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -22
   - ID#: 1799591297024
     NameComponent:
       name: Iron
@@ -7247,9 +6017,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -9
   - ID#: 1803886264320
     NameComponent:
       name: Tree
@@ -7262,9 +6029,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: -8
   - ID#: 1808181231616
     NameComponent:
       name: Rock
@@ -7277,9 +6041,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 4
   - ID#: 1812476198912
     NameComponent:
       name: Rock
@@ -7292,9 +6053,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 5
   - ID#: 1816771166208
     NameComponent:
       name: Rock
@@ -7307,9 +6065,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 22
   - ID#: 1821066133504
     NameComponent:
       name: Rock
@@ -7322,9 +6077,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 15
   - ID#: 1825361100800
     NameComponent:
       name: Rock
@@ -7337,9 +6089,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -11
-      z: 24
   - ID#: 1829656068096
     NameComponent:
       name: Rock
@@ -7352,9 +6101,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: -25
   - ID#: 1833951035392
     NameComponent:
       name: Rock
@@ -7367,9 +6113,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: -24
   - ID#: 1838246002688
     NameComponent:
       name: Rock
@@ -7382,9 +6125,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: -23
   - ID#: 1842540969984
     NameComponent:
       name: Rock
@@ -7397,9 +6137,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: -22
   - ID#: 1846835937280
     NameComponent:
       name: Tree
@@ -7412,9 +6149,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: -3
   - ID#: 1851130904576
     NameComponent:
       name: Tin
@@ -7427,9 +6161,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 1
   - ID#: 1855425871872
     NameComponent:
       name: Rock
@@ -7442,9 +6173,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 5
   - ID#: 1859720839168
     NameComponent:
       name: Rock
@@ -7457,9 +6185,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 22
   - ID#: 1864015806464
     NameComponent:
       name: Rock
@@ -7472,9 +6197,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 16
   - ID#: 1868310773760
     NameComponent:
       name: Rock
@@ -7487,9 +6209,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -10
-      z: 24
   - ID#: 1872605741056
     NameComponent:
       name: Rock
@@ -7502,9 +6221,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -25
   - ID#: 1876900708352
     NameComponent:
       name: Rock
@@ -7517,9 +6233,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -24
   - ID#: 1881195675648
     NameComponent:
       name: Rock
@@ -7532,9 +6245,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -23
   - ID#: 1885490642944
     NameComponent:
       name: Rock
@@ -7547,9 +6257,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -22
   - ID#: 1889785610240
     NameComponent:
       name: Tree
@@ -7562,9 +6269,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -7
   - ID#: 1894080577536
     NameComponent:
       name: Tin
@@ -7577,9 +6281,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: -1
   - ID#: 1898375544832
     NameComponent:
       name: Rock
@@ -7592,9 +6293,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 0
   - ID#: 1902670512128
     NameComponent:
       name: Rock
@@ -7607,9 +6305,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 1
   - ID#: 1906965479424
     NameComponent:
       name: Iron
@@ -7622,9 +6317,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 2
   - ID#: 1911260446720
     NameComponent:
       name: Rock
@@ -7637,9 +6329,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 5
   - ID#: 1915555414016
     NameComponent:
       name: Tin
@@ -7652,9 +6341,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 6
   - ID#: 1919850381312
     NameComponent:
       name: Rock
@@ -7667,9 +6353,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 18
   - ID#: 1924145348608
     NameComponent:
       name: Rock
@@ -7682,9 +6365,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 22
   - ID#: 1928440315904
     NameComponent:
       name: Rock
@@ -7697,9 +6377,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 14
   - ID#: 1932735283200
     NameComponent:
       name: Rock
@@ -7712,9 +6389,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -9
-      z: 24
   - ID#: 1937030250496
     NameComponent:
       name: Rock
@@ -7727,9 +6401,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -25
   - ID#: 1941325217792
     NameComponent:
       name: Rock
@@ -7742,9 +6413,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -24
   - ID#: 1945620185088
     NameComponent:
       name: Rock
@@ -7757,9 +6425,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -23
   - ID#: 1949915152384
     NameComponent:
       name: Rock
@@ -7772,9 +6437,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -22
   - ID#: 1954210119680
     NameComponent:
       name: Rock
@@ -7787,9 +6449,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -21
   - ID#: 1958505086976
     NameComponent:
       name: Tree
@@ -7802,9 +6461,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -4
   - ID#: 1962800054272
     NameComponent:
       name: Rock
@@ -7817,9 +6473,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: -1
   - ID#: 1967095021568
     NameComponent:
       name: Rock
@@ -7832,9 +6485,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 0
   - ID#: 1971389988864
     NameComponent:
       name: Iron
@@ -7847,9 +6497,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 1
   - ID#: 1975684956160
     NameComponent:
       name: Rock
@@ -7862,9 +6509,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 2
   - ID#: 1979979923456
     NameComponent:
       name: Rock
@@ -7877,9 +6521,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 3
   - ID#: 1984274890752
     NameComponent:
       name: Rock
@@ -7892,9 +6533,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 20
   - ID#: 1988569858048
     NameComponent:
       name: Rock
@@ -7907,9 +6545,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 22
   - ID#: 1992864825344
     NameComponent:
       name: Rock
@@ -7922,9 +6557,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 13
   - ID#: 1997159792640
     NameComponent:
       name: Rock
@@ -7937,9 +6569,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -8
-      z: 24
   - ID#: 2001454759936
     NameComponent:
       name: Rock
@@ -7952,9 +6581,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -25
   - ID#: 2005749727232
     NameComponent:
       name: Rock
@@ -7967,9 +6593,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -24
   - ID#: 2010044694528
     NameComponent:
       name: Rock
@@ -7982,9 +6605,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -23
   - ID#: 2014339661824
     NameComponent:
       name: Rock
@@ -7997,9 +6617,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -22
   - ID#: 2018634629120
     NameComponent:
       name: Rock
@@ -8012,9 +6629,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -21
   - ID#: 2022929596416
     NameComponent:
       name: Tin
@@ -8027,9 +6641,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -2
   - ID#: 2027224563712
     NameComponent:
       name: Rock
@@ -8042,9 +6653,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: -1
   - ID#: 2031519531008
     NameComponent:
       name: Iron
@@ -8057,9 +6665,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 0
   - ID#: 2035814498304
     NameComponent:
       name: Iron
@@ -8072,9 +6677,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 1
   - ID#: 2040109465600
     NameComponent:
       name: Iron
@@ -8087,9 +6689,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 2
   - ID#: 2044404432896
     NameComponent:
       name: Rock
@@ -8102,9 +6701,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 3
   - ID#: 2048699400192
     NameComponent:
       name: Tin
@@ -8117,9 +6713,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 4
   - ID#: 2052994367488
     NameComponent:
       name: Rock
@@ -8132,9 +6725,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 5
   - ID#: 2057289334784
     NameComponent:
       name: Rock
@@ -8147,9 +6737,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 22
   - ID#: 2061584302080
     NameComponent:
       name: Rock
@@ -8162,9 +6749,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 12
   - ID#: 2065879269376
     NameComponent:
       name: Rock
@@ -8177,9 +6761,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -7
-      z: 24
   - ID#: 2070174236672
     NameComponent:
       name: Rock
@@ -8192,9 +6773,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -25
   - ID#: 2074469203968
     NameComponent:
       name: Rock
@@ -8207,9 +6785,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -24
   - ID#: 2078764171264
     NameComponent:
       name: Rock
@@ -8222,9 +6797,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -23
   - ID#: 2083059138560
     NameComponent:
       name: Rock
@@ -8237,9 +6809,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -22
   - ID#: 2087354105856
     NameComponent:
       name: Rock
@@ -8252,9 +6821,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -21
   - ID#: 2091649073152
     NameComponent:
       name: Tree
@@ -8267,9 +6833,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -6
   - ID#: 2095944040448
     NameComponent:
       name: Rock
@@ -8282,9 +6845,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -5
   - ID#: 2100239007744
     NameComponent:
       name: Rock
@@ -8297,9 +6857,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -4
   - ID#: 2104533975040
     NameComponent:
       name: Rock
@@ -8312,9 +6869,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -3
   - ID#: 2108828942336
     NameComponent:
       name: Rock
@@ -8327,9 +6881,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -2
   - ID#: 2113123909632
     NameComponent:
       name: Rock
@@ -8342,9 +6893,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: -1
   - ID#: 2117418876928
     NameComponent:
       name: Iron
@@ -8357,9 +6905,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 0
   - ID#: 2121713844224
     NameComponent:
       name: Iron
@@ -8372,9 +6917,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 1
   - ID#: 2126008811520
     NameComponent:
       name: Rock
@@ -8387,9 +6929,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 2
   - ID#: 2130303778816
     NameComponent:
       name: Tin
@@ -8402,9 +6941,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 3
   - ID#: 2134598746112
     NameComponent:
       name: Rock
@@ -8417,9 +6953,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 4
   - ID#: 2138893713408
     NameComponent:
       name: Rock
@@ -8432,9 +6965,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 22
   - ID#: 2143188680704
     NameComponent:
       name: Rock
@@ -8447,9 +6977,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 12
   - ID#: 2147483648000
     NameComponent:
       name: Rock
@@ -8462,9 +6989,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -6
-      z: 24
   - ID#: 2151778615296
     NameComponent:
       name: Rock
@@ -8477,9 +7001,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -25
   - ID#: 2156073582592
     NameComponent:
       name: Rock
@@ -8492,9 +7013,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -24
   - ID#: 2160368549888
     NameComponent:
       name: Rock
@@ -8507,9 +7025,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -23
   - ID#: 2164663517184
     NameComponent:
       name: Rock
@@ -8522,9 +7037,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -22
   - ID#: 2168958484480
     NameComponent:
       name: Rock
@@ -8537,9 +7049,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -21
   - ID#: 2173253451776
     NameComponent:
       name: Rock
@@ -8552,9 +7061,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -2
   - ID#: 2177548419072
     NameComponent:
       name: Iron
@@ -8567,9 +7073,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -1
   - ID#: 2181843386368
     NameComponent:
       name: Iron
@@ -8582,9 +7085,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 0
   - ID#: 2186138353664
     NameComponent:
       name: Rock
@@ -8597,9 +7097,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 1
   - ID#: 2190433320960
     NameComponent:
       name: Iron
@@ -8612,9 +7109,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 2
   - ID#: 2194728288256
     NameComponent:
       name: Iron
@@ -8627,9 +7121,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 3
   - ID#: 2199023255552
     NameComponent:
       name: Rock
@@ -8642,9 +7133,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 22
   - ID#: 2203318222848
     NameComponent:
       name: Rock
@@ -8657,9 +7145,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 22
   - ID#: 2207613190144
     NameComponent:
       name: Rock
@@ -8672,9 +7157,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: 24
   - ID#: 2211908157440
     NameComponent:
       name: Rock
@@ -8687,9 +7169,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -25
   - ID#: 2216203124736
     NameComponent:
       name: Rock
@@ -8702,9 +7181,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -24
   - ID#: 2220498092032
     NameComponent:
       name: Rock
@@ -8717,9 +7193,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -23
   - ID#: 2224793059328
     NameComponent:
       name: Rock
@@ -8732,9 +7205,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -22
   - ID#: 2229088026624
     NameComponent:
       name: Rock
@@ -8747,9 +7217,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -21
   - ID#: 2233382993920
     NameComponent:
       name: Tree
@@ -8762,9 +7229,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -4
   - ID#: 2237677961216
     NameComponent:
       name: Rock
@@ -8777,9 +7241,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -1
   - ID#: 2241972928512
     NameComponent:
       name: Rock
@@ -8792,9 +7253,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 0
   - ID#: 2246267895808
     NameComponent:
       name: Rock
@@ -8807,9 +7265,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 1
   - ID#: 2250562863104
     NameComponent:
       name: Tin
@@ -8822,9 +7277,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 2
   - ID#: 2254857830400
     NameComponent:
       name: Rock
@@ -8837,9 +7289,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 22
   - ID#: 2259152797696
     NameComponent:
       name: Rock
@@ -8852,9 +7301,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 24
   - ID#: 2263447764992
     NameComponent:
       name: Rock
@@ -8867,9 +7313,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -25
   - ID#: 2267742732288
     NameComponent:
       name: Rock
@@ -8882,9 +7325,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -24
   - ID#: 2272037699584
     NameComponent:
       name: Rock
@@ -8897,9 +7337,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -23
   - ID#: 2276332666880
     NameComponent:
       name: Rock
@@ -8912,9 +7349,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -22
   - ID#: 2280627634176
     NameComponent:
       name: Rock
@@ -8927,9 +7361,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -21
   - ID#: 2284922601472
     NameComponent:
       name: Tin
@@ -8942,9 +7373,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -5
   - ID#: 2289217568768
     NameComponent:
       name: Rock
@@ -8957,9 +7385,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -4
   - ID#: 2293512536064
     NameComponent:
       name: Rock
@@ -8972,9 +7397,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -3
   - ID#: 2297807503360
     NameComponent:
       name: Tree
@@ -8987,9 +7409,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -1
   - ID#: 2302102470656
     NameComponent:
       name: Tin
@@ -9002,9 +7421,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 1
   - ID#: 2306397437952
     NameComponent:
       name: Rock
@@ -9017,9 +7433,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 23
   - ID#: 2310692405248
     NameComponent:
       name: Rock
@@ -9032,9 +7445,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: 24
   - ID#: 2314987372544
     NameComponent:
       name: Rock
@@ -9047,9 +7457,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -25
   - ID#: 2319282339840
     NameComponent:
       name: Rock
@@ -9062,9 +7469,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -24
   - ID#: 2323577307136
     NameComponent:
       name: Rock
@@ -9077,9 +7481,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -23
   - ID#: 2327872274432
     NameComponent:
       name: Rock
@@ -9092,9 +7493,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -22
   - ID#: 2332167241728
     NameComponent:
       name: Tree
@@ -9107,9 +7505,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: -6
   - ID#: 2336462209024
     NameComponent:
       name: Rock
@@ -9122,9 +7517,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: 22
   - ID#: 2340757176320
     NameComponent:
       name: Rock
@@ -9137,9 +7529,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: 23
   - ID#: 2345052143616
     NameComponent:
       name: Rock
@@ -9152,9 +7541,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -2
-      z: 24
   - ID#: 2349347110912
     NameComponent:
       name: Rock
@@ -9167,9 +7553,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: -25
   - ID#: 2353642078208
     NameComponent:
       name: Rock
@@ -9182,9 +7565,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: -24
   - ID#: 2357937045504
     NameComponent:
       name: Rock
@@ -9197,9 +7577,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: -23
   - ID#: 2362232012800
     NameComponent:
       name: Rock
@@ -9212,9 +7589,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: -22
   - ID#: 2366526980096
     NameComponent:
       name: Rock
@@ -9227,9 +7601,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: 22
   - ID#: 2370821947392
     NameComponent:
       name: Rock
@@ -9242,9 +7613,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: 23
   - ID#: 2375116914688
     NameComponent:
       name: Rock
@@ -9257,9 +7625,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -1
-      z: 24
   - ID#: 2379411881984
     NameComponent:
       name: Rock
@@ -9272,9 +7637,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -25
   - ID#: 2383706849280
     NameComponent:
       name: Rock
@@ -9287,9 +7649,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -24
   - ID#: 2388001816576
     NameComponent:
       name: Rock
@@ -9302,9 +7661,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -23
   - ID#: 2392296783872
     NameComponent:
       name: Rock
@@ -9317,9 +7673,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -22
   - ID#: 2396591751168
     NameComponent:
       name: Tree
@@ -9332,9 +7685,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -7
   - ID#: 2400886718464
     NameComponent:
       name: Rock
@@ -9347,9 +7697,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -6
   - ID#: 2405181685760
     NameComponent:
       name: Rock
@@ -9362,9 +7709,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: -5
   - ID#: 2409476653056
     NameComponent:
       name: Tree
@@ -9377,9 +7721,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 3
   - ID#: 2413771620352
     NameComponent:
       name: Mithril
@@ -9392,9 +7733,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 9
   - ID#: 2418066587648
     NameComponent:
       name: Mithril
@@ -9407,9 +7745,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 10
   - ID#: 2422361554944
     NameComponent:
       name: Tree
@@ -9422,9 +7757,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 11
   - ID#: 2426656522240
     NameComponent:
       name: Rock
@@ -9437,9 +7769,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 21
   - ID#: 2430951489536
     NameComponent:
       name: Rock
@@ -9452,9 +7781,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 22
   - ID#: 2435246456832
     NameComponent:
       name: Rock
@@ -9467,9 +7793,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 23
   - ID#: 2439541424128
     NameComponent:
       name: Rock
@@ -9482,9 +7805,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 0
-      z: 24
   - ID#: 2443836391424
     NameComponent:
       name: Rock
@@ -9497,9 +7817,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -25
   - ID#: 2448131358720
     NameComponent:
       name: Rock
@@ -9512,9 +7829,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -24
   - ID#: 2452426326016
     NameComponent:
       name: Rock
@@ -9527,9 +7841,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -23
   - ID#: 2456721293312
     NameComponent:
       name: Rock
@@ -9542,9 +7853,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -8
   - ID#: 2461016260608
     NameComponent:
       name: Rock
@@ -9557,9 +7865,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -7
   - ID#: 2465311227904
     NameComponent:
       name: Rock
@@ -9572,9 +7877,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -6
   - ID#: 2469606195200
     NameComponent:
       name: Tree
@@ -9587,9 +7889,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: -1
   - ID#: 2473901162496
     NameComponent:
       name: Rock
@@ -9602,9 +7901,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 2
   - ID#: 2478196129792
     NameComponent:
       name: Rock
@@ -9617,9 +7913,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 3
   - ID#: 2482491097088
     NameComponent:
       name: Rock
@@ -9632,9 +7925,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 4
   - ID#: 2486786064384
     NameComponent:
       name: Mithril
@@ -9647,9 +7937,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 5
   - ID#: 2491081031680
     NameComponent:
       name: Rock
@@ -9662,9 +7949,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 6
   - ID#: 2495375998976
     NameComponent:
       name: Rock
@@ -9677,9 +7961,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 7
   - ID#: 2499670966272
     NameComponent:
       name: Mithril
@@ -9692,9 +7973,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 8
   - ID#: 2503965933568
     NameComponent:
       name: Rock
@@ -9707,9 +7985,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 9
   - ID#: 2508260900864
     NameComponent:
       name: Mithril
@@ -9722,9 +7997,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 13
   - ID#: 2512555868160
     NameComponent:
       name: Rock
@@ -9737,9 +8009,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 21
   - ID#: 2516850835456
     NameComponent:
       name: Rock
@@ -9752,9 +8021,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 22
   - ID#: 2521145802752
     NameComponent:
       name: Rock
@@ -9767,9 +8033,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 23
   - ID#: 2525440770048
     NameComponent:
       name: Rock
@@ -9782,9 +8045,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 1
-      z: 24
   - ID#: 2529735737344
     NameComponent:
       name: Rock
@@ -9797,9 +8057,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -25
   - ID#: 2534030704640
     NameComponent:
       name: Rock
@@ -9812,9 +8069,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -24
   - ID#: 2538325671936
     NameComponent:
       name: Mithril
@@ -9827,9 +8081,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -4
   - ID#: 2542620639232
     NameComponent:
       name: Mithril
@@ -9842,9 +8093,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -3
   - ID#: 2546915606528
     NameComponent:
       name: Mithril
@@ -9857,9 +8105,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -2
   - ID#: 2551210573824
     NameComponent:
       name: Mithril
@@ -9872,9 +8117,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: -1
   - ID#: 2555505541120
     NameComponent:
       name: Mithril
@@ -9887,9 +8129,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 2
   - ID#: 2559800508416
     NameComponent:
       name: Rock
@@ -9902,9 +8141,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 3
   - ID#: 2564095475712
     NameComponent:
       name: Rock
@@ -9917,9 +8153,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 4
   - ID#: 2568390443008
     NameComponent:
       name: Rock
@@ -9932,9 +8165,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 5
   - ID#: 2572685410304
     NameComponent:
       name: Mithril
@@ -9947,9 +8177,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 6
   - ID#: 2576980377600
     NameComponent:
       name: Rock
@@ -9962,9 +8189,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 7
   - ID#: 2581275344896
     NameComponent:
       name: Mithril
@@ -9977,9 +8201,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 10
   - ID#: 2585570312192
     NameComponent:
       name: Rock
@@ -9992,9 +8213,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 11
   - ID#: 2589865279488
     NameComponent:
       name: Tree
@@ -10007,9 +8225,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 15
   - ID#: 2594160246784
     NameComponent:
       name: Rock
@@ -10022,9 +8237,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 22
   - ID#: 2598455214080
     NameComponent:
       name: Rock
@@ -10037,9 +8249,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 23
   - ID#: 2602750181376
     NameComponent:
       name: Rock
@@ -10052,9 +8261,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 2
-      z: 24
   - ID#: 2607045148672
     NameComponent:
       name: Rock
@@ -10067,9 +8273,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -25
   - ID#: 2611340115968
     NameComponent:
       name: Rock
@@ -10082,9 +8285,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -24
   - ID#: 2615635083264
     NameComponent:
       name: Tree
@@ -10097,9 +8297,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -7
   - ID#: 2619930050560
     NameComponent:
       name: Rock
@@ -10112,9 +8309,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -6
   - ID#: 2624225017856
     NameComponent:
       name: Mithril
@@ -10127,9 +8321,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -5
   - ID#: 2628519985152
     NameComponent:
       name: Mithril
@@ -10142,9 +8333,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -4
   - ID#: 2632814952448
     NameComponent:
       name: Mithril
@@ -10157,9 +8345,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -3
   - ID#: 2637109919744
     NameComponent:
       name: Mithril
@@ -10172,9 +8357,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -2
   - ID#: 2641404887040
     NameComponent:
       name: Mithril
@@ -10187,9 +8369,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: -1
   - ID#: 2645699854336
     NameComponent:
       name: Rock
@@ -10202,9 +8381,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 3
   - ID#: 2649994821632
     NameComponent:
       name: Rock
@@ -10217,9 +8393,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 4
   - ID#: 2654289788928
     NameComponent:
       name: Tree
@@ -10232,9 +8405,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 9
   - ID#: 2658584756224
     NameComponent:
       name: Rock
@@ -10247,9 +8417,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 21
   - ID#: 2662879723520
     NameComponent:
       name: Rock
@@ -10262,9 +8429,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 22
   - ID#: 2667174690816
     NameComponent:
       name: Rock
@@ -10277,9 +8441,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 23
   - ID#: 2671469658112
     NameComponent:
       name: Rock
@@ -10292,9 +8453,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 3
-      z: 24
   - ID#: 2675764625408
     NameComponent:
       name: Rock
@@ -10307,9 +8465,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -25
   - ID#: 2680059592704
     NameComponent:
       name: Rock
@@ -10322,9 +8477,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -24
   - ID#: 2684354560000
     NameComponent:
       name: Tree
@@ -10337,9 +8489,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -16
   - ID#: 2688649527296
     NameComponent:
       name: Tin
@@ -10352,9 +8501,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -9
   - ID#: 2692944494592
     NameComponent:
       name: Tin
@@ -10367,9 +8513,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -8
   - ID#: 2697239461888
     NameComponent:
       name: Iron
@@ -10382,9 +8525,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -7
   - ID#: 2701534429184
     NameComponent:
       name: Iron
@@ -10397,9 +8537,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -6
   - ID#: 2705829396480
     NameComponent:
       name: Iron
@@ -10412,9 +8549,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -5
   - ID#: 2710124363776
     NameComponent:
       name: Mithril
@@ -10427,9 +8561,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -4
   - ID#: 2714419331072
     NameComponent:
       name: Mithril
@@ -10442,9 +8573,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -3
   - ID#: 2718714298368
     NameComponent:
       name: Mithril
@@ -10457,9 +8585,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -2
   - ID#: 2723009265664
     NameComponent:
       name: Mithril
@@ -10472,9 +8597,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: -1
   - ID#: 2727304232960
     NameComponent:
       name: Rock
@@ -10487,9 +8609,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: 4
   - ID#: 2731599200256
     NameComponent:
       name: Rock
@@ -10502,9 +8621,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: 5
   - ID#: 2735894167552
     NameComponent:
       name: Rock
@@ -10517,9 +8633,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: 22
   - ID#: 2740189134848
     NameComponent:
       name: Rock
@@ -10532,9 +8645,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: 23
   - ID#: 2744484102144
     NameComponent:
       name: Rock
@@ -10547,9 +8657,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 4
-      z: 24
   - ID#: 2748779069440
     NameComponent:
       name: Rock
@@ -10562,9 +8669,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -25
   - ID#: 2753074036736
     NameComponent:
       name: Rock
@@ -10577,9 +8681,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -24
   - ID#: 2757369004032
     NameComponent:
       name: Rock
@@ -10592,9 +8693,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -23
   - ID#: 2761663971328
     NameComponent:
       name: Tree
@@ -10607,9 +8705,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -18
   - ID#: 2765958938624
     NameComponent:
       name: Iron
@@ -10622,9 +8717,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -17
   - ID#: 2770253905920
     NameComponent:
       name: Rock
@@ -10637,9 +8729,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -6
   - ID#: 2774548873216
     NameComponent:
       name: Rock
@@ -10652,9 +8741,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -5
   - ID#: 2778843840512
     NameComponent:
       name: Rock
@@ -10667,9 +8753,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: -4
   - ID#: 2783138807808
     NameComponent:
       name: Rock
@@ -10682,9 +8765,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 3
   - ID#: 2787433775104
     NameComponent:
       name: Rock
@@ -10697,9 +8777,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 4
   - ID#: 2791728742400
     NameComponent:
       name: Rock
@@ -10712,9 +8789,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 22
   - ID#: 2796023709696
     NameComponent:
       name: Rock
@@ -10727,9 +8801,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 23
   - ID#: 2800318676992
     NameComponent:
       name: Rock
@@ -10742,9 +8813,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 5
-      z: 24
   - ID#: 2804613644288
     NameComponent:
       name: Rock
@@ -10757,9 +8825,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -25
   - ID#: 2808908611584
     NameComponent:
       name: Rock
@@ -10772,9 +8837,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -24
   - ID#: 2813203578880
     NameComponent:
       name: Rock
@@ -10787,9 +8849,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -23
   - ID#: 2817498546176
     NameComponent:
       name: Iron
@@ -10802,9 +8861,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -13
   - ID#: 2821793513472
     NameComponent:
       name: Rock
@@ -10817,9 +8873,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -12
   - ID#: 2826088480768
     NameComponent:
       name: Rock
@@ -10832,9 +8885,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -11
   - ID#: 2830383448064
     NameComponent:
       name: Rock
@@ -10847,9 +8897,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -10
   - ID#: 2834678415360
     NameComponent:
       name: Rock
@@ -10862,9 +8909,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: -9
   - ID#: 2838973382656
     NameComponent:
       name: Rock
@@ -10877,9 +8921,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 2
   - ID#: 2843268349952
     NameComponent:
       name: Rock
@@ -10892,9 +8933,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 3
   - ID#: 2847563317248
     NameComponent:
       name: Rock
@@ -10907,9 +8945,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 4
   - ID#: 2851858284544
     NameComponent:
       name: Rock
@@ -10922,9 +8957,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 5
   - ID#: 2856153251840
     NameComponent:
       name: Rock
@@ -10937,9 +8969,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 6
   - ID#: 2860448219136
     NameComponent:
       name: Rock
@@ -10952,9 +8981,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 23
   - ID#: 2864743186432
     NameComponent:
       name: Rock
@@ -10967,9 +8993,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 6
-      z: 24
   - ID#: 2869038153728
     NameComponent:
       name: Rock
@@ -10982,9 +9005,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -25
   - ID#: 2873333121024
     NameComponent:
       name: Rock
@@ -10997,9 +9017,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -24
   - ID#: 2877628088320
     NameComponent:
       name: Rock
@@ -11012,9 +9029,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -23
   - ID#: 2881923055616
     NameComponent:
       name: Rock
@@ -11027,9 +9041,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -22
   - ID#: 2886218022912
     NameComponent:
       name: Iron
@@ -11042,9 +9053,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -16
   - ID#: 2890512990208
     NameComponent:
       name: Rock
@@ -11057,9 +9065,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -15
   - ID#: 2894807957504
     NameComponent:
       name: Rock
@@ -11072,9 +9077,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -14
   - ID#: 2899102924800
     NameComponent:
       name: Rock
@@ -11087,9 +9089,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -13
   - ID#: 2903397892096
     NameComponent:
       name: Rock
@@ -11102,9 +9101,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -12
   - ID#: 2907692859392
     NameComponent:
       name: Iron
@@ -11117,9 +9113,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -11
   - ID#: 2911987826688
     NameComponent:
       name: Tree
@@ -11132,9 +9125,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: -8
   - ID#: 2916282793984
     NameComponent:
       name: Rock
@@ -11147,9 +9137,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 2
   - ID#: 2920577761280
     NameComponent:
       name: Rock
@@ -11162,9 +9149,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 3
   - ID#: 2924872728576
     NameComponent:
       name: Rock
@@ -11177,9 +9161,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 4
   - ID#: 2929167695872
     NameComponent:
       name: Rock
@@ -11192,9 +9173,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 5
   - ID#: 2933462663168
     NameComponent:
       name: Rock
@@ -11207,9 +9185,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 6
   - ID#: 2937757630464
     NameComponent:
       name: Rock
@@ -11222,9 +9197,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 23
   - ID#: 2942052597760
     NameComponent:
       name: Rock
@@ -11237,9 +9209,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 24
   - ID#: 2946347565056
     NameComponent:
       name: Rock
@@ -11252,9 +9221,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -25
   - ID#: 2950642532352
     NameComponent:
       name: Rock
@@ -11267,9 +9233,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -24
   - ID#: 2954937499648
     NameComponent:
       name: Rock
@@ -11282,9 +9245,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -23
   - ID#: 2959232466944
     NameComponent:
       name: Rock
@@ -11297,9 +9257,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -22
   - ID#: 2963527434240
     NameComponent:
       name: Tree
@@ -11312,9 +9269,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -14
   - ID#: 2967822401536
     NameComponent:
       name: Rock
@@ -11327,9 +9281,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -13
   - ID#: 2972117368832
     NameComponent:
       name: Iron
@@ -11342,9 +9293,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: -12
   - ID#: 2976412336128
     NameComponent:
       name: Rock
@@ -11357,9 +9305,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 4
   - ID#: 2980707303424
     NameComponent:
       name: Rock
@@ -11372,9 +9317,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 5
   - ID#: 2985002270720
     NameComponent:
       name: Rock
@@ -11387,9 +9329,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 6
   - ID#: 2989297238016
     NameComponent:
       name: Rock
@@ -11402,9 +9341,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 7
   - ID#: 2993592205312
     NameComponent:
       name: Rock
@@ -11417,9 +9353,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 22
   - ID#: 2997887172608
     NameComponent:
       name: Rock
@@ -11432,9 +9365,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 23
   - ID#: 3002182139904
     NameComponent:
       name: Rock
@@ -11447,9 +9377,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 24
   - ID#: 3006477107200
     NameComponent:
       name: Rock
@@ -11462,9 +9389,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -25
   - ID#: 3010772074496
     NameComponent:
       name: Rock
@@ -11477,9 +9401,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -24
   - ID#: 3015067041792
     NameComponent:
       name: Rock
@@ -11492,9 +9413,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -23
   - ID#: 3019362009088
     NameComponent:
       name: Iron
@@ -11507,9 +9425,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -9
   - ID#: 3023656976384
     NameComponent:
       name: Tree
@@ -11522,9 +9437,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -8
   - ID#: 3027951943680
     NameComponent:
       name: Rock
@@ -11537,9 +9449,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 4
   - ID#: 3032246910976
     NameComponent:
       name: Rock
@@ -11552,9 +9461,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 5
   - ID#: 3036541878272
     NameComponent:
       name: Rock
@@ -11567,9 +9473,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 22
   - ID#: 3040836845568
     NameComponent:
       name: Rock
@@ -11582,9 +9485,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 23
   - ID#: 3045131812864
     NameComponent:
       name: Rock
@@ -11597,9 +9497,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 24
   - ID#: 3049426780160
     NameComponent:
       name: Rock
@@ -11612,9 +9509,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: -25
   - ID#: 3053721747456
     NameComponent:
       name: Rock
@@ -11627,9 +9521,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: -24
   - ID#: 3058016714752
     NameComponent:
       name: Rock
@@ -11642,9 +9533,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 22
   - ID#: 3062311682048
     NameComponent:
       name: Rock
@@ -11657,9 +9545,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 23
   - ID#: 3066606649344
     NameComponent:
       name: Rock
@@ -11672,9 +9557,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 24
   - ID#: 3070901616640
     NameComponent:
       name: Rock
@@ -11687,9 +9569,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: -25
   - ID#: 3075196583936
     NameComponent:
       name: Rock
@@ -11702,9 +9581,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: -24
   - ID#: 3079491551232
     NameComponent:
       name: Rock
@@ -11717,9 +9593,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 21
   - ID#: 3083786518528
     NameComponent:
       name: Rock
@@ -11732,9 +9605,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 22
   - ID#: 3088081485824
     NameComponent:
       name: Rock
@@ -11747,9 +9617,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 23
   - ID#: 3092376453120
     NameComponent:
       name: Rock
@@ -11762,9 +9629,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 24
   - ID#: 3096671420416
     NameComponent:
       name: Rock
@@ -11777,9 +9641,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: -25
   - ID#: 3100966387712
     NameComponent:
       name: Rock
@@ -11792,9 +9653,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: -24
   - ID#: 3105261355008
     NameComponent:
       name: Rock
@@ -11807,9 +9665,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 21
   - ID#: 3109556322304
     NameComponent:
       name: Rock
@@ -11822,9 +9677,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 22
   - ID#: 3113851289600
     NameComponent:
       name: Rock
@@ -11837,9 +9689,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 23
   - ID#: 3118146256896
     NameComponent:
       name: Rock
@@ -11852,9 +9701,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 24
   - ID#: 3122441224192
     NameComponent:
       name: Rock
@@ -11867,9 +9713,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: -25
   - ID#: 3126736191488
     NameComponent:
       name: Rock
@@ -11882,9 +9725,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: -24
   - ID#: 3131031158784
     NameComponent:
       name: Rock
@@ -11897,9 +9737,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 22
   - ID#: 3135326126080
     NameComponent:
       name: Rock
@@ -11912,9 +9749,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 23
   - ID#: 3139621093376
     NameComponent:
       name: Rock
@@ -11927,9 +9761,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 24
   - ID#: 3143916060672
     NameComponent:
       name: Rock
@@ -11942,9 +9773,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: -25
   - ID#: 3148211027968
     NameComponent:
       name: Rock
@@ -11957,9 +9785,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: -24
   - ID#: 3152505995264
     NameComponent:
       name: Rock
@@ -11972,9 +9797,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 22
   - ID#: 3156800962560
     NameComponent:
       name: Rock
@@ -11987,9 +9809,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 23
   - ID#: 3161095929856
     NameComponent:
       name: Rock
@@ -12002,9 +9821,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 24
   - ID#: 3165390897152
     NameComponent:
       name: Rock
@@ -12017,9 +9833,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -25
   - ID#: 3169685864448
     NameComponent:
       name: Rock
@@ -12032,9 +9845,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -24
   - ID#: 3173980831744
     NameComponent:
       name: Rock
@@ -12047,9 +9857,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -23
   - ID#: 3178275799040
     NameComponent:
       name: Tree
@@ -12062,9 +9869,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -18
   - ID#: 3182570766336
     NameComponent:
       name: Iron
@@ -12077,9 +9881,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -17
   - ID#: 3186865733632
     NameComponent:
       name: Rock
@@ -12092,9 +9893,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -6
   - ID#: 3191160700928
     NameComponent:
       name: Rock
@@ -12107,9 +9905,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -5
   - ID#: 3195455668224
     NameComponent:
       name: Rock
@@ -12122,9 +9917,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: -4
   - ID#: 3199750635520
     NameComponent:
       name: Rock
@@ -12137,9 +9929,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 3
   - ID#: 3204045602816
     NameComponent:
       name: Rock
@@ -12152,9 +9941,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 4
   - ID#: 3208340570112
     NameComponent:
       name: Rock
@@ -12167,9 +9953,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 22
   - ID#: 3212635537408
     NameComponent:
       name: Rock
@@ -12182,9 +9965,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 23
   - ID#: 3216930504704
     NameComponent:
       name: Rock
@@ -12197,9 +9977,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 24
   - ID#: 3221225472000
     NameComponent:
       name: Rock
@@ -12212,9 +9989,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -25
   - ID#: 3225520439296
     NameComponent:
       name: Rock
@@ -12227,9 +10001,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -24
   - ID#: 3229815406592
     NameComponent:
       name: Rock
@@ -12242,9 +10013,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -23
   - ID#: 3234110373888
     NameComponent:
       name: Rock
@@ -12257,9 +10025,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -22
   - ID#: 3238405341184
     NameComponent:
       name: Iron
@@ -12272,9 +10037,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -13
   - ID#: 3242700308480
     NameComponent:
       name: Rock
@@ -12287,9 +10049,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -12
   - ID#: 3246995275776
     NameComponent:
       name: Rock
@@ -12302,9 +10061,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -11
   - ID#: 3251290243072
     NameComponent:
       name: Rock
@@ -12317,9 +10073,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -10
   - ID#: 3255585210368
     NameComponent:
       name: Rock
@@ -12332,9 +10085,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: -9
   - ID#: 3259880177664
     NameComponent:
       name: Rock
@@ -12347,9 +10097,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 2
   - ID#: 3264175144960
     NameComponent:
       name: Rock
@@ -12362,9 +10109,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 3
   - ID#: 3268470112256
     NameComponent:
       name: Rock
@@ -12377,9 +10121,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 4
   - ID#: 3272765079552
     NameComponent:
       name: Rock
@@ -12392,9 +10133,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 5
   - ID#: 3277060046848
     NameComponent:
       name: Rock
@@ -12407,9 +10145,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 6
   - ID#: 3281355014144
     NameComponent:
       name: Rock
@@ -12422,9 +10157,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 23
   - ID#: 3285649981440
     NameComponent:
       name: Rock
@@ -12437,9 +10169,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 24
   - ID#: 3289944948736
     NameComponent:
       name: Rock
@@ -12452,9 +10181,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -25
   - ID#: 3294239916032
     NameComponent:
       name: Rock
@@ -12467,9 +10193,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -24
   - ID#: 3298534883328
     NameComponent:
       name: Rock
@@ -12482,9 +10205,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -23
   - ID#: 3302829850624
     NameComponent:
       name: Rock
@@ -12497,9 +10217,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -22
   - ID#: 3307124817920
     NameComponent:
       name: Iron
@@ -12512,9 +10229,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -16
   - ID#: 3311419785216
     NameComponent:
       name: Rock
@@ -12527,9 +10241,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -15
   - ID#: 3315714752512
     NameComponent:
       name: Rock
@@ -12542,9 +10253,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -14
   - ID#: 3320009719808
     NameComponent:
       name: Rock
@@ -12557,9 +10265,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -13
   - ID#: 3324304687104
     NameComponent:
       name: Rock
@@ -12572,9 +10277,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -12
   - ID#: 3328599654400
     NameComponent:
       name: Iron
@@ -12587,9 +10289,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -11
   - ID#: 3332894621696
     NameComponent:
       name: Tree
@@ -12602,9 +10301,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: -8
   - ID#: 3337189588992
     NameComponent:
       name: Rock
@@ -12617,9 +10313,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 2
   - ID#: 3341484556288
     NameComponent:
       name: Rock
@@ -12632,9 +10325,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 3
   - ID#: 3345779523584
     NameComponent:
       name: Rock
@@ -12647,9 +10337,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 4
   - ID#: 3350074490880
     NameComponent:
       name: Rock
@@ -12662,9 +10349,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 5
   - ID#: 3354369458176
     NameComponent:
       name: Rock
@@ -12677,9 +10361,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 6
   - ID#: 3358664425472
     NameComponent:
       name: Rock
@@ -12692,9 +10373,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 23
   - ID#: 3362959392768
     NameComponent:
       name: Rock
@@ -12707,9 +10385,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 24
   - ID#: 3367254360064
     NameComponent:
       name: Rock
@@ -12722,9 +10397,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -25
   - ID#: 3371549327360
     NameComponent:
       name: Rock
@@ -12737,9 +10409,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -24
   - ID#: 3375844294656
     NameComponent:
       name: Rock
@@ -12752,9 +10421,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -23
   - ID#: 3380139261952
     NameComponent:
       name: Rock
@@ -12767,9 +10433,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -22
   - ID#: 3384434229248
     NameComponent:
       name: Tree
@@ -12782,9 +10445,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -14
   - ID#: 3388729196544
     NameComponent:
       name: Rock
@@ -12797,9 +10457,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -13
   - ID#: 3393024163840
     NameComponent:
       name: Iron
@@ -12812,9 +10469,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: -12
   - ID#: 3397319131136
     NameComponent:
       name: Rock
@@ -12827,9 +10481,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 4
   - ID#: 3401614098432
     NameComponent:
       name: Rock
@@ -12842,9 +10493,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 5
   - ID#: 3405909065728
     NameComponent:
       name: Rock
@@ -12857,9 +10505,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 6
   - ID#: 3410204033024
     NameComponent:
       name: Rock
@@ -12872,9 +10517,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 7
   - ID#: 3414499000320
     NameComponent:
       name: Rock
@@ -12887,9 +10529,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 22
   - ID#: 3418793967616
     NameComponent:
       name: Rock
@@ -12902,9 +10541,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 23
   - ID#: 3423088934912
     NameComponent:
       name: Rock
@@ -12917,9 +10553,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 24
   - ID#: 3427383902208
     NameComponent:
       name: Rock
@@ -12932,9 +10565,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -25
   - ID#: 3431678869504
     NameComponent:
       name: Rock
@@ -12947,9 +10577,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -24
   - ID#: 3435973836800
     NameComponent:
       name: Rock
@@ -12962,9 +10589,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -23
   - ID#: 3440268804096
     NameComponent:
       name: Rock
@@ -12977,9 +10601,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -22
   - ID#: 3444563771392
     NameComponent:
       name: Iron
@@ -12992,9 +10613,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -9
   - ID#: 3448858738688
     NameComponent:
       name: Tree
@@ -13007,9 +10625,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: -8
   - ID#: 3453153705984
     NameComponent:
       name: Rock
@@ -13022,9 +10637,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: 4
   - ID#: 3457448673280
     NameComponent:
       name: Rock
@@ -13037,9 +10649,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: 5
   - ID#: 3461743640576
     NameComponent:
       name: Rock
@@ -13052,9 +10661,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: 22
   - ID#: 3466038607872
     NameComponent:
       name: Rock
@@ -13067,9 +10673,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: 23
   - ID#: 3470333575168
     NameComponent:
       name: Rock
@@ -13082,9 +10685,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 19
-      z: 24
   - ID#: 3474628542464
     NameComponent:
       name: Rock
@@ -13097,9 +10697,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: -25
   - ID#: 3478923509760
     NameComponent:
       name: Rock
@@ -13112,9 +10709,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: -24
   - ID#: 3483218477056
     NameComponent:
       name: Rock
@@ -13127,9 +10721,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: -23
   - ID#: 3487513444352
     NameComponent:
       name: Rock
@@ -13142,9 +10733,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: -22
   - ID#: 3491808411648
     NameComponent:
       name: Rock
@@ -13157,9 +10745,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: 22
   - ID#: 3496103378944
     NameComponent:
       name: Rock
@@ -13172,9 +10757,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: 23
   - ID#: 3500398346240
     NameComponent:
       name: Rock
@@ -13187,9 +10769,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 20
-      z: 24
   - ID#: 3504693313536
     NameComponent:
       name: Rock
@@ -13202,9 +10781,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -25
   - ID#: 3508988280832
     NameComponent:
       name: Rock
@@ -13217,9 +10793,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -24
   - ID#: 3513283248128
     NameComponent:
       name: Rock
@@ -13232,9 +10805,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -23
   - ID#: 3517578215424
     NameComponent:
       name: Rock
@@ -13247,9 +10817,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -22
   - ID#: 3521873182720
     NameComponent:
       name: Rock
@@ -13262,9 +10829,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -21
   - ID#: 3526168150016
     NameComponent:
       name: Rock
@@ -13277,9 +10841,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -20
   - ID#: 3530463117312
     NameComponent:
       name: Rock
@@ -13292,9 +10853,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -19
   - ID#: 3534758084608
     NameComponent:
       name: Rock
@@ -13307,9 +10865,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -18
   - ID#: 3539053051904
     NameComponent:
       name: Rock
@@ -13322,9 +10877,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -17
   - ID#: 3543348019200
     NameComponent:
       name: Rock
@@ -13337,9 +10889,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -2
   - ID#: 3547642986496
     NameComponent:
       name: Rock
@@ -13352,9 +10901,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: -1
   - ID#: 3551937953792
     NameComponent:
       name: Rock
@@ -13367,9 +10913,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 0
   - ID#: 3556232921088
     NameComponent:
       name: Rock
@@ -13382,9 +10925,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 1
   - ID#: 3560527888384
     NameComponent:
       name: Rock
@@ -13397,9 +10937,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 2
   - ID#: 3564822855680
     NameComponent:
       name: Rock
@@ -13412,9 +10949,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 3
   - ID#: 3569117822976
     NameComponent:
       name: Rock
@@ -13427,9 +10961,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 4
   - ID#: 3573412790272
     NameComponent:
       name: Rock
@@ -13442,9 +10973,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 5
   - ID#: 3577707757568
     NameComponent:
       name: Rock
@@ -13457,9 +10985,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 6
   - ID#: 3582002724864
     NameComponent:
       name: Rock
@@ -13472,9 +10997,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 20
   - ID#: 3586297692160
     NameComponent:
       name: Rock
@@ -13487,9 +11009,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 21
   - ID#: 3590592659456
     NameComponent:
       name: Rock
@@ -13502,9 +11021,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 22
   - ID#: 3594887626752
     NameComponent:
       name: Rock
@@ -13517,9 +11033,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 23
   - ID#: 3599182594048
     NameComponent:
       name: Rock
@@ -13532,9 +11045,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 21
-      z: 24
   - ID#: 3603477561344
     NameComponent:
       name: Rock
@@ -13547,9 +11057,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -25
   - ID#: 3607772528640
     NameComponent:
       name: Rock
@@ -13562,9 +11069,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -24
   - ID#: 3612067495936
     NameComponent:
       name: Rock
@@ -13577,9 +11081,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -23
   - ID#: 3616362463232
     NameComponent:
       name: Rock
@@ -13592,9 +11093,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -22
   - ID#: 3620657430528
     NameComponent:
       name: Rock
@@ -13607,9 +11105,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -21
   - ID#: 3624952397824
     NameComponent:
       name: Rock
@@ -13622,9 +11117,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -20
   - ID#: 3629247365120
     NameComponent:
       name: Rock
@@ -13637,9 +11129,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -19
   - ID#: 3633542332416
     NameComponent:
       name: Rock
@@ -13652,9 +11141,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -18
   - ID#: 3637837299712
     NameComponent:
       name: Rock
@@ -13667,9 +11153,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -17
   - ID#: 3642132267008
     NameComponent:
       name: Rock
@@ -13682,9 +11165,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -16
   - ID#: 3646427234304
     NameComponent:
       name: Rock
@@ -13697,9 +11177,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -15
   - ID#: 3650722201600
     NameComponent:
       name: Rock
@@ -13712,9 +11189,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -14
   - ID#: 3655017168896
     NameComponent:
       name: Rock
@@ -13727,9 +11201,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -13
   - ID#: 3659312136192
     NameComponent:
       name: Rock
@@ -13742,9 +11213,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -6
   - ID#: 3663607103488
     NameComponent:
       name: Rock
@@ -13757,9 +11225,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -5
   - ID#: 3667902070784
     NameComponent:
       name: Rock
@@ -13772,9 +11237,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -4
   - ID#: 3672197038080
     NameComponent:
       name: Rock
@@ -13787,9 +11249,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -3
   - ID#: 3676492005376
     NameComponent:
       name: Rock
@@ -13802,9 +11261,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -2
   - ID#: 3680786972672
     NameComponent:
       name: Rock
@@ -13817,9 +11273,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: -1
   - ID#: 3685081939968
     NameComponent:
       name: Rock
@@ -13832,9 +11285,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 0
   - ID#: 3689376907264
     NameComponent:
       name: Rock
@@ -13847,9 +11297,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 1
   - ID#: 3693671874560
     NameComponent:
       name: Rock
@@ -13862,9 +11309,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 2
   - ID#: 3697966841856
     NameComponent:
       name: Rock
@@ -13877,9 +11321,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 3
   - ID#: 3702261809152
     NameComponent:
       name: Rock
@@ -13892,9 +11333,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 4
   - ID#: 3706556776448
     NameComponent:
       name: Rock
@@ -13907,9 +11345,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 5
   - ID#: 3710851743744
     NameComponent:
       name: Rock
@@ -13922,9 +11357,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 6
   - ID#: 3715146711040
     NameComponent:
       name: Rock
@@ -13937,9 +11369,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 7
   - ID#: 3719441678336
     NameComponent:
       name: Rock
@@ -13952,9 +11381,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 8
   - ID#: 3723736645632
     NameComponent:
       name: Rock
@@ -13967,9 +11393,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 16
   - ID#: 3728031612928
     NameComponent:
       name: Rock
@@ -13982,9 +11405,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 17
   - ID#: 3732326580224
     NameComponent:
       name: Rock
@@ -13997,9 +11417,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 18
   - ID#: 3736621547520
     NameComponent:
       name: Rock
@@ -14012,9 +11429,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 19
   - ID#: 3740916514816
     NameComponent:
       name: Rock
@@ -14027,9 +11441,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 20
   - ID#: 3745211482112
     NameComponent:
       name: Rock
@@ -14042,9 +11453,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 21
   - ID#: 3749506449408
     NameComponent:
       name: Rock
@@ -14057,9 +11465,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 22
   - ID#: 3753801416704
     NameComponent:
       name: Rock
@@ -14072,9 +11477,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 23
   - ID#: 3758096384000
     NameComponent:
       name: Rock
@@ -14087,9 +11489,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 22
-      z: 24
   - ID#: 3762391351296
     NameComponent:
       name: Rock
@@ -14102,9 +11501,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -12
   - ID#: 3766686318592
     NameComponent:
       name: Rock
@@ -14117,9 +11513,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -24
   - ID#: 3770981285888
     NameComponent:
       name: Rock
@@ -14132,9 +11525,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -23
   - ID#: 3775276253184
     NameComponent:
       name: Rock
@@ -14147,9 +11537,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -22
   - ID#: 3779571220480
     NameComponent:
       name: Rock
@@ -14162,9 +11549,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -21
   - ID#: 3783866187776
     NameComponent:
       name: Rock
@@ -14177,9 +11561,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -20
   - ID#: 3788161155072
     NameComponent:
       name: Rock
@@ -14192,9 +11573,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -19
   - ID#: 3792456122368
     NameComponent:
       name: Rock
@@ -14207,9 +11585,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -18
   - ID#: 3796751089664
     NameComponent:
       name: Rock
@@ -14222,9 +11597,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -17
   - ID#: 3801046056960
     NameComponent:
       name: Rock
@@ -14237,9 +11609,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -16
   - ID#: 3805341024256
     NameComponent:
       name: Rock
@@ -14252,9 +11621,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -15
   - ID#: 3809635991552
     NameComponent:
       name: Rock
@@ -14267,9 +11633,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -14
   - ID#: 3813930958848
     NameComponent:
       name: Rock
@@ -14282,9 +11645,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -13
   - ID#: 3818225926144
     NameComponent:
       name: Rock
@@ -14297,9 +11657,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -12
   - ID#: 3822520893440
     NameComponent:
       name: Rock
@@ -14312,9 +11669,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -11
   - ID#: 3826815860736
     NameComponent:
       name: Rock
@@ -14327,9 +11681,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -10
   - ID#: 3831110828032
     NameComponent:
       name: Rock
@@ -14342,9 +11693,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -9
   - ID#: 3835405795328
     NameComponent:
       name: Rock
@@ -14357,9 +11705,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -8
   - ID#: 3839700762624
     NameComponent:
       name: Rock
@@ -14372,9 +11717,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -7
   - ID#: 3843995729920
     NameComponent:
       name: Rock
@@ -14387,9 +11729,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -6
   - ID#: 3848290697216
     NameComponent:
       name: Rock
@@ -14402,9 +11741,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -5
   - ID#: 3852585664512
     NameComponent:
       name: Rock
@@ -14417,9 +11753,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -4
   - ID#: 3856880631808
     NameComponent:
       name: Rock
@@ -14432,9 +11765,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -3
   - ID#: 3861175599104
     NameComponent:
       name: Rock
@@ -14447,9 +11777,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -2
   - ID#: 3865470566400
     NameComponent:
       name: Rock
@@ -14462,9 +11789,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: -1
   - ID#: 3869765533696
     NameComponent:
       name: Rock
@@ -14477,9 +11801,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 0
   - ID#: 3874060500992
     NameComponent:
       name: Rock
@@ -14492,9 +11813,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 1
   - ID#: 3878355468288
     NameComponent:
       name: Rock
@@ -14507,9 +11825,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 2
   - ID#: 3882650435584
     NameComponent:
       name: Rock
@@ -14522,9 +11837,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 3
   - ID#: 3886945402880
     NameComponent:
       name: Rock
@@ -14537,9 +11849,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 4
   - ID#: 3891240370176
     NameComponent:
       name: Rock
@@ -14552,9 +11861,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 5
   - ID#: 3895535337472
     NameComponent:
       name: Rock
@@ -14567,9 +11873,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 6
   - ID#: 3899830304768
     NameComponent:
       name: Rock
@@ -14582,9 +11885,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 7
   - ID#: 3904125272064
     NameComponent:
       name: Rock
@@ -14597,9 +11897,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 8
   - ID#: 3908420239360
     NameComponent:
       name: Rock
@@ -14612,9 +11909,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 9
   - ID#: 3912715206656
     NameComponent:
       name: Rock
@@ -14627,9 +11921,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 10
   - ID#: 3917010173952
     NameComponent:
       name: Rock
@@ -14642,9 +11933,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 11
   - ID#: 3921305141248
     NameComponent:
       name: Rock
@@ -14657,9 +11945,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 14
   - ID#: 3925600108544
     NameComponent:
       name: Rock
@@ -14672,9 +11957,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 15
   - ID#: 3929895075840
     NameComponent:
       name: Rock
@@ -14687,9 +11969,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 16
   - ID#: 3934190043136
     NameComponent:
       name: Rock
@@ -14702,9 +11981,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 17
   - ID#: 3938485010432
     NameComponent:
       name: Rock
@@ -14717,9 +11993,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 18
   - ID#: 3942779977728
     NameComponent:
       name: Rock
@@ -14732,9 +12005,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 19
   - ID#: 3947074945024
     NameComponent:
       name: Rock
@@ -14747,9 +12017,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 20
   - ID#: 3951369912320
     NameComponent:
       name: Rock
@@ -14762,9 +12029,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 21
   - ID#: 3955664879616
     NameComponent:
       name: Rock
@@ -14777,9 +12041,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 22
   - ID#: 3959959846912
     NameComponent:
       name: Rock
@@ -14792,9 +12053,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 23
-      z: 23
   - ID#: 3964254814208
     NameComponent:
       name: Tree
@@ -14807,9 +12065,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -16
   - ID#: 3968549781504
     NameComponent:
       name: Rock
@@ -14822,9 +12077,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -15
   - ID#: 3972844748800
     NameComponent:
       name: Rock
@@ -14837,9 +12089,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -3
-      z: -15
   - ID#: 3977139716096
     NameComponent:
       name: Rock
@@ -14852,9 +12101,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -23
   - ID#: 3981434683392
     NameComponent:
       name: Rock
@@ -14867,9 +12113,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -22
   - ID#: 3985729650688
     NameComponent:
       name: Rock
@@ -14882,9 +12125,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -21
   - ID#: 3990024617984
     NameComponent:
       name: Rock
@@ -14897,9 +12137,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -20
   - ID#: 3994319585280
     NameComponent:
       name: Rock
@@ -14912,9 +12149,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -19
   - ID#: 3998614552576
     NameComponent:
       name: Rock
@@ -14927,9 +12161,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -18
   - ID#: 4002909519872
     NameComponent:
       name: Rock
@@ -14942,9 +12173,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -17
   - ID#: 4007204487168
     NameComponent:
       name: Rock
@@ -14957,9 +12185,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -16
   - ID#: 4011499454464
     NameComponent:
       name: Rock
@@ -14972,9 +12197,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -15
   - ID#: 4015794421760
     NameComponent:
       name: Rock
@@ -14987,9 +12209,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -14
   - ID#: 4020089389056
     NameComponent:
       name: Rock
@@ -15002,9 +12221,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -13
   - ID#: 4024384356352
     NameComponent:
       name: Rock
@@ -15017,9 +12233,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -12
   - ID#: 4028679323648
     NameComponent:
       name: Rock
@@ -15032,9 +12245,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -11
   - ID#: 4032974290944
     NameComponent:
       name: Rock
@@ -15047,9 +12257,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -10
   - ID#: 4037269258240
     NameComponent:
       name: Rock
@@ -15062,9 +12269,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -9
   - ID#: 4041564225536
     NameComponent:
       name: Rock
@@ -15077,9 +12281,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -8
   - ID#: 4045859192832
     NameComponent:
       name: Rock
@@ -15092,9 +12293,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -7
   - ID#: 4050154160128
     NameComponent:
       name: Rock
@@ -15107,9 +12305,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -6
   - ID#: 4054449127424
     NameComponent:
       name: Rock
@@ -15122,9 +12317,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -5
   - ID#: 4058744094720
     NameComponent:
       name: Rock
@@ -15137,9 +12329,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -4
   - ID#: 4063039062016
     NameComponent:
       name: Rock
@@ -15152,9 +12341,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -3
   - ID#: 4067334029312
     NameComponent:
       name: Rock
@@ -15167,9 +12353,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -2
   - ID#: 4071628996608
     NameComponent:
       name: Rock
@@ -15182,9 +12365,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: -1
   - ID#: 4075923963904
     NameComponent:
       name: Rock
@@ -15197,9 +12377,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 0
   - ID#: 4080218931200
     NameComponent:
       name: Rock
@@ -15212,9 +12389,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 1
   - ID#: 4084513898496
     NameComponent:
       name: Rock
@@ -15227,9 +12401,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 2
   - ID#: 4088808865792
     NameComponent:
       name: Rock
@@ -15242,9 +12413,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 3
   - ID#: 4093103833088
     NameComponent:
       name: Rock
@@ -15257,9 +12425,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 4
   - ID#: 4097398800384
     NameComponent:
       name: Rock
@@ -15272,9 +12437,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 5
   - ID#: 4101693767680
     NameComponent:
       name: Rock
@@ -15287,9 +12449,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 6
   - ID#: 4105988734976
     NameComponent:
       name: Rock
@@ -15302,9 +12461,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 7
   - ID#: 4110283702272
     NameComponent:
       name: Rock
@@ -15317,9 +12473,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 8
   - ID#: 4114578669568
     NameComponent:
       name: Rock
@@ -15332,9 +12485,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 9
   - ID#: 4118873636864
     NameComponent:
       name: Rock
@@ -15347,9 +12497,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 10
   - ID#: 4123168604160
     NameComponent:
       name: Rock
@@ -15362,9 +12509,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 11
   - ID#: 4127463571456
     NameComponent:
       name: Rock
@@ -15377,9 +12521,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 12
   - ID#: 4131758538752
     NameComponent:
       name: Rock
@@ -15392,9 +12533,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 13
   - ID#: 4136053506048
     NameComponent:
       name: Rock
@@ -15407,9 +12545,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 14
   - ID#: 4140348473344
     NameComponent:
       name: Rock
@@ -15422,9 +12557,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 15
   - ID#: 4144643440640
     NameComponent:
       name: Rock
@@ -15437,9 +12569,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 16
   - ID#: 4148938407936
     NameComponent:
       name: Rock
@@ -15452,9 +12581,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 17
   - ID#: 4153233375232
     NameComponent:
       name: Rock
@@ -15467,9 +12593,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 18
   - ID#: 4157528342528
     NameComponent:
       name: Rock
@@ -15482,9 +12605,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 19
   - ID#: 4161823309824
     NameComponent:
       name: Rock
@@ -15497,9 +12617,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 20
   - ID#: 4166118277120
     NameComponent:
       name: Rock
@@ -15512,9 +12629,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 21
   - ID#: 4170413244416
     NameComponent:
       name: Rock
@@ -15527,9 +12641,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 22
   - ID#: 4174708211712
     NameComponent:
       name: Rock
@@ -15542,9 +12653,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 24
-      z: 23
   - ID#: 4179003179008
     NameComponent:
       name: Tree
@@ -15557,9 +12665,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -11
   - ID#: 4183298146304
     NameComponent:
       name: Rock
@@ -15572,9 +12677,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 13
   - ID#: 4187593113600
     NameComponent:
       name: Rock
@@ -15587,9 +12689,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 14
   - ID#: 4191888080896
     NameComponent:
       name: Rock
@@ -15602,9 +12701,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 14
   - ID#: 4196183048192
     NameComponent:
       name: Rock
@@ -15617,9 +12713,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 12
   - ID#: 4200478015488
     NameComponent:
       name: Rock
@@ -15632,9 +12725,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 15
   - ID#: 4204772982784
     NameComponent:
       name: Rock
@@ -15647,9 +12737,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 15
   - ID#: 4209067950080
     NameComponent:
       name: Rock
@@ -15662,9 +12749,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 15
   - ID#: 4213362917376
     NameComponent:
       name: Tin
@@ -15677,9 +12761,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 15
   - ID#: 4217657884672
     NameComponent:
       name: Tin
@@ -15692,9 +12773,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 15
   - ID#: 4221952851968
     NameComponent:
       name: Tree
@@ -15707,9 +12785,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 14
   - ID#: 4226247819264
     NameComponent:
       name: Tree
@@ -15722,9 +12797,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 13
   - ID#: 4230542786560
     NameComponent:
       name: Tree
@@ -15737,9 +12809,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 13
   - ID#: 4234837753856
     NameComponent:
       name: Tin
@@ -15752,9 +12821,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 14
   - ID#: 4239132721152
     NameComponent:
       name: Tree
@@ -15767,9 +12833,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 14
   - ID#: 4243427688448
     NameComponent:
       name: Tree
@@ -15782,9 +12845,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 15
   - ID#: 4247722655744
     NameComponent:
       name: Tree
@@ -15797,9 +12857,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 14
   - ID#: 4252017623040
     NameComponent:
       name: Tree
@@ -15812,9 +12869,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 16
   - ID#: 4256312590336
     NameComponent:
       name: Tree
@@ -15827,9 +12881,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 16
   - ID#: 4260607557632
     NameComponent:
       name: Tree
@@ -15842,9 +12893,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 16
   - ID#: 4264902524928
     NameComponent:
       name: Tree
@@ -15857,9 +12905,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 12
   - ID#: 4269197492224
     NameComponent:
       name: Tree
@@ -15872,9 +12917,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 11
   - ID#: 4273492459520
     NameComponent:
       name: Tree
@@ -15887,9 +12929,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 10
   - ID#: 4277787426816
     NameComponent:
       name: Tree
@@ -15902,9 +12941,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 13
   - ID#: 4282082394112
     NameComponent:
       name: Tree
@@ -15917,9 +12953,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 12
   - ID#: 4286377361408
     NameComponent:
       name: Tree
@@ -15932,9 +12965,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 16
-      z: 15
   - ID#: 4290672328704
     NameComponent:
       name: Tree
@@ -15947,9 +12977,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 16
   - ID#: 4294967296000
     NameComponent:
       name: Tree
@@ -15962,9 +12989,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 13
-      z: 17
   - ID#: 4299262263296
     NameComponent:
       name: Tree
@@ -15977,9 +13001,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 16
   - ID#: 4303557230592
     NameComponent:
       name: Tree
@@ -15992,9 +13013,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 14
-      z: 17
   - ID#: 4307852197888
     NameComponent:
       name: Rock
@@ -16007,9 +13025,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 16
   - ID#: 4312147165184
     NameComponent:
       name: Tree
@@ -16022,9 +13037,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 15
   - ID#: 4316442132480
     NameComponent:
       name: Tree
@@ -16037,9 +13049,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 17
   - ID#: 4320737099776
     NameComponent:
       name: Tree
@@ -16052,9 +13061,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 17
   - ID#: 4325032067072
     NameComponent:
       name: Tree
@@ -16067,9 +13073,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 17
   - ID#: 4329327034368
     NameComponent:
       name: Tree
@@ -16082,9 +13085,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 16
   - ID#: 4333622001664
     NameComponent:
       name: Rock
@@ -16097,9 +13097,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 11
   - ID#: 4337916968960
     NameComponent:
       name: Tin
@@ -16112,9 +13109,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 11
   - ID#: 4342211936256
     NameComponent:
       name: Tin
@@ -16127,9 +13121,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 10
   - ID#: 4346506903552
     NameComponent:
       name: Rock
@@ -16142,9 +13133,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 11
   - ID#: 4350801870848
     NameComponent:
       name: Tree
@@ -16157,9 +13145,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 12
   - ID#: 4355096838144
     NameComponent:
       name: Tree
@@ -16172,9 +13157,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 12
   - ID#: 4359391805440
     NameComponent:
       name: Tree
@@ -16187,9 +13169,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 10
-      z: 12
   - ID#: 4363686772736
     NameComponent:
       name: Tree
@@ -16202,9 +13181,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 11
   - ID#: 4367981740032
     NameComponent:
       name: Tree
@@ -16217,9 +13193,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: 10
   - ID#: 4372276707328
     NameComponent:
       name: Tree
@@ -16232,9 +13205,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 8
-      z: 11
   - ID#: 4376571674624
     NameComponent:
       name: Tree
@@ -16247,9 +13217,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 11
-      z: 10
   - ID#: 4380866641920
     NameComponent:
       name: Tree
@@ -16262,9 +13229,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 7
-      z: 11
   - ID#: 4385161609216
     NameComponent:
       name: Tree
@@ -16277,9 +13241,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 10
   - ID#: 4389456576512
     NameComponent:
       name: Tree
@@ -16292,9 +13253,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 9
   - ID#: 4393751543808
     NameComponent:
       name: Tree
@@ -16307,9 +13265,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 12
-      z: 8
   - ID#: 4398046511104
     NameComponent:
       name: Tree
@@ -16322,9 +13277,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 15
-      z: 9
   - ID#: 4402341478400
     NameComponent:
       name: Tree
@@ -16337,9 +13289,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 18
-      z: 12
   - ID#: 4406636445696
     NameComponent:
       name: Tree
@@ -16352,9 +13301,6 @@ Entities:
       material: Resources/Materials/tree.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 17
-      z: 19
   - ID#: 4410931412992
     NameComponent:
       name: Mithril
@@ -16367,9 +13313,6 @@ Entities:
       material: Resources/Materials/rock.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: 23
   - ID#: 4415226380288
     NameComponent:
       name: Iron
@@ -16382,9 +13325,6 @@ Entities:
       material: Resources/Materials/iron.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: 9
-      z: -4
   - ID#: 4419521347584
     NameComponent:
       name: Tin
@@ -16397,9 +13337,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -13
   - ID#: 4423816314880
     NameComponent:
       name: Tin
@@ -16412,9 +13349,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -12
   - ID#: 4428111282176
     NameComponent:
       name: Tin
@@ -16427,9 +13361,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -5
-      z: -13
   - ID#: 4432406249472
     NameComponent:
       name: Tin
@@ -16442,9 +13373,6 @@ Entities:
       material: Resources/Material/tin.yaml
     SelectComponent:
       {}
-    GridComponent:
-      x: -4
-      z: -14
   - ID#: 4436701216768
     NameComponent:
       name: Rock

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -721,12 +721,6 @@
                     "display_name": "Clicked Square",
                     "type": "std::optional<glm::ivec2>",
                     "default": "std::nullopt"
-                },
-                {
-                    "name": "game_grid",
-                    "display_name": "Game Grid",
-                    "type": "std::unordered_map<glm::ivec2, apx::entity>",
-                    "default": "{}"
                 }
             ]
         },

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -731,6 +731,21 @@
             ]
         },
         {
+            "name": "TileMapSingleton",
+            "display_name": "Tile Map Singleton",
+            "flags": {
+                "SCRIPTABLE": false
+            },
+            "attributes": [
+                {
+                    "name": "tiles",
+                    "display_name": "Tiles",
+                    "type": "std::unordered_map<glm::ivec2, apx::entity>",
+                    "default": "{}"
+                }
+            ]
+        },
+        {
             "name": "CameraSingleton",
             "display_name": "Camera Singleton",
             "flags": {

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -428,24 +428,6 @@
             ]
         },
         {
-            "name": "GridComponent",
-            "display_name": "Grid",
-            "attributes": [
-                {
-                    "name": "x",
-                    "display_name": "X",
-                    "type": "int",
-                    "default": "0"
-                },
-                {
-                    "name": "z",
-                    "display_name": "Z",
-                    "type": "int",
-                    "default": "0"
-                }
-            ]
-        },
-        {
             "name": "LightComponent",
             "display_name": "Light",
             "attributes": [

--- a/Sprocket/Scene/Components.dm.h
+++ b/Sprocket/Scene/Components.dm.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <array>
 #include <unordered_map>
+#include <map>
 #include <optional>
 #include <memory>
 

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -117,12 +117,6 @@ struct PathComponent
     float speed = 0.0f;
 };
 
-struct GridComponent
-{
-    int x = 0;
-    int z = 0;
-};
-
 struct LightComponent
 {
     glm::vec3 colour = {1.0f, 1.0f, 1.0f};

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -190,7 +190,6 @@ struct GameGridSingleton
     apx::entity clicked_square_entity = apx::null;
     glm::ivec2 hovered_square = {0, 0};
     std::optional<glm::ivec2> clicked_square = std::nullopt;
-    std::unordered_map<glm::ivec2, apx::entity> game_grid = {};
 };
 
 struct TileMapSingleton

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <array>
 #include <unordered_map>
+#include <map>
 #include <optional>
 #include <memory>
 
@@ -190,6 +191,11 @@ struct GameGridSingleton
     glm::ivec2 hovered_square = {0, 0};
     std::optional<glm::ivec2> clicked_square = std::nullopt;
     std::unordered_map<glm::ivec2, apx::entity> game_grid = {};
+};
+
+struct TileMapSingleton
+{
+    std::unordered_map<glm::ivec2, apx::entity> tiles = {};
 };
 
 struct CameraSingleton

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -23,7 +23,6 @@ using registry = apx::registry<
     Sprocket::Camera3DComponent,
     Sprocket::SelectComponent,
     Sprocket::PathComponent,
-    Sprocket::GridComponent,
     Sprocket::LightComponent,
     Sprocket::SunComponent,
     Sprocket::AmbienceComponent,

--- a/Sprocket/Scene/ECS.h
+++ b/Sprocket/Scene/ECS.h
@@ -33,6 +33,7 @@ using registry = apx::registry<
     Sprocket::CollisionSingleton,
     Sprocket::InputSingleton,
     Sprocket::GameGridSingleton,
+    Sprocket::TileMapSingleton,
     Sprocket::CameraSingleton
 >;
 

--- a/Sprocket/Scene/EntitySystem.h
+++ b/Sprocket/Scene/EntitySystem.h
@@ -13,8 +13,6 @@ public:
     virtual void on_startup(spkt::registry& registry) {};
         // Called once when starting the scene. There may be
         // entities in the scene by this point.
-
-    virtual void on_event(spkt::registry& registry, ev::Event& event) {};
     
     virtual void on_update(spkt::registry& registry, double dt) {};
         // Called every tick of the game loop.

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -649,7 +649,6 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.clicked_square_entity = transform(source_comp.clicked_square_entity);
             target_comp.hovered_square = transform(source_comp.hovered_square);
             target_comp.clicked_square = transform(source_comp.clicked_square);
-            target_comp.game_grid = transform(source_comp.game_grid);
             dst.add<GameGridSingleton>(target_comp);
         }
         if (src.has<TileMapSingleton>()) {

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -121,13 +121,6 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "speed" << YAML::Value << c.speed;
             out << YAML::EndMap;
         }
-        if (entity.has<GridComponent>()) {
-            const auto& c = entity.get<GridComponent>();
-            out << YAML::Key << "GridComponent" << YAML::BeginMap;
-            out << YAML::Key << "x" << YAML::Value << c.x;
-            out << YAML::Key << "z" << YAML::Value << c.z;
-            out << YAML::EndMap;
-        }
         if (entity.has<LightComponent>()) {
             const auto& c = entity.get<LightComponent>();
             out << YAML::Key << "LightComponent" << YAML::BeginMap;
@@ -304,12 +297,6 @@ void Load(const std::string& file, spkt::registry* reg)
             c.speed = transform(spec["speed"].as<float>());
             e.add<PathComponent>(c);
         }
-        if (auto spec = entity["GridComponent"]) {
-            GridComponent c;
-            c.x = transform(spec["x"].as<int>());
-            c.z = transform(spec["z"].as<int>());
-            e.add<GridComponent>(c);
-        }
         if (auto spec = entity["LightComponent"]) {
             LightComponent c;
             c.colour = transform(spec["colour"].as<glm::vec3>());
@@ -396,9 +383,6 @@ spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
     }
     if (entity.has<PathComponent>()) {
         e.add<PathComponent>(entity.get<PathComponent>());
-    }
-    if (entity.has<GridComponent>()) {
-        e.add<GridComponent>(entity.get<GridComponent>());
     }
     if (entity.has<LightComponent>()) {
         e.add<LightComponent>(entity.get<LightComponent>());
@@ -565,13 +549,6 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.markers = transform(source_comp.markers);
             target_comp.speed = transform(source_comp.speed);
             dst.add<PathComponent>(target_comp);
-        }
-        if (src.has<GridComponent>()) {
-            const GridComponent& source_comp = src.get<GridComponent>();
-            GridComponent target_comp;
-            target_comp.x = transform(source_comp.x);
-            target_comp.z = transform(source_comp.z);
-            dst.add<GridComponent>(target_comp);
         }
         if (src.has<LightComponent>()) {
             const LightComponent& source_comp = src.get<LightComponent>();

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -19,7 +19,7 @@ void Save(const std::string& file, spkt::registry* reg)
     out << YAML::Key << "Entities" << YAML::BeginSeq;
     for (auto id : reg->all()) {
         spkt::entity entity{*reg, id};
-        if (entity.has<TemporaryComponent>()) { return; }
+        if (entity.has<TemporaryComponent>()) { continue; }
         out << YAML::BeginMap;
         out << YAML::Key << "ID#" << YAML::Value << id;
 DATAMATIC_BEGIN SAVABLE=true

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -12,18 +12,6 @@ Scene::Scene(Window* window)
     d_registry.emplace<TemporaryComponent>(singleton);
     d_registry.emplace<NameComponent>(singleton, "::RuntimeSingleton");
     d_registry.emplace<InputSingleton>(singleton);
-
-    apx::meta::for_each(d_registry.tags, [&](auto&& tag) {
-        using T = decltype(tag.type());
-        d_registry.on_add<T>([&](apx::entity entity, const T&) {
-            ev::Event event = ev::make_event<spkt::added<T>>(spkt::entity(d_registry, entity));
-            OnEvent(event);
-        });
-        d_registry.on_remove<T>([&](apx::entity entity, const T&) {
-            ev::Event event = ev::make_event<spkt::removed<T>>(spkt::entity(d_registry, entity));
-            OnEvent(event);
-        });
-    });
 }
 
 Scene::~Scene()

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -83,10 +83,6 @@ void Scene::OnEvent(ev::Event& event)
 
     input.window_width = (float)d_window->Width();
     input.window_height = (float)d_window->Height();
-
-    for (auto& system : d_systems) {
-        system->on_event(d_registry, event);
-    }
 }
 
 void Scene::post_update()

--- a/Sprocket/Scene/Systems/CameraSystem.cpp
+++ b/Sprocket/Scene/Systems/CameraSystem.cpp
@@ -17,20 +17,6 @@ float aspect_ratio(const InputSingleton& input)
 
 }
 
-void CameraSystem::on_event(spkt::registry& registry, ev::Event& event)
-{
-    if (auto e = event.get_if<spkt::added<Camera3DComponent>>()) {
-        auto singleton = registry.find<Singleton>();
-        const auto& input = registry.get<InputSingleton>(singleton);
-
-        spkt::entity entity = e->entity;
-        auto& camera = entity.get<Camera3DComponent>();
-        camera.projection = glm::perspective(
-            camera.fov, aspect_ratio(input), 0.1f, 1000.0f
-        );
-    }
-}
-
 void CameraSystem::on_update(spkt::registry& registry, double dt)
 {
     auto singleton = registry.find<Singleton>();

--- a/Sprocket/Scene/Systems/CameraSystem.h
+++ b/Sprocket/Scene/Systems/CameraSystem.h
@@ -6,7 +6,6 @@ namespace Sprocket {
 
 struct CameraSystem : public EntitySystem
 {
-    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 };
 

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -34,38 +34,6 @@ void GameGrid::on_startup(spkt::registry& registry)
     model2.mesh = gridSquare;
 }
 
-void GameGrid::on_event(spkt::registry& registry, ev::Event& event)
-{
-    auto singleton = registry.find<Singleton>();
-    if (!registry.valid(singleton)) {
-        return;
-    }
-
-    auto& grid = registry.get<GameGridSingleton>(singleton);
-
-    if (auto e = event.get_if<spkt::added<GridComponent>>()) {
-        spkt::entity entity = e->entity;
-        auto& transform = entity.get<Transform3DComponent>();
-        const auto& gc = entity.get<GridComponent>();
-
-        assert(!grid.game_grid.contains({gc.x, gc.z}));
-    
-        transform.position.x = gc.x + 0.5f;
-        transform.position.z = gc.z + 0.5f;
-        grid.game_grid[{gc.x, gc.z}] = entity.entity();
-    }
-    else if (auto e = event.get_if<spkt::removed<GridComponent>>()) {
-        auto& gc = e->entity.get<GridComponent>();
-        auto it = grid.game_grid.find({gc.x, gc.z});
-        if (it == grid.game_grid.end()) {
-            log::warn("No entity exists at this coord!");
-        }
-        else {
-            grid.game_grid.erase(it);
-        }
-    }
-}
-
 void GameGrid::on_update(spkt::registry& registry, double)
 {
     const auto& input = get_singleton<InputSingleton>(registry);

--- a/Sprocket/Scene/Systems/GameGrid.cpp
+++ b/Sprocket/Scene/Systems/GameGrid.cpp
@@ -72,6 +72,17 @@ void GameGrid::on_update(spkt::registry& registry, double)
     const auto& cam = get_singleton<CameraSingleton>(registry);
     auto& grid = get_singleton<GameGridSingleton>(registry);
 
+    auto tile_map = registry.find<TileMapSingleton>();
+    assert(registry.valid(tile_map));
+
+    auto& tms = registry.get<TileMapSingleton>(tile_map);
+
+    // Clean out any invalid entities.
+    std::erase_if(tms.tiles, [&](const auto& elem) {
+        const auto& [pos, entity] = elem;
+        return !registry.valid(entity);
+    });
+
     if (input.mouse_click[Mouse::LEFT]) {
         grid.clicked_square = grid.hovered_square;
     } else if (input.mouse_click[Mouse::RIGHT]) {

--- a/Sprocket/Scene/Systems/GameGrid.h
+++ b/Sprocket/Scene/Systems/GameGrid.h
@@ -8,7 +8,6 @@ namespace Sprocket {
 struct GameGrid : public EntitySystem
 {
     void on_startup(spkt::registry& registry) override;
-    void on_event(spkt::registry& registry, ev::Event& event) override;
     void on_update(spkt::registry& registry, double dt) override;
 };
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -753,40 +753,6 @@ int _AddPathComponent(lua_State* L) {
     return 0;
 }
 
-// C++ Functions for GridComponent =====================================================
-
-int _GetGridComponent(lua_State* L) {
-    if (!CheckArgCount(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::entity e = Converter<spkt::entity>::read(L, 1);
-    assert(e.has<GridComponent>());
-    const auto& c = e.get<GridComponent>();
-    Converter<int>::push(L, c.x);
-    Converter<int>::push(L, c.z);
-    return 2;
-}
-
-int _SetGridComponent(lua_State* L) {
-    if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-    int ptr = 0;
-    spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
-    auto& c = e.get<GridComponent>();
-    c.x = Converter<int>::read(L, ++ptr);
-    c.z = Converter<int>::read(L, ++ptr);
-    return 0;
-}
-
-int _AddGridComponent(lua_State* L) {
-    if (!CheckArgCount(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
-    int ptr = 0;
-    spkt::entity e = Converter<spkt::entity>::read(L, ++ptr);
-    assert(!e.has<GridComponent>());
-    GridComponent c;
-    c.x = Converter<int>::read(L, ++ptr);
-    c.z = Converter<int>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<GridComponent>(c); });
-    return 0;
-}
-
 // C++ Functions for LightComponent =====================================================
 
 int _GetLightComponent(lua_State* L) {
@@ -1466,43 +1432,6 @@ void load_entity_component_functions(lua::Script& script)
     )lua");
 
     lua_register(L, "HasPathComponent", &_has_impl<PathComponent>);
-
-
-    // Lua functions for GridComponent =====================================================
-
-    luaL_dostring(L, R"lua(
-        GridComponent = Class(function(self, x, z)
-            self.x = x
-            self.z = z
-        end)
-    )lua");
-
-    lua_register(L, "_GetGridComponent", &_GetGridComponent);
-
-    luaL_dostring(L, R"lua(
-        function GetGridComponent(entity)
-            x, z = _GetGridComponent(entity)
-            return GridComponent(x, z)
-        end
-    )lua");
-
-    lua_register(L, "_SetGridComponent", &_SetGridComponent);
-
-    luaL_dostring(L, R"lua(
-        function SetGridComponent(entity, c)
-            _SetGridComponent(entity, c.x, c.z)
-        end
-    )lua");
-
-    lua_register(L, "_AddGridComponent", &_AddGridComponent);
-
-    luaL_dostring(L, R"lua(
-        function AddGridComponent(entity, c)
-            _AddGridComponent(entity, c.x, c.z)
-        end
-    )lua");
-
-    lua_register(L, "HasGridComponent", &_has_impl<GridComponent>);
 
 
     // Lua functions for LightComponent =====================================================

--- a/Sprocket/Utility/Yaml.cpp
+++ b/Sprocket/Utility/Yaml.cpp
@@ -23,6 +23,24 @@ bool convert<glm::vec2>::decode(const Node& node, glm::vec2& rhs)
     return true;
 }
 
+Node convert<glm::ivec2>::encode(const glm::ivec2& rhs)
+{
+    Node n;
+    n.push_back(rhs.x);
+    n.push_back(rhs.y);
+    return n;
+}
+
+bool convert<glm::ivec2>::decode(const Node& node, glm::ivec2& rhs)
+{
+    if (!node.IsSequence() || node.size() != 2)
+        return false;
+
+    rhs.x = node[0].as<int>();
+    rhs.y = node[1].as<int>();
+    return true;
+}
+
 Node convert<glm::vec3>::encode(const glm::vec3& rhs)
 {
     Node n;
@@ -135,6 +153,13 @@ bool convert<spkt::identifier>::decode(const Node& node, spkt::identifier& rhs)
 namespace Sprocket {
 
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v)
+{
+    out << YAML::Flow;
+    out << YAML::BeginSeq << v.x << v.y << YAML::EndSeq;
+    return out;
+}
+
+YAML::Emitter& operator<<(YAML::Emitter& out, const glm::ivec2& v)
 {
     out << YAML::Flow;
     out << YAML::BeginSeq << v.x << v.y << YAML::EndSeq;

--- a/Sprocket/Utility/Yaml.h
+++ b/Sprocket/Utility/Yaml.h
@@ -16,6 +16,13 @@ struct convert<glm::vec2>
 };
 
 template<>
+struct convert<glm::ivec2>
+{
+    static Node encode(const glm::ivec2& rhs);
+    static bool decode(const Node& node, glm::ivec2& rhs);
+};
+
+template<>
 struct convert<glm::vec3>
 {
     static Node encode(const glm::vec3& rhs);
@@ -43,14 +50,53 @@ struct convert<spkt::identifier>
     static bool decode(const Node& node, spkt::identifier& rhs);
 };
 
+template <typename K, typename V, typename... Rest>
+struct convert<std::unordered_map<K, V, Rest...>>
+{
+    using map_t = std::unordered_map<K, V, Rest...>;
+    static Node encode(const map_t& rhs)
+    {
+        Node node(NodeType::Map);
+        for (const auto& [k, v] : rhs) {
+            node.force_insert(k, v);
+        }
+        return node;
+    }
+
+    static bool decode(const Node& node, map_t& rhs)
+    {
+        if (!node.IsMap()) {
+            return false;
+        }
+
+        rhs.clear();
+        for (const auto& elem : node) {
+            rhs[elem.first.as<K>()] = elem.second.as<V>();
+        }
+        return true;
+    }
+};
+
 }
 
 namespace Sprocket {
 
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v);
+YAML::Emitter& operator<<(YAML::Emitter& out, const glm::ivec2& v);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec3& v);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::quat& q);
 YAML::Emitter& operator<<(YAML::Emitter& out, const glm::mat4& m);
 YAML::Emitter& operator<<(YAML::Emitter& out, const spkt::identifier& i);
+
+template <typename K, typename V, typename... Rest>
+YAML::Emitter& operator<<(YAML::Emitter& out, const std::unordered_map<K, V, Rest...>& m)
+{
+    out << YAML::BeginMap;
+    for (const auto& [k, v] : m) {
+        out << YAML::Key << k << YAML::Value << v;
+    }
+    out << YAML::EndMap;
+    return out;
+}
 
 }


### PR DESCRIPTION
* `GridComponent` is now gone.
* Instead, grid data is stored in a `TileMapSingleton`. This is not on the runtime singleton as it needs to be saved.
* Fix the A* pathing that was broken in a previous PR.
* Fix `Loader::Save` as it has been broken for a while.
* Remove `on_event` for `EntitySystem`.
* With all event logic gone, `Scene` no longer sets up event handlers for `added` and `removed` events.
* Added YAML encodings for `std::unoredered_map<K, V>` and `glm::ivec2`.