### PR TITLE
Reduce `spkt::entity` Usage

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -49,11 +49,6 @@ Anvil::Anvil(Window* window)
 
     d_scene = std::make_shared<Scene>(window);    
     d_scene->Load(d_sceneFile);
-
-    d_runtimeCamera = d_scene->find([](spkt::entity entity) {
-        return entity.has<Camera3DComponent>();
-    });
-
     d_activeScene = d_scene;
 }
 
@@ -109,17 +104,19 @@ void Anvil::on_update(double dt)
 
 glm::mat4 Anvil::get_proj_matrix() const
 {
-    return d_playingGame ? spkt::make_proj(d_runtimeCamera) : d_editor_camera.Proj();
+    auto& registry = d_activeScene->Entities();
+    return d_playingGame ? spkt::make_proj({registry, d_runtimeCamera}) : d_editor_camera.Proj();
 }
 
 glm::mat4 Anvil::get_view_matrix() const
 {
-    return d_playingGame ? spkt::make_view(d_runtimeCamera) : d_editor_camera.View();
+    auto& registry = d_activeScene->Entities();
+    return d_playingGame ? spkt::make_view({registry, d_runtimeCamera}) : d_editor_camera.View();
 }
 
 void Anvil::on_render()
 {
-    auto& registry = d_scene->Entities();
+    auto& registry = d_activeScene->Entities();
 
     // If the size of the viewport has changed since the previous frame, recreate
     // the framebuffer.
@@ -199,7 +196,7 @@ void Anvil::on_render()
                 d_activeScene->add(spkt::clear_events_system);
 
                 d_playingGame = true;
-                d_runtimeCamera = d_activeScene->find<Camera3DComponent>();
+                d_runtimeCamera = d_activeScene->Entities().find<Camera3DComponent>();
                 d_window->SetCursorVisibility(false);
             }
             ImGui::EndMenu();

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -47,7 +47,6 @@ class Anvil
     bool d_playingGame = false;
     bool d_showColliders = false;
 
-    void add_entity_to_list(const spkt::entity& entity);
     apx::entity d_selected = apx::null;
 
     // Panels

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -34,7 +34,7 @@ class Anvil
     std::string d_sceneFile = "Resources/Anvil.yaml";
     std::shared_ptr<Scene> d_activeScene;
     std::shared_ptr<Scene> d_scene;
-    spkt::entity d_runtimeCamera;
+    apx::entity d_runtimeCamera;
 
     // Additional world setup
     CubeMap d_skybox;

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -48,7 +48,7 @@ class Anvil
     bool d_showColliders = false;
 
     void add_entity_to_list(const spkt::entity& entity);
-    spkt::entity d_selected = spkt::null;
+    apx::entity d_selected = apx::null;
 
     // Panels
     Inspector d_inspector;
@@ -65,9 +65,9 @@ public:
     void on_update(double dt);
     void on_render();
 
-    spkt::entity selected() { return d_selected; }
-    void set_selected(spkt::entity e) { d_selected = e; }
-    void clear_selected() { d_selected = spkt::null; }
+    apx::entity selected() { return d_selected; }
+    void set_selected(apx::entity e) { d_selected = e; }
+    void clear_selected() { d_selected = apx::null; }
 
     bool is_game_running() const { return d_playingGame; }
 

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -12,12 +12,13 @@ namespace spkt {
 
 void Inspector::Show(Anvil& editor)
 {
-    spkt::entity entity = editor.selected();
+    apx::entity e = editor.selected();
+    spkt::entity entity{editor.active_scene()->Entities(), e};
 
     if (!entity.valid()) {
         if (ImGui::Button("New Entity")) {
             auto e = apx::create_from(editor.active_scene()->Entities());
-            editor.set_selected(e);
+            editor.set_selected(e.entity());
         }
         return;
     }
@@ -482,7 +483,7 @@ void Inspector::Show(Anvil& editor)
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
-        editor.set_selected(copy);
+        editor.set_selected(copy.entity());
     }
     if (ImGui::Button("Delete Entity")) {
         entity.destroy();

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -12,101 +12,101 @@ namespace spkt {
 
 void Inspector::Show(Anvil& editor)
 {
-    apx::entity e = editor.selected();
-    spkt::entity entity{editor.active_scene()->Entities(), e};
+    spkt::registry& registry = editor.active_scene()->Entities();
+    apx::entity entity = editor.selected();
 
-    if (!entity.valid()) {
+    if (!registry.valid(entity)) {
         if (ImGui::Button("New Entity")) {
-            auto e = apx::create_from(editor.active_scene()->Entities());
-            editor.set_selected(e.entity());
+            entity = registry.create();
+            editor.set_selected(entity);
         }
         return;
     }
     int count = 0;
 
-    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity.entity());
+    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity);
 
-    if (entity.has<Runtime>()) {
-        auto& c = entity.get<Runtime>();
+    if (registry.has<Runtime>(entity)) {
+        auto& c = registry.get<Runtime>(entity);
         if (ImGui::CollapsingHeader("Runtime")) {
             ImGui::PushID(count++);
             
-            if (ImGui::Button("Delete")) { entity.remove<Runtime>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Runtime>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<Singleton>()) {
-        auto& c = entity.get<Singleton>();
+    if (registry.has<Singleton>(entity)) {
+        auto& c = registry.get<Singleton>(entity);
         if (ImGui::CollapsingHeader("Singleton")) {
             ImGui::PushID(count++);
             
-            if (ImGui::Button("Delete")) { entity.remove<Singleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Singleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<Event>()) {
-        auto& c = entity.get<Event>();
+    if (registry.has<Event>(entity)) {
+        auto& c = registry.get<Event>(entity);
         if (ImGui::CollapsingHeader("Event")) {
             ImGui::PushID(count++);
             
-            if (ImGui::Button("Delete")) { entity.remove<Event>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Event>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<NameComponent>()) {
-        auto& c = entity.get<NameComponent>();
+    if (registry.has<NameComponent>(entity)) {
+        auto& c = registry.get<NameComponent>(entity);
         if (ImGui::CollapsingHeader("Name")) {
             ImGui::PushID(count++);
             ImGuiXtra::TextModifiable(c.name);
             
-            if (ImGui::Button("Delete")) { entity.remove<NameComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<NameComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<Transform2DComponent>()) {
-        auto& c = entity.get<Transform2DComponent>();
+    if (registry.has<Transform2DComponent>(entity)) {
+        auto& c = registry.get<Transform2DComponent>(entity);
         if (ImGui::CollapsingHeader("Transform 2D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat2("Position", &c.position.x, 0.1f);
             ImGui::DragFloat("Rotation", &c.rotation, 0.01f);
             ImGui::DragFloat2("Scale", &c.scale.x, 0.1f);
             
-            if (ImGui::Button("Delete")) { entity.remove<Transform2DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Transform2DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<Transform3DComponent>()) {
-        auto& c = entity.get<Transform3DComponent>();
+    if (registry.has<Transform3DComponent>(entity)) {
+        auto& c = registry.get<Transform3DComponent>(entity);
         if (ImGui::CollapsingHeader("Transform 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
             ImGuiXtra::Euler("Orientation", &c.orientation);
             ImGui::DragFloat3("Scale", &c.scale.x, 0.1f);
             ImGuiXtra::GuizmoSettings(d_operation, d_mode, d_useSnap, d_snap);
-            if (ImGui::Button("Delete")) { entity.remove<Transform3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Transform3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<ModelComponent>()) {
-        auto& c = entity.get<ModelComponent>();
+    if (registry.has<ModelComponent>(entity)) {
+        auto& c = registry.get<ModelComponent>(entity);
         if (ImGui::CollapsingHeader("Model")) {
             ImGui::PushID(count++);
             ImGuiXtra::File("Mesh", editor.window(), &c.mesh, "*.obj");
             ImGuiXtra::File("Material", editor.window(), &c.material, "*.yaml");
             
-            if (ImGui::Button("Delete")) { entity.remove<ModelComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<ModelComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<RigidBody3DComponent>()) {
-        auto& c = entity.get<RigidBody3DComponent>();
+    if (registry.has<RigidBody3DComponent>(entity)) {
+        auto& c = registry.get<RigidBody3DComponent>(entity);
         if (ImGui::CollapsingHeader("Rigid Body 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Velocity", &c.velocity.x, 0.1f);
@@ -119,13 +119,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::Checkbox("OnFloor", &c.onFloor);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<RigidBody3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<RigidBody3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<BoxCollider3DComponent>()) {
-        auto& c = entity.get<BoxCollider3DComponent>();
+    if (registry.has<BoxCollider3DComponent>(entity)) {
+        auto& c = registry.get<BoxCollider3DComponent>(entity);
         if (ImGui::CollapsingHeader("Box Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -135,13 +135,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::Checkbox("Apply Scale", &c.applyScale);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<BoxCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<BoxCollider3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<SphereCollider3DComponent>()) {
-        auto& c = entity.get<SphereCollider3DComponent>();
+    if (registry.has<SphereCollider3DComponent>(entity)) {
+        auto& c = registry.get<SphereCollider3DComponent>(entity);
         if (ImGui::CollapsingHeader("Sphere Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -150,13 +150,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Radius", &c.radius, 0.01f);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<SphereCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<SphereCollider3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<CapsuleCollider3DComponent>()) {
-        auto& c = entity.get<CapsuleCollider3DComponent>();
+    if (registry.has<CapsuleCollider3DComponent>(entity)) {
+        auto& c = registry.get<CapsuleCollider3DComponent>(entity);
         if (ImGui::CollapsingHeader("Capsule Collider 3D")) {
             ImGui::PushID(count++);
             ImGui::DragFloat3("Position", &c.position.x, 0.1f);
@@ -166,63 +166,63 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Height", &c.height, 0.01f);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<CapsuleCollider3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<CapsuleCollider3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<ScriptComponent>()) {
-        auto& c = entity.get<ScriptComponent>();
+    if (registry.has<ScriptComponent>(entity)) {
+        auto& c = registry.get<ScriptComponent>(entity);
         if (ImGui::CollapsingHeader("Script")) {
             ImGui::PushID(count++);
             ImGuiXtra::File("Script", editor.window(), &c.script, "*.lua");
             ImGui::Checkbox("Active", &c.active);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<ScriptComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<ScriptComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<Camera3DComponent>()) {
-        auto& c = entity.get<Camera3DComponent>();
+    if (registry.has<Camera3DComponent>(entity)) {
+        auto& c = registry.get<Camera3DComponent>(entity);
         if (ImGui::CollapsingHeader("Camera 3D")) {
             ImGui::PushID(count++);
             ;
             ImGui::DragFloat("FOV", &c.fov, 0.01f);
             ImGui::DragFloat("Pitch", &c.pitch, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<Camera3DComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<Camera3DComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<PathComponent>()) {
-        auto& c = entity.get<PathComponent>();
+    if (registry.has<PathComponent>(entity)) {
+        auto& c = registry.get<PathComponent>(entity);
         if (ImGui::CollapsingHeader("Path")) {
             ImGui::PushID(count++);
             ;
             ImGui::DragFloat("Speed", &c.speed, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<PathComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<PathComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<LightComponent>()) {
-        auto& c = entity.get<LightComponent>();
+    if (registry.has<LightComponent>(entity)) {
+        auto& c = registry.get<LightComponent>(entity);
         if (ImGui::CollapsingHeader("Light")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
             ImGui::DragFloat("Brightness", &c.brightness, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<LightComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<LightComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<SunComponent>()) {
-        auto& c = entity.get<SunComponent>();
+    if (registry.has<SunComponent>(entity)) {
+        auto& c = registry.get<SunComponent>(entity);
         if (ImGui::CollapsingHeader("Sun")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
@@ -230,25 +230,25 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat3("Direction", &c.direction.x, 0.1f);
             ImGui::Checkbox("Shadows", &c.shadows);
             
-            if (ImGui::Button("Delete")) { entity.remove<SunComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<SunComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<AmbienceComponent>()) {
-        auto& c = entity.get<AmbienceComponent>();
+    if (registry.has<AmbienceComponent>(entity)) {
+        auto& c = registry.get<AmbienceComponent>(entity);
         if (ImGui::CollapsingHeader("Ambience")) {
             ImGui::PushID(count++);
             ImGui::ColorEdit3("Colour", &c.colour.r);
             ImGui::DragFloat("Brightness", &c.brightness, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<AmbienceComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<AmbienceComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<ParticleComponent>()) {
-        auto& c = entity.get<ParticleComponent>();
+    if (registry.has<ParticleComponent>(entity)) {
+        auto& c = registry.get<ParticleComponent>(entity);
         if (ImGui::CollapsingHeader("Particle")) {
             ImGui::PushID(count++);
             ImGui::DragFloat("Interval", &c.interval, 0.01f);
@@ -259,49 +259,49 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Life", &c.life, 0.01f);
             ImGui::DragFloat("Accumulator", &c.accumulator, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<ParticleComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<ParticleComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<MeshAnimationComponent>()) {
-        auto& c = entity.get<MeshAnimationComponent>();
+    if (registry.has<MeshAnimationComponent>(entity)) {
+        auto& c = registry.get<MeshAnimationComponent>(entity);
         if (ImGui::CollapsingHeader("Mesh Animation")) {
             ImGui::PushID(count++);
             ImGuiXtra::TextModifiable(c.name);
             ImGui::DragFloat("Time", &c.time, 0.01f);
             ImGui::DragFloat("Speed", &c.speed, 0.01f);
             
-            if (ImGui::Button("Delete")) { entity.remove<MeshAnimationComponent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<MeshAnimationComponent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<CollisionEvent>()) {
-        auto& c = entity.get<CollisionEvent>();
+    if (registry.has<CollisionEvent>(entity)) {
+        auto& c = registry.get<CollisionEvent>(entity);
         if (ImGui::CollapsingHeader("Collision Event")) {
             ImGui::PushID(count++);
             ;
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<CollisionEvent>(); }
+            if (ImGui::Button("Delete")) { registry.remove<CollisionEvent>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<PhysicsSingleton>()) {
-        auto& c = entity.get<PhysicsSingleton>();
+    if (registry.has<PhysicsSingleton>(entity)) {
+        auto& c = registry.get<PhysicsSingleton>(entity);
         if (ImGui::CollapsingHeader("Physics Singleton")) {
             ImGui::PushID(count++);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<PhysicsSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<PhysicsSingleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<InputSingleton>()) {
-        auto& c = entity.get<InputSingleton>();
+    if (registry.has<InputSingleton>(entity)) {
+        auto& c = registry.get<InputSingleton>(entity);
         if (ImGui::CollapsingHeader("Input Singleton")) {
             ImGui::PushID(count++);
             ;
@@ -315,13 +315,13 @@ void Inspector::Show(Anvil& editor)
             ImGui::DragFloat("Window Height", &c.window_height, 0.01f);
             ImGui::Checkbox("Window Resized", &c.window_resized);
             
-            if (ImGui::Button("Delete")) { entity.remove<InputSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<InputSingleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<GameGridSingleton>()) {
-        auto& c = entity.get<GameGridSingleton>();
+    if (registry.has<GameGridSingleton>(entity)) {
+        auto& c = registry.get<GameGridSingleton>(entity);
         if (ImGui::CollapsingHeader("Game Grid Singleton")) {
             ImGui::PushID(count++);
             ;
@@ -329,40 +329,40 @@ void Inspector::Show(Anvil& editor)
             ;
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<GameGridSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<GameGridSingleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<TileMapSingleton>()) {
-        auto& c = entity.get<TileMapSingleton>();
+    if (registry.has<TileMapSingleton>(entity)) {
+        auto& c = registry.get<TileMapSingleton>(entity);
         if (ImGui::CollapsingHeader("Tile Map Singleton")) {
             ImGui::PushID(count++);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<TileMapSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<TileMapSingleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<CameraSingleton>()) {
-        auto& c = entity.get<CameraSingleton>();
+    if (registry.has<CameraSingleton>(entity)) {
+        auto& c = registry.get<CameraSingleton>(entity);
         if (ImGui::CollapsingHeader("Camera Singleton")) {
             ImGui::PushID(count++);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<CameraSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<CameraSingleton>(entity); }
             ImGui::PopID();
         }
     }
 
-    if (entity.has<ParticleSingleton>()) {
-        auto& c = entity.get<ParticleSingleton>();
+    if (registry.has<ParticleSingleton>(entity)) {
+        auto& c = registry.get<ParticleSingleton>(entity);
         if (ImGui::CollapsingHeader("Particle Singleton")) {
             ImGui::PushID(count++);
             ;
             
-            if (ImGui::Button("Delete")) { entity.remove<ParticleSingleton>(); }
+            if (ImGui::Button("Delete")) { registry.remove<ParticleSingleton>(entity); }
             ImGui::PopID();
         }
     }
@@ -374,119 +374,119 @@ void Inspector::Show(Anvil& editor)
     }
 
     if (ImGui::BeginPopup("missing_components_list")) {
-        if (!entity.has<Runtime>() && ImGui::Selectable("Runtime")) {
+        if (!registry.has<Runtime>(entity) && ImGui::Selectable("Runtime")) {
             Runtime c;
-            entity.add<Runtime>(c);
+            registry.add<Runtime>(entity, c);
         }
-        if (!entity.has<Singleton>() && ImGui::Selectable("Singleton")) {
+        if (!registry.has<Singleton>(entity) && ImGui::Selectable("Singleton")) {
             Singleton c;
-            entity.add<Singleton>(c);
+            registry.add<Singleton>(entity, c);
         }
-        if (!entity.has<Event>() && ImGui::Selectable("Event")) {
+        if (!registry.has<Event>(entity) && ImGui::Selectable("Event")) {
             Event c;
-            entity.add<Event>(c);
+            registry.add<Event>(entity, c);
         }
-        if (!entity.has<NameComponent>() && ImGui::Selectable("Name")) {
+        if (!registry.has<NameComponent>(entity) && ImGui::Selectable("Name")) {
             NameComponent c;
-            entity.add<NameComponent>(c);
+            registry.add<NameComponent>(entity, c);
         }
-        if (!entity.has<Transform2DComponent>() && ImGui::Selectable("Transform 2D")) {
+        if (!registry.has<Transform2DComponent>(entity) && ImGui::Selectable("Transform 2D")) {
             Transform2DComponent c;
-            entity.add<Transform2DComponent>(c);
+            registry.add<Transform2DComponent>(entity, c);
         }
-        if (!entity.has<Transform3DComponent>() && ImGui::Selectable("Transform 3D")) {
+        if (!registry.has<Transform3DComponent>(entity) && ImGui::Selectable("Transform 3D")) {
             Transform3DComponent c;
-            entity.add<Transform3DComponent>(c);
+            registry.add<Transform3DComponent>(entity, c);
         }
-        if (!entity.has<ModelComponent>() && ImGui::Selectable("Model")) {
+        if (!registry.has<ModelComponent>(entity) && ImGui::Selectable("Model")) {
             ModelComponent c;
-            entity.add<ModelComponent>(c);
+            registry.add<ModelComponent>(entity, c);
         }
-        if (!entity.has<RigidBody3DComponent>() && ImGui::Selectable("Rigid Body 3D")) {
+        if (!registry.has<RigidBody3DComponent>(entity) && ImGui::Selectable("Rigid Body 3D")) {
             RigidBody3DComponent c;
-            entity.add<RigidBody3DComponent>(c);
+            registry.add<RigidBody3DComponent>(entity, c);
         }
-        if (!entity.has<BoxCollider3DComponent>() && ImGui::Selectable("Box Collider 3D")) {
+        if (!registry.has<BoxCollider3DComponent>(entity) && ImGui::Selectable("Box Collider 3D")) {
             BoxCollider3DComponent c;
-            entity.add<BoxCollider3DComponent>(c);
+            registry.add<BoxCollider3DComponent>(entity, c);
         }
-        if (!entity.has<SphereCollider3DComponent>() && ImGui::Selectable("Sphere Collider 3D")) {
+        if (!registry.has<SphereCollider3DComponent>(entity) && ImGui::Selectable("Sphere Collider 3D")) {
             SphereCollider3DComponent c;
-            entity.add<SphereCollider3DComponent>(c);
+            registry.add<SphereCollider3DComponent>(entity, c);
         }
-        if (!entity.has<CapsuleCollider3DComponent>() && ImGui::Selectable("Capsule Collider 3D")) {
+        if (!registry.has<CapsuleCollider3DComponent>(entity) && ImGui::Selectable("Capsule Collider 3D")) {
             CapsuleCollider3DComponent c;
-            entity.add<CapsuleCollider3DComponent>(c);
+            registry.add<CapsuleCollider3DComponent>(entity, c);
         }
-        if (!entity.has<ScriptComponent>() && ImGui::Selectable("Script")) {
+        if (!registry.has<ScriptComponent>(entity) && ImGui::Selectable("Script")) {
             ScriptComponent c;
-            entity.add<ScriptComponent>(c);
+            registry.add<ScriptComponent>(entity, c);
         }
-        if (!entity.has<Camera3DComponent>() && ImGui::Selectable("Camera 3D")) {
+        if (!registry.has<Camera3DComponent>(entity) && ImGui::Selectable("Camera 3D")) {
             Camera3DComponent c;
-            entity.add<Camera3DComponent>(c);
+            registry.add<Camera3DComponent>(entity, c);
         }
-        if (!entity.has<PathComponent>() && ImGui::Selectable("Path")) {
+        if (!registry.has<PathComponent>(entity) && ImGui::Selectable("Path")) {
             PathComponent c;
-            entity.add<PathComponent>(c);
+            registry.add<PathComponent>(entity, c);
         }
-        if (!entity.has<LightComponent>() && ImGui::Selectable("Light")) {
+        if (!registry.has<LightComponent>(entity) && ImGui::Selectable("Light")) {
             LightComponent c;
-            entity.add<LightComponent>(c);
+            registry.add<LightComponent>(entity, c);
         }
-        if (!entity.has<SunComponent>() && ImGui::Selectable("Sun")) {
+        if (!registry.has<SunComponent>(entity) && ImGui::Selectable("Sun")) {
             SunComponent c;
-            entity.add<SunComponent>(c);
+            registry.add<SunComponent>(entity, c);
         }
-        if (!entity.has<AmbienceComponent>() && ImGui::Selectable("Ambience")) {
+        if (!registry.has<AmbienceComponent>(entity) && ImGui::Selectable("Ambience")) {
             AmbienceComponent c;
-            entity.add<AmbienceComponent>(c);
+            registry.add<AmbienceComponent>(entity, c);
         }
-        if (!entity.has<ParticleComponent>() && ImGui::Selectable("Particle")) {
+        if (!registry.has<ParticleComponent>(entity) && ImGui::Selectable("Particle")) {
             ParticleComponent c;
-            entity.add<ParticleComponent>(c);
+            registry.add<ParticleComponent>(entity, c);
         }
-        if (!entity.has<MeshAnimationComponent>() && ImGui::Selectable("Mesh Animation")) {
+        if (!registry.has<MeshAnimationComponent>(entity) && ImGui::Selectable("Mesh Animation")) {
             MeshAnimationComponent c;
-            entity.add<MeshAnimationComponent>(c);
+            registry.add<MeshAnimationComponent>(entity, c);
         }
-        if (!entity.has<CollisionEvent>() && ImGui::Selectable("Collision Event")) {
+        if (!registry.has<CollisionEvent>(entity) && ImGui::Selectable("Collision Event")) {
             CollisionEvent c;
-            entity.add<CollisionEvent>(c);
+            registry.add<CollisionEvent>(entity, c);
         }
-        if (!entity.has<PhysicsSingleton>() && ImGui::Selectable("Physics Singleton")) {
+        if (!registry.has<PhysicsSingleton>(entity) && ImGui::Selectable("Physics Singleton")) {
             PhysicsSingleton c;
-            entity.add<PhysicsSingleton>(c);
+            registry.add<PhysicsSingleton>(entity, c);
         }
-        if (!entity.has<InputSingleton>() && ImGui::Selectable("Input Singleton")) {
+        if (!registry.has<InputSingleton>(entity) && ImGui::Selectable("Input Singleton")) {
             InputSingleton c;
-            entity.add<InputSingleton>(c);
+            registry.add<InputSingleton>(entity, c);
         }
-        if (!entity.has<GameGridSingleton>() && ImGui::Selectable("Game Grid Singleton")) {
+        if (!registry.has<GameGridSingleton>(entity) && ImGui::Selectable("Game Grid Singleton")) {
             GameGridSingleton c;
-            entity.add<GameGridSingleton>(c);
+            registry.add<GameGridSingleton>(entity, c);
         }
-        if (!entity.has<TileMapSingleton>() && ImGui::Selectable("Tile Map Singleton")) {
+        if (!registry.has<TileMapSingleton>(entity) && ImGui::Selectable("Tile Map Singleton")) {
             TileMapSingleton c;
-            entity.add<TileMapSingleton>(c);
+            registry.add<TileMapSingleton>(entity, c);
         }
-        if (!entity.has<CameraSingleton>() && ImGui::Selectable("Camera Singleton")) {
+        if (!registry.has<CameraSingleton>(entity) && ImGui::Selectable("Camera Singleton")) {
             CameraSingleton c;
-            entity.add<CameraSingleton>(c);
+            registry.add<CameraSingleton>(entity, c);
         }
-        if (!entity.has<ParticleSingleton>() && ImGui::Selectable("Particle Singleton")) {
+        if (!registry.has<ParticleSingleton>(entity) && ImGui::Selectable("Particle Singleton")) {
             ParticleSingleton c;
-            entity.add<ParticleSingleton>(c);
+            registry.add<ParticleSingleton>(entity, c);
         }
         ImGui::EndMenu();
     }
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
-        spkt::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
-        editor.set_selected(copy.entity());
+        apx::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
+        editor.set_selected(copy);
     }
     if (ImGui::Button("Delete Entity")) {
-        entity.destroy();
+        registry.destroy(entity);
         editor.clear_selected();
     }
 }

--- a/Anvil/Inspector.dm.cpp
+++ b/Anvil/Inspector.dm.cpp
@@ -12,12 +12,13 @@ namespace spkt {
 
 void Inspector::Show(Anvil& editor)
 {
-    spkt::entity entity = editor.selected();
+    apx::entity e = editor.selected();
+    spkt::entity entity{editor.active_scene()->Entities(), e};
 
     if (!entity.valid()) {
         if (ImGui::Button("New Entity")) {
             auto e = apx::create_from(editor.active_scene()->Entities());
-            editor.set_selected(e);
+            editor.set_selected(e.entity());
         }
         return;
     }
@@ -56,7 +57,7 @@ DATAMATIC_END
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
-        editor.set_selected(copy);
+        editor.set_selected(copy.entity());
     }
     if (ImGui::Button("Delete Entity")) {
         entity.destroy();

--- a/Anvil/Inspector.dm.cpp
+++ b/Anvil/Inspector.dm.cpp
@@ -12,28 +12,28 @@ namespace spkt {
 
 void Inspector::Show(Anvil& editor)
 {
-    apx::entity e = editor.selected();
-    spkt::entity entity{editor.active_scene()->Entities(), e};
+    spkt::registry& registry = editor.active_scene()->Entities();
+    apx::entity entity = editor.selected();
 
-    if (!entity.valid()) {
+    if (!registry.valid(entity)) {
         if (ImGui::Button("New Entity")) {
-            auto e = apx::create_from(editor.active_scene()->Entities());
-            editor.set_selected(e.entity());
+            entity = registry.create();
+            editor.set_selected(entity);
         }
         return;
     }
     int count = 0;
 
-    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity.entity());
+    ImGui::TextColored(ImVec4(0.5, 0.5, 0.5, 1.0), "ID: %llu", entity);
 
 DATAMATIC_BEGIN
-    if (entity.has<{{Comp::name}}>()) {
-        auto& c = entity.get<{{Comp::name}}>();
+    if (registry.has<{{Comp::name}}>(entity)) {
+        auto& c = registry.get<{{Comp::name}}>(entity);
         if (ImGui::CollapsingHeader("{{Comp::display_name}}")) {
             ImGui::PushID(count++);
             {{Attr::inspector_display}};
             {{Comp::inspector_guizmo_settings}}
-            if (ImGui::Button("Delete")) { entity.remove<{{Comp::name}}>(); }
+            if (ImGui::Button("Delete")) { registry.remove<{{Comp::name}}>(entity); }
             ImGui::PopID();
         }
     }
@@ -47,20 +47,20 @@ DATAMATIC_END
 
     if (ImGui::BeginPopup("missing_components_list")) {
 DATAMATIC_BEGIN
-        if (!entity.has<{{Comp::name}}>() && ImGui::Selectable("{{Comp::display_name}}")) {
+        if (!registry.has<{{Comp::name}}>(entity) && ImGui::Selectable("{{Comp::display_name}}")) {
             {{Comp::name}} c;
-            entity.add<{{Comp::name}}>(c);
+            registry.add<{{Comp::name}}>(entity, c);
         }
 DATAMATIC_END
         ImGui::EndMenu();
     }
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
-        spkt::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
-        editor.set_selected(copy.entity());
+        apx::entity copy = Loader::Copy(&editor.active_scene()->Entities(), entity);
+        editor.set_selected(copy);
     }
     if (ImGui::Button("Delete Entity")) {
-        entity.destroy();
+        registry.destroy(entity);
         editor.clear_selected();
     }
 }

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -12,7 +12,7 @@ enum class Mode { PLAYER, EDITOR };
 
 class Game
 {
-    spkt::Window*      d_window;
+    spkt::Window* d_window;
     spkt::AssetManager d_assetManager;
     
     Mode d_mode;
@@ -23,8 +23,8 @@ class Game
     spkt::entity d_worker;
     
     // RENDERING
-    spkt::Scene3DRenderer  d_entityRenderer;
-    spkt::PostProcessor   d_postProcessor;
+    spkt::Scene3DRenderer d_entityRenderer;
+    spkt::PostProcessor d_postProcessor;
 
     // Additional world setup
     spkt::CircadianCycle d_cycle;

--- a/Resources/Scripts/PlayerController.lua
+++ b/Resources/Scripts/PlayerController.lua
@@ -5,7 +5,6 @@ function init(entity)
     TIME = 0.0
 
     SPAWN_POINT = vec3.new(-11, 2, 3)
-    ENTITY = entity
 end
 
 function on_update(entity, dt)
@@ -61,17 +60,17 @@ function on_update(entity, dt)
     end
 
     if IsMouseClicked(0) then
-        Fire()
+        Fire(entity)
     end
 
 end
 
-function Fire()
+function Fire(entity)
     local newEntity = NewEntity()
 
-    local dir = GetForwardsDir(ENTITY)
-    local pos = GetTransform3DComponent(ENTITY).position
-    local vel = GetRigidBody3DComponent(ENTITY).velocity
+    local dir = GetForwardsDir(entity)
+    local pos = GetTransform3DComponent(entity).position
+    local vel = GetRigidBody3DComponent(entity).velocity
     
     local tc = Transform3DComponent(pos + dir, vec3.new(0.1, 0.1, 0.1))
     AddTransform3DComponent(newEntity, tc)

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -17,45 +17,44 @@ void Save(const std::string& file, spkt::registry* reg)
     YAML::Emitter out;
     out << YAML::BeginMap;
     out << YAML::Key << "Entities" << YAML::BeginSeq;
-    for (auto id : reg->all()) {
-        spkt::entity entity{*reg, id};
+    for (auto entity : reg->all()) {
 
         // Don't save runtime entities
-        if (entity.has<Runtime>()) { continue; }
+        if (reg->has<Runtime>(entity)) { continue; }
 
         out << YAML::BeginMap;
-        out << YAML::Key << "ID#" << YAML::Value << id;
-        if (entity.has<NameComponent>()) {
-            const auto& c = entity.get<NameComponent>();
+        out << YAML::Key << "ID#" << YAML::Value << entity;
+        if (reg->has<NameComponent>(entity)) {
+            const auto& c = reg->get<NameComponent>(entity);
             out << YAML::Key << "NameComponent" << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::EndMap;
         }
-        if (entity.has<Transform2DComponent>()) {
-            const auto& c = entity.get<Transform2DComponent>();
+        if (reg->has<Transform2DComponent>(entity)) {
+            const auto& c = reg->get<Transform2DComponent>(entity);
             out << YAML::Key << "Transform2DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "rotation" << YAML::Value << c.rotation;
             out << YAML::Key << "scale" << YAML::Value << c.scale;
             out << YAML::EndMap;
         }
-        if (entity.has<Transform3DComponent>()) {
-            const auto& c = entity.get<Transform3DComponent>();
+        if (reg->has<Transform3DComponent>(entity)) {
+            const auto& c = reg->get<Transform3DComponent>(entity);
             out << YAML::Key << "Transform3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
             out << YAML::Key << "scale" << YAML::Value << c.scale;
             out << YAML::EndMap;
         }
-        if (entity.has<ModelComponent>()) {
-            const auto& c = entity.get<ModelComponent>();
+        if (reg->has<ModelComponent>(entity)) {
+            const auto& c = reg->get<ModelComponent>(entity);
             out << YAML::Key << "ModelComponent" << YAML::BeginMap;
             out << YAML::Key << "mesh" << YAML::Value << c.mesh;
             out << YAML::Key << "material" << YAML::Value << c.material;
             out << YAML::EndMap;
         }
-        if (entity.has<RigidBody3DComponent>()) {
-            const auto& c = entity.get<RigidBody3DComponent>();
+        if (reg->has<RigidBody3DComponent>(entity)) {
+            const auto& c = reg->get<RigidBody3DComponent>(entity);
             out << YAML::Key << "RigidBody3DComponent" << YAML::BeginMap;
             out << YAML::Key << "velocity" << YAML::Value << c.velocity;
             out << YAML::Key << "gravity" << YAML::Value << c.gravity;
@@ -65,8 +64,8 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "rollingResistance" << YAML::Value << c.rollingResistance;
             out << YAML::EndMap;
         }
-        if (entity.has<BoxCollider3DComponent>()) {
-            const auto& c = entity.get<BoxCollider3DComponent>();
+        if (reg->has<BoxCollider3DComponent>(entity)) {
+            const auto& c = reg->get<BoxCollider3DComponent>(entity);
             out << YAML::Key << "BoxCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -75,8 +74,8 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "applyScale" << YAML::Value << c.applyScale;
             out << YAML::EndMap;
         }
-        if (entity.has<SphereCollider3DComponent>()) {
-            const auto& c = entity.get<SphereCollider3DComponent>();
+        if (reg->has<SphereCollider3DComponent>(entity)) {
+            const auto& c = reg->get<SphereCollider3DComponent>(entity);
             out << YAML::Key << "SphereCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -84,8 +83,8 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "radius" << YAML::Value << c.radius;
             out << YAML::EndMap;
         }
-        if (entity.has<CapsuleCollider3DComponent>()) {
-            const auto& c = entity.get<CapsuleCollider3DComponent>();
+        if (reg->has<CapsuleCollider3DComponent>(entity)) {
+            const auto& c = reg->get<CapsuleCollider3DComponent>(entity);
             out << YAML::Key << "CapsuleCollider3DComponent" << YAML::BeginMap;
             out << YAML::Key << "position" << YAML::Value << c.position;
             out << YAML::Key << "orientation" << YAML::Value << c.orientation;
@@ -94,35 +93,35 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "height" << YAML::Value << c.height;
             out << YAML::EndMap;
         }
-        if (entity.has<ScriptComponent>()) {
-            const auto& c = entity.get<ScriptComponent>();
+        if (reg->has<ScriptComponent>(entity)) {
+            const auto& c = reg->get<ScriptComponent>(entity);
             out << YAML::Key << "ScriptComponent" << YAML::BeginMap;
             out << YAML::Key << "script" << YAML::Value << c.script;
             out << YAML::Key << "active" << YAML::Value << c.active;
             out << YAML::EndMap;
         }
-        if (entity.has<Camera3DComponent>()) {
-            const auto& c = entity.get<Camera3DComponent>();
+        if (reg->has<Camera3DComponent>(entity)) {
+            const auto& c = reg->get<Camera3DComponent>(entity);
             out << YAML::Key << "Camera3DComponent" << YAML::BeginMap;
             out << YAML::Key << "fov" << YAML::Value << c.fov;
             out << YAML::Key << "pitch" << YAML::Value << c.pitch;
             out << YAML::EndMap;
         }
-        if (entity.has<PathComponent>()) {
-            const auto& c = entity.get<PathComponent>();
+        if (reg->has<PathComponent>(entity)) {
+            const auto& c = reg->get<PathComponent>(entity);
             out << YAML::Key << "PathComponent" << YAML::BeginMap;
             out << YAML::Key << "speed" << YAML::Value << c.speed;
             out << YAML::EndMap;
         }
-        if (entity.has<LightComponent>()) {
-            const auto& c = entity.get<LightComponent>();
+        if (reg->has<LightComponent>(entity)) {
+            const auto& c = reg->get<LightComponent>(entity);
             out << YAML::Key << "LightComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
             out << YAML::EndMap;
         }
-        if (entity.has<SunComponent>()) {
-            const auto& c = entity.get<SunComponent>();
+        if (reg->has<SunComponent>(entity)) {
+            const auto& c = reg->get<SunComponent>(entity);
             out << YAML::Key << "SunComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
@@ -130,15 +129,15 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "shadows" << YAML::Value << c.shadows;
             out << YAML::EndMap;
         }
-        if (entity.has<AmbienceComponent>()) {
-            const auto& c = entity.get<AmbienceComponent>();
+        if (reg->has<AmbienceComponent>(entity)) {
+            const auto& c = reg->get<AmbienceComponent>(entity);
             out << YAML::Key << "AmbienceComponent" << YAML::BeginMap;
             out << YAML::Key << "colour" << YAML::Value << c.colour;
             out << YAML::Key << "brightness" << YAML::Value << c.brightness;
             out << YAML::EndMap;
         }
-        if (entity.has<ParticleComponent>()) {
-            const auto& c = entity.get<ParticleComponent>();
+        if (reg->has<ParticleComponent>(entity)) {
+            const auto& c = reg->get<ParticleComponent>(entity);
             out << YAML::Key << "ParticleComponent" << YAML::BeginMap;
             out << YAML::Key << "interval" << YAML::Value << c.interval;
             out << YAML::Key << "velocity" << YAML::Value << c.velocity;
@@ -148,16 +147,16 @@ void Save(const std::string& file, spkt::registry* reg)
             out << YAML::Key << "life" << YAML::Value << c.life;
             out << YAML::EndMap;
         }
-        if (entity.has<MeshAnimationComponent>()) {
-            const auto& c = entity.get<MeshAnimationComponent>();
+        if (reg->has<MeshAnimationComponent>(entity)) {
+            const auto& c = reg->get<MeshAnimationComponent>(entity);
             out << YAML::Key << "MeshAnimationComponent" << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << c.name;
             out << YAML::Key << "time" << YAML::Value << c.time;
             out << YAML::Key << "speed" << YAML::Value << c.speed;
             out << YAML::EndMap;
         }
-        if (entity.has<TileMapSingleton>()) {
-            const auto& c = entity.get<TileMapSingleton>();
+        if (reg->has<TileMapSingleton>(entity)) {
+            const auto& c = reg->get<TileMapSingleton>(entity);
             out << YAML::Key << "TileMapSingleton" << YAML::BeginMap;
             out << YAML::Key << "tiles" << YAML::Value << c.tiles;
             out << YAML::EndMap;
@@ -167,8 +166,7 @@ void Save(const std::string& file, spkt::registry* reg)
     out << YAML::EndSeq;
     out << YAML::EndMap;
 
-    std::ofstream fout(file);
-    fout << out.c_str();
+    std::ofstream(file) << out.c_str();
 }
 
 void Load(const std::string& file, spkt::registry* reg)
@@ -188,141 +186,146 @@ void Load(const std::string& file, spkt::registry* reg)
 
     // Performs any extra transformations to values that cannot be done during
     // yaml decoding, for example converting entity IDs to their new values.
-    const auto transform = [&](auto&& param) {
-        if constexpr (std::is_same_v<decltype(param), apx::entity>) {
+    const auto transform = [&] <typename T> (T&& param) {
+        if constexpr (std::is_same_v<T, apx::entity>) {
             return id_remapper[param];
+        } else if constexpr (std::is_same_v<T, std::unordered_map<glm::ivec2, apx::entity>>) {
+            for (auto& entry : param) {
+                entry.second = id_remapper[entry.second];
+            }
+            return param;
+        } else {
+            static_assert(false);
         }
-        return param;
     };
 
-    for (auto entity : entities) {
-        apx::entity old_id = entity["ID#"].as<apx::entity>();
+    for (auto yaml_entity : entities) {
+        apx::entity old_id = yaml_entity["ID#"].as<apx::entity>();
         apx::entity new_id = reg->create();
         id_remapper[old_id] = new_id;
     }
 
-    for (auto entity : entities) {
-        apx::entity old_id = entity["ID#"].as<apx::entity>();
-        spkt::entity e{*reg, id_remapper[old_id]};
-        if (auto spec = entity["NameComponent"]) {
+    for (auto yaml_entity : entities) {
+        apx::entity entity = id_remapper[yaml_entity["ID#"].as<apx::entity>()];
+        if (auto spec = yaml_entity["NameComponent"]) {
             NameComponent c;
-            c.name = transform(spec["name"].as<std::string>());
-            e.add<NameComponent>(c);
+            c.name = spec["name"].as<std::string>();
+            reg->add<NameComponent>(entity, c);
         }
-        if (auto spec = entity["Transform2DComponent"]) {
+        if (auto spec = yaml_entity["Transform2DComponent"]) {
             Transform2DComponent c;
-            c.position = transform(spec["position"].as<glm::vec2>());
-            c.rotation = transform(spec["rotation"].as<float>());
-            c.scale = transform(spec["scale"].as<glm::vec2>());
-            e.add<Transform2DComponent>(c);
+            c.position = spec["position"].as<glm::vec2>();
+            c.rotation = spec["rotation"].as<float>();
+            c.scale = spec["scale"].as<glm::vec2>();
+            reg->add<Transform2DComponent>(entity, c);
         }
-        if (auto spec = entity["Transform3DComponent"]) {
+        if (auto spec = yaml_entity["Transform3DComponent"]) {
             Transform3DComponent c;
-            c.position = transform(spec["position"].as<glm::vec3>());
-            c.orientation = transform(spec["orientation"].as<glm::quat>());
-            c.scale = transform(spec["scale"].as<glm::vec3>());
-            e.add<Transform3DComponent>(c);
+            c.position = spec["position"].as<glm::vec3>();
+            c.orientation = spec["orientation"].as<glm::quat>();
+            c.scale = spec["scale"].as<glm::vec3>();
+            reg->add<Transform3DComponent>(entity, c);
         }
-        if (auto spec = entity["ModelComponent"]) {
+        if (auto spec = yaml_entity["ModelComponent"]) {
             ModelComponent c;
-            c.mesh = transform(spec["mesh"].as<std::string>());
-            c.material = transform(spec["material"].as<std::string>());
-            e.add<ModelComponent>(c);
+            c.mesh = spec["mesh"].as<std::string>();
+            c.material = spec["material"].as<std::string>();
+            reg->add<ModelComponent>(entity, c);
         }
-        if (auto spec = entity["RigidBody3DComponent"]) {
+        if (auto spec = yaml_entity["RigidBody3DComponent"]) {
             RigidBody3DComponent c;
-            c.velocity = transform(spec["velocity"].as<glm::vec3>());
-            c.gravity = transform(spec["gravity"].as<bool>());
-            c.frozen = transform(spec["frozen"].as<bool>());
-            c.bounciness = transform(spec["bounciness"].as<float>());
-            c.frictionCoefficient = transform(spec["frictionCoefficient"].as<float>());
-            c.rollingResistance = transform(spec["rollingResistance"].as<float>());
-            e.add<RigidBody3DComponent>(c);
+            c.velocity = spec["velocity"].as<glm::vec3>();
+            c.gravity = spec["gravity"].as<bool>();
+            c.frozen = spec["frozen"].as<bool>();
+            c.bounciness = spec["bounciness"].as<float>();
+            c.frictionCoefficient = spec["frictionCoefficient"].as<float>();
+            c.rollingResistance = spec["rollingResistance"].as<float>();
+            reg->add<RigidBody3DComponent>(entity, c);
         }
-        if (auto spec = entity["BoxCollider3DComponent"]) {
+        if (auto spec = yaml_entity["BoxCollider3DComponent"]) {
             BoxCollider3DComponent c;
-            c.position = transform(spec["position"].as<glm::vec3>());
-            c.orientation = transform(spec["orientation"].as<glm::quat>());
-            c.mass = transform(spec["mass"].as<float>());
-            c.halfExtents = transform(spec["halfExtents"].as<glm::vec3>());
-            c.applyScale = transform(spec["applyScale"].as<bool>());
-            e.add<BoxCollider3DComponent>(c);
+            c.position = spec["position"].as<glm::vec3>();
+            c.orientation = spec["orientation"].as<glm::quat>();
+            c.mass = spec["mass"].as<float>();
+            c.halfExtents = spec["halfExtents"].as<glm::vec3>();
+            c.applyScale = spec["applyScale"].as<bool>();
+            reg->add<BoxCollider3DComponent>(entity, c);
         }
-        if (auto spec = entity["SphereCollider3DComponent"]) {
+        if (auto spec = yaml_entity["SphereCollider3DComponent"]) {
             SphereCollider3DComponent c;
-            c.position = transform(spec["position"].as<glm::vec3>());
-            c.orientation = transform(spec["orientation"].as<glm::quat>());
-            c.mass = transform(spec["mass"].as<float>());
-            c.radius = transform(spec["radius"].as<float>());
-            e.add<SphereCollider3DComponent>(c);
+            c.position = spec["position"].as<glm::vec3>();
+            c.orientation = spec["orientation"].as<glm::quat>();
+            c.mass = spec["mass"].as<float>();
+            c.radius = spec["radius"].as<float>();
+            reg->add<SphereCollider3DComponent>(entity, c);
         }
-        if (auto spec = entity["CapsuleCollider3DComponent"]) {
+        if (auto spec = yaml_entity["CapsuleCollider3DComponent"]) {
             CapsuleCollider3DComponent c;
-            c.position = transform(spec["position"].as<glm::vec3>());
-            c.orientation = transform(spec["orientation"].as<glm::quat>());
-            c.mass = transform(spec["mass"].as<float>());
-            c.radius = transform(spec["radius"].as<float>());
-            c.height = transform(spec["height"].as<float>());
-            e.add<CapsuleCollider3DComponent>(c);
+            c.position = spec["position"].as<glm::vec3>();
+            c.orientation = spec["orientation"].as<glm::quat>();
+            c.mass = spec["mass"].as<float>();
+            c.radius = spec["radius"].as<float>();
+            c.height = spec["height"].as<float>();
+            reg->add<CapsuleCollider3DComponent>(entity, c);
         }
-        if (auto spec = entity["ScriptComponent"]) {
+        if (auto spec = yaml_entity["ScriptComponent"]) {
             ScriptComponent c;
-            c.script = transform(spec["script"].as<std::string>());
-            c.active = transform(spec["active"].as<bool>());
-            e.add<ScriptComponent>(c);
+            c.script = spec["script"].as<std::string>();
+            c.active = spec["active"].as<bool>();
+            reg->add<ScriptComponent>(entity, c);
         }
-        if (auto spec = entity["Camera3DComponent"]) {
+        if (auto spec = yaml_entity["Camera3DComponent"]) {
             Camera3DComponent c;
-            c.fov = transform(spec["fov"].as<float>());
-            c.pitch = transform(spec["pitch"].as<float>());
-            e.add<Camera3DComponent>(c);
+            c.fov = spec["fov"].as<float>();
+            c.pitch = spec["pitch"].as<float>();
+            reg->add<Camera3DComponent>(entity, c);
         }
-        if (auto spec = entity["PathComponent"]) {
+        if (auto spec = yaml_entity["PathComponent"]) {
             PathComponent c;
-            c.speed = transform(spec["speed"].as<float>());
-            e.add<PathComponent>(c);
+            c.speed = spec["speed"].as<float>();
+            reg->add<PathComponent>(entity, c);
         }
-        if (auto spec = entity["LightComponent"]) {
+        if (auto spec = yaml_entity["LightComponent"]) {
             LightComponent c;
-            c.colour = transform(spec["colour"].as<glm::vec3>());
-            c.brightness = transform(spec["brightness"].as<float>());
-            e.add<LightComponent>(c);
+            c.colour = spec["colour"].as<glm::vec3>();
+            c.brightness = spec["brightness"].as<float>();
+            reg->add<LightComponent>(entity, c);
         }
-        if (auto spec = entity["SunComponent"]) {
+        if (auto spec = yaml_entity["SunComponent"]) {
             SunComponent c;
-            c.colour = transform(spec["colour"].as<glm::vec3>());
-            c.brightness = transform(spec["brightness"].as<float>());
-            c.direction = transform(spec["direction"].as<glm::vec3>());
-            c.shadows = transform(spec["shadows"].as<bool>());
-            e.add<SunComponent>(c);
+            c.colour = spec["colour"].as<glm::vec3>();
+            c.brightness = spec["brightness"].as<float>();
+            c.direction = spec["direction"].as<glm::vec3>();
+            c.shadows = spec["shadows"].as<bool>();
+            reg->add<SunComponent>(entity, c);
         }
-        if (auto spec = entity["AmbienceComponent"]) {
+        if (auto spec = yaml_entity["AmbienceComponent"]) {
             AmbienceComponent c;
-            c.colour = transform(spec["colour"].as<glm::vec3>());
-            c.brightness = transform(spec["brightness"].as<float>());
-            e.add<AmbienceComponent>(c);
+            c.colour = spec["colour"].as<glm::vec3>();
+            c.brightness = spec["brightness"].as<float>();
+            reg->add<AmbienceComponent>(entity, c);
         }
-        if (auto spec = entity["ParticleComponent"]) {
+        if (auto spec = yaml_entity["ParticleComponent"]) {
             ParticleComponent c;
-            c.interval = transform(spec["interval"].as<float>());
-            c.velocity = transform(spec["velocity"].as<glm::vec3>());
-            c.velocityNoise = transform(spec["velocityNoise"].as<float>());
-            c.acceleration = transform(spec["acceleration"].as<glm::vec3>());
-            c.scale = transform(spec["scale"].as<glm::vec3>());
-            c.life = transform(spec["life"].as<float>());
-            e.add<ParticleComponent>(c);
+            c.interval = spec["interval"].as<float>();
+            c.velocity = spec["velocity"].as<glm::vec3>();
+            c.velocityNoise = spec["velocityNoise"].as<float>();
+            c.acceleration = spec["acceleration"].as<glm::vec3>();
+            c.scale = spec["scale"].as<glm::vec3>();
+            c.life = spec["life"].as<float>();
+            reg->add<ParticleComponent>(entity, c);
         }
-        if (auto spec = entity["MeshAnimationComponent"]) {
+        if (auto spec = yaml_entity["MeshAnimationComponent"]) {
             MeshAnimationComponent c;
-            c.name = transform(spec["name"].as<std::string>());
-            c.time = transform(spec["time"].as<float>());
-            c.speed = transform(spec["speed"].as<float>());
-            e.add<MeshAnimationComponent>(c);
+            c.name = spec["name"].as<std::string>();
+            c.time = spec["time"].as<float>();
+            c.speed = spec["speed"].as<float>();
+            reg->add<MeshAnimationComponent>(entity, c);
         }
-        if (auto spec = entity["TileMapSingleton"]) {
+        if (auto spec = yaml_entity["TileMapSingleton"]) {
             TileMapSingleton c;
             c.tiles = transform(spec["tiles"].as<std::unordered_map<glm::ivec2, apx::entity>>());
-            e.add<TileMapSingleton>(c);
+            reg->add<TileMapSingleton>(entity, c);
         }
     }
 }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -327,86 +327,86 @@ void Load(const std::string& file, spkt::registry* reg)
     }
 }
 
-spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
+apx::entity Copy(spkt::registry* reg, apx::entity entity)
 {
-    spkt::entity e = apx::create_from(*reg);
-    if (entity.has<Runtime>()) {
-        e.add<Runtime>(entity.get<Runtime>());
+    apx::entity e = reg->create();
+    if (reg->has<Runtime>(entity)) {
+        reg->add<Runtime>(e, reg->get<Runtime>(entity));
     }
-    if (entity.has<Singleton>()) {
-        e.add<Singleton>(entity.get<Singleton>());
+    if (reg->has<Singleton>(entity)) {
+        reg->add<Singleton>(e, reg->get<Singleton>(entity));
     }
-    if (entity.has<Event>()) {
-        e.add<Event>(entity.get<Event>());
+    if (reg->has<Event>(entity)) {
+        reg->add<Event>(e, reg->get<Event>(entity));
     }
-    if (entity.has<NameComponent>()) {
-        e.add<NameComponent>(entity.get<NameComponent>());
+    if (reg->has<NameComponent>(entity)) {
+        reg->add<NameComponent>(e, reg->get<NameComponent>(entity));
     }
-    if (entity.has<Transform2DComponent>()) {
-        e.add<Transform2DComponent>(entity.get<Transform2DComponent>());
+    if (reg->has<Transform2DComponent>(entity)) {
+        reg->add<Transform2DComponent>(e, reg->get<Transform2DComponent>(entity));
     }
-    if (entity.has<Transform3DComponent>()) {
-        e.add<Transform3DComponent>(entity.get<Transform3DComponent>());
+    if (reg->has<Transform3DComponent>(entity)) {
+        reg->add<Transform3DComponent>(e, reg->get<Transform3DComponent>(entity));
     }
-    if (entity.has<ModelComponent>()) {
-        e.add<ModelComponent>(entity.get<ModelComponent>());
+    if (reg->has<ModelComponent>(entity)) {
+        reg->add<ModelComponent>(e, reg->get<ModelComponent>(entity));
     }
-    if (entity.has<RigidBody3DComponent>()) {
-        e.add<RigidBody3DComponent>(entity.get<RigidBody3DComponent>());
+    if (reg->has<RigidBody3DComponent>(entity)) {
+        reg->add<RigidBody3DComponent>(e, reg->get<RigidBody3DComponent>(entity));
     }
-    if (entity.has<BoxCollider3DComponent>()) {
-        e.add<BoxCollider3DComponent>(entity.get<BoxCollider3DComponent>());
+    if (reg->has<BoxCollider3DComponent>(entity)) {
+        reg->add<BoxCollider3DComponent>(e, reg->get<BoxCollider3DComponent>(entity));
     }
-    if (entity.has<SphereCollider3DComponent>()) {
-        e.add<SphereCollider3DComponent>(entity.get<SphereCollider3DComponent>());
+    if (reg->has<SphereCollider3DComponent>(entity)) {
+        reg->add<SphereCollider3DComponent>(e, reg->get<SphereCollider3DComponent>(entity));
     }
-    if (entity.has<CapsuleCollider3DComponent>()) {
-        e.add<CapsuleCollider3DComponent>(entity.get<CapsuleCollider3DComponent>());
+    if (reg->has<CapsuleCollider3DComponent>(entity)) {
+        reg->add<CapsuleCollider3DComponent>(e, reg->get<CapsuleCollider3DComponent>(entity));
     }
-    if (entity.has<ScriptComponent>()) {
-        e.add<ScriptComponent>(entity.get<ScriptComponent>());
+    if (reg->has<ScriptComponent>(entity)) {
+        reg->add<ScriptComponent>(e, reg->get<ScriptComponent>(entity));
     }
-    if (entity.has<Camera3DComponent>()) {
-        e.add<Camera3DComponent>(entity.get<Camera3DComponent>());
+    if (reg->has<Camera3DComponent>(entity)) {
+        reg->add<Camera3DComponent>(e, reg->get<Camera3DComponent>(entity));
     }
-    if (entity.has<PathComponent>()) {
-        e.add<PathComponent>(entity.get<PathComponent>());
+    if (reg->has<PathComponent>(entity)) {
+        reg->add<PathComponent>(e, reg->get<PathComponent>(entity));
     }
-    if (entity.has<LightComponent>()) {
-        e.add<LightComponent>(entity.get<LightComponent>());
+    if (reg->has<LightComponent>(entity)) {
+        reg->add<LightComponent>(e, reg->get<LightComponent>(entity));
     }
-    if (entity.has<SunComponent>()) {
-        e.add<SunComponent>(entity.get<SunComponent>());
+    if (reg->has<SunComponent>(entity)) {
+        reg->add<SunComponent>(e, reg->get<SunComponent>(entity));
     }
-    if (entity.has<AmbienceComponent>()) {
-        e.add<AmbienceComponent>(entity.get<AmbienceComponent>());
+    if (reg->has<AmbienceComponent>(entity)) {
+        reg->add<AmbienceComponent>(e, reg->get<AmbienceComponent>(entity));
     }
-    if (entity.has<ParticleComponent>()) {
-        e.add<ParticleComponent>(entity.get<ParticleComponent>());
+    if (reg->has<ParticleComponent>(entity)) {
+        reg->add<ParticleComponent>(e, reg->get<ParticleComponent>(entity));
     }
-    if (entity.has<MeshAnimationComponent>()) {
-        e.add<MeshAnimationComponent>(entity.get<MeshAnimationComponent>());
+    if (reg->has<MeshAnimationComponent>(entity)) {
+        reg->add<MeshAnimationComponent>(e, reg->get<MeshAnimationComponent>(entity));
     }
-    if (entity.has<CollisionEvent>()) {
-        e.add<CollisionEvent>(entity.get<CollisionEvent>());
+    if (reg->has<CollisionEvent>(entity)) {
+        reg->add<CollisionEvent>(e, reg->get<CollisionEvent>(entity));
     }
-    if (entity.has<PhysicsSingleton>()) {
-        e.add<PhysicsSingleton>(entity.get<PhysicsSingleton>());
+    if (reg->has<PhysicsSingleton>(entity)) {
+        reg->add<PhysicsSingleton>(e, reg->get<PhysicsSingleton>(entity));
     }
-    if (entity.has<InputSingleton>()) {
-        e.add<InputSingleton>(entity.get<InputSingleton>());
+    if (reg->has<InputSingleton>(entity)) {
+        reg->add<InputSingleton>(e, reg->get<InputSingleton>(entity));
     }
-    if (entity.has<GameGridSingleton>()) {
-        e.add<GameGridSingleton>(entity.get<GameGridSingleton>());
+    if (reg->has<GameGridSingleton>(entity)) {
+        reg->add<GameGridSingleton>(e, reg->get<GameGridSingleton>(entity));
     }
-    if (entity.has<TileMapSingleton>()) {
-        e.add<TileMapSingleton>(entity.get<TileMapSingleton>());
+    if (reg->has<TileMapSingleton>(entity)) {
+        reg->add<TileMapSingleton>(e, reg->get<TileMapSingleton>(entity));
     }
-    if (entity.has<CameraSingleton>()) {
-        e.add<CameraSingleton>(entity.get<CameraSingleton>());
+    if (reg->has<CameraSingleton>(entity)) {
+        reg->add<CameraSingleton>(e, reg->get<CameraSingleton>(entity));
     }
-    if (entity.has<ParticleSingleton>()) {
-        e.add<ParticleSingleton>(entity.get<ParticleSingleton>());
+    if (reg->has<ParticleSingleton>(entity)) {
+        reg->add<ParticleSingleton>(e, reg->get<ParticleSingleton>(entity));
     }
     return e;
 }

--- a/Sprocket/Scene/Loader.cpp
+++ b/Sprocket/Scene/Loader.cpp
@@ -343,86 +343,13 @@ void Load(const std::string& file, spkt::registry* reg)
 
 apx::entity Copy(spkt::registry* reg, apx::entity entity)
 {
-    apx::entity e = reg->create();
-    if (reg->has<Runtime>(entity)) {
-        reg->add<Runtime>(e, reg->get<Runtime>(entity));
-    }
-    if (reg->has<Singleton>(entity)) {
-        reg->add<Singleton>(e, reg->get<Singleton>(entity));
-    }
-    if (reg->has<Event>(entity)) {
-        reg->add<Event>(e, reg->get<Event>(entity));
-    }
-    if (reg->has<NameComponent>(entity)) {
-        reg->add<NameComponent>(e, reg->get<NameComponent>(entity));
-    }
-    if (reg->has<Transform2DComponent>(entity)) {
-        reg->add<Transform2DComponent>(e, reg->get<Transform2DComponent>(entity));
-    }
-    if (reg->has<Transform3DComponent>(entity)) {
-        reg->add<Transform3DComponent>(e, reg->get<Transform3DComponent>(entity));
-    }
-    if (reg->has<ModelComponent>(entity)) {
-        reg->add<ModelComponent>(e, reg->get<ModelComponent>(entity));
-    }
-    if (reg->has<RigidBody3DComponent>(entity)) {
-        reg->add<RigidBody3DComponent>(e, reg->get<RigidBody3DComponent>(entity));
-    }
-    if (reg->has<BoxCollider3DComponent>(entity)) {
-        reg->add<BoxCollider3DComponent>(e, reg->get<BoxCollider3DComponent>(entity));
-    }
-    if (reg->has<SphereCollider3DComponent>(entity)) {
-        reg->add<SphereCollider3DComponent>(e, reg->get<SphereCollider3DComponent>(entity));
-    }
-    if (reg->has<CapsuleCollider3DComponent>(entity)) {
-        reg->add<CapsuleCollider3DComponent>(e, reg->get<CapsuleCollider3DComponent>(entity));
-    }
-    if (reg->has<ScriptComponent>(entity)) {
-        reg->add<ScriptComponent>(e, reg->get<ScriptComponent>(entity));
-    }
-    if (reg->has<Camera3DComponent>(entity)) {
-        reg->add<Camera3DComponent>(e, reg->get<Camera3DComponent>(entity));
-    }
-    if (reg->has<PathComponent>(entity)) {
-        reg->add<PathComponent>(e, reg->get<PathComponent>(entity));
-    }
-    if (reg->has<LightComponent>(entity)) {
-        reg->add<LightComponent>(e, reg->get<LightComponent>(entity));
-    }
-    if (reg->has<SunComponent>(entity)) {
-        reg->add<SunComponent>(e, reg->get<SunComponent>(entity));
-    }
-    if (reg->has<AmbienceComponent>(entity)) {
-        reg->add<AmbienceComponent>(e, reg->get<AmbienceComponent>(entity));
-    }
-    if (reg->has<ParticleComponent>(entity)) {
-        reg->add<ParticleComponent>(e, reg->get<ParticleComponent>(entity));
-    }
-    if (reg->has<MeshAnimationComponent>(entity)) {
-        reg->add<MeshAnimationComponent>(e, reg->get<MeshAnimationComponent>(entity));
-    }
-    if (reg->has<CollisionEvent>(entity)) {
-        reg->add<CollisionEvent>(e, reg->get<CollisionEvent>(entity));
-    }
-    if (reg->has<PhysicsSingleton>(entity)) {
-        reg->add<PhysicsSingleton>(e, reg->get<PhysicsSingleton>(entity));
-    }
-    if (reg->has<InputSingleton>(entity)) {
-        reg->add<InputSingleton>(e, reg->get<InputSingleton>(entity));
-    }
-    if (reg->has<GameGridSingleton>(entity)) {
-        reg->add<GameGridSingleton>(e, reg->get<GameGridSingleton>(entity));
-    }
-    if (reg->has<TileMapSingleton>(entity)) {
-        reg->add<TileMapSingleton>(e, reg->get<TileMapSingleton>(entity));
-    }
-    if (reg->has<CameraSingleton>(entity)) {
-        reg->add<CameraSingleton>(e, reg->get<CameraSingleton>(entity));
-    }
-    if (reg->has<ParticleSingleton>(entity)) {
-        reg->add<ParticleSingleton>(e, reg->get<ParticleSingleton>(entity));
-    }
-    return e;
+    apx::entity new_entity = reg->create();
+    apx::meta::for_each(reg->tags, [&] <typename T> (apx::meta::tag<T> tag) {
+        if (reg->has<T>(entity)) {
+            reg->add<T>(new_entity, reg->get<T>(entity));
+        }
+    });
+    return new_entity;
 }
 
 void Copy(spkt::registry* source, spkt::registry* target)
@@ -431,59 +358,57 @@ void Copy(spkt::registry* source, spkt::registry* target)
     // new and old IDs.
     std::unordered_map<apx::entity, apx::entity> id_remapper;
     for (auto id : source->all()) {
-        apx::entity new_id = target->create();
-        id_remapper[id] = new_id;
+        id_remapper[id] = target->create();;
     }
 
-    for (auto id : source->all()) {
-        spkt::entity src{*source, id};
-        spkt::entity dst{*target, id_remapper[id]};
-        if (src.has<Runtime>()) {
-            const Runtime& source_comp = src.get<Runtime>();
+    for (auto old_entity : source->all()) {
+        apx::entity new_entity = id_remapper.at(old_entity);
+        if (source->has<Runtime>(old_entity)) {
+            const Runtime& source_comp = source->get<Runtime>(old_entity);
             Runtime target_comp;
-            dst.add<Runtime>(target_comp);
+            target->add<Runtime>(new_entity, target_comp);
         }
-        if (src.has<Singleton>()) {
-            const Singleton& source_comp = src.get<Singleton>();
+        if (source->has<Singleton>(old_entity)) {
+            const Singleton& source_comp = source->get<Singleton>(old_entity);
             Singleton target_comp;
-            dst.add<Singleton>(target_comp);
+            target->add<Singleton>(new_entity, target_comp);
         }
-        if (src.has<Event>()) {
-            const Event& source_comp = src.get<Event>();
+        if (source->has<Event>(old_entity)) {
+            const Event& source_comp = source->get<Event>(old_entity);
             Event target_comp;
-            dst.add<Event>(target_comp);
+            target->add<Event>(new_entity, target_comp);
         }
-        if (src.has<NameComponent>()) {
-            const NameComponent& source_comp = src.get<NameComponent>();
+        if (source->has<NameComponent>(old_entity)) {
+            const NameComponent& source_comp = source->get<NameComponent>(old_entity);
             NameComponent target_comp;
             target_comp.name = source_comp.name;
-            dst.add<NameComponent>(target_comp);
+            target->add<NameComponent>(new_entity, target_comp);
         }
-        if (src.has<Transform2DComponent>()) {
-            const Transform2DComponent& source_comp = src.get<Transform2DComponent>();
+        if (source->has<Transform2DComponent>(old_entity)) {
+            const Transform2DComponent& source_comp = source->get<Transform2DComponent>(old_entity);
             Transform2DComponent target_comp;
             target_comp.position = source_comp.position;
             target_comp.rotation = source_comp.rotation;
             target_comp.scale = source_comp.scale;
-            dst.add<Transform2DComponent>(target_comp);
+            target->add<Transform2DComponent>(new_entity, target_comp);
         }
-        if (src.has<Transform3DComponent>()) {
-            const Transform3DComponent& source_comp = src.get<Transform3DComponent>();
+        if (source->has<Transform3DComponent>(old_entity)) {
+            const Transform3DComponent& source_comp = source->get<Transform3DComponent>(old_entity);
             Transform3DComponent target_comp;
             target_comp.position = source_comp.position;
             target_comp.orientation = source_comp.orientation;
             target_comp.scale = source_comp.scale;
-            dst.add<Transform3DComponent>(target_comp);
+            target->add<Transform3DComponent>(new_entity, target_comp);
         }
-        if (src.has<ModelComponent>()) {
-            const ModelComponent& source_comp = src.get<ModelComponent>();
+        if (source->has<ModelComponent>(old_entity)) {
+            const ModelComponent& source_comp = source->get<ModelComponent>(old_entity);
             ModelComponent target_comp;
             target_comp.mesh = source_comp.mesh;
             target_comp.material = source_comp.material;
-            dst.add<ModelComponent>(target_comp);
+            target->add<ModelComponent>(new_entity, target_comp);
         }
-        if (src.has<RigidBody3DComponent>()) {
-            const RigidBody3DComponent& source_comp = src.get<RigidBody3DComponent>();
+        if (source->has<RigidBody3DComponent>(old_entity)) {
+            const RigidBody3DComponent& source_comp = source->get<RigidBody3DComponent>(old_entity);
             RigidBody3DComponent target_comp;
             target_comp.velocity = source_comp.velocity;
             target_comp.gravity = source_comp.gravity;
@@ -494,10 +419,10 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.force = source_comp.force;
             target_comp.onFloor = source_comp.onFloor;
             target_comp.runtime = source_comp.runtime;
-            dst.add<RigidBody3DComponent>(target_comp);
+            target->add<RigidBody3DComponent>(new_entity, target_comp);
         }
-        if (src.has<BoxCollider3DComponent>()) {
-            const BoxCollider3DComponent& source_comp = src.get<BoxCollider3DComponent>();
+        if (source->has<BoxCollider3DComponent>(old_entity)) {
+            const BoxCollider3DComponent& source_comp = source->get<BoxCollider3DComponent>(old_entity);
             BoxCollider3DComponent target_comp;
             target_comp.position = source_comp.position;
             target_comp.orientation = source_comp.orientation;
@@ -505,20 +430,20 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.halfExtents = source_comp.halfExtents;
             target_comp.applyScale = source_comp.applyScale;
             target_comp.runtime = source_comp.runtime;
-            dst.add<BoxCollider3DComponent>(target_comp);
+            target->add<BoxCollider3DComponent>(new_entity, target_comp);
         }
-        if (src.has<SphereCollider3DComponent>()) {
-            const SphereCollider3DComponent& source_comp = src.get<SphereCollider3DComponent>();
+        if (source->has<SphereCollider3DComponent>(old_entity)) {
+            const SphereCollider3DComponent& source_comp = source->get<SphereCollider3DComponent>(old_entity);
             SphereCollider3DComponent target_comp;
             target_comp.position = source_comp.position;
             target_comp.orientation = source_comp.orientation;
             target_comp.mass = source_comp.mass;
             target_comp.radius = source_comp.radius;
             target_comp.runtime = source_comp.runtime;
-            dst.add<SphereCollider3DComponent>(target_comp);
+            target->add<SphereCollider3DComponent>(new_entity, target_comp);
         }
-        if (src.has<CapsuleCollider3DComponent>()) {
-            const CapsuleCollider3DComponent& source_comp = src.get<CapsuleCollider3DComponent>();
+        if (source->has<CapsuleCollider3DComponent>(old_entity)) {
+            const CapsuleCollider3DComponent& source_comp = source->get<CapsuleCollider3DComponent>(old_entity);
             CapsuleCollider3DComponent target_comp;
             target_comp.position = source_comp.position;
             target_comp.orientation = source_comp.orientation;
@@ -526,56 +451,56 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.radius = source_comp.radius;
             target_comp.height = source_comp.height;
             target_comp.runtime = source_comp.runtime;
-            dst.add<CapsuleCollider3DComponent>(target_comp);
+            target->add<CapsuleCollider3DComponent>(new_entity, target_comp);
         }
-        if (src.has<ScriptComponent>()) {
-            const ScriptComponent& source_comp = src.get<ScriptComponent>();
+        if (source->has<ScriptComponent>(old_entity)) {
+            const ScriptComponent& source_comp = source->get<ScriptComponent>(old_entity);
             ScriptComponent target_comp;
             target_comp.script = source_comp.script;
             target_comp.active = source_comp.active;
             target_comp.script_runtime = source_comp.script_runtime;
-            dst.add<ScriptComponent>(target_comp);
+            target->add<ScriptComponent>(new_entity, target_comp);
         }
-        if (src.has<Camera3DComponent>()) {
-            const Camera3DComponent& source_comp = src.get<Camera3DComponent>();
+        if (source->has<Camera3DComponent>(old_entity)) {
+            const Camera3DComponent& source_comp = source->get<Camera3DComponent>(old_entity);
             Camera3DComponent target_comp;
             target_comp.projection = source_comp.projection;
             target_comp.fov = source_comp.fov;
             target_comp.pitch = source_comp.pitch;
-            dst.add<Camera3DComponent>(target_comp);
+            target->add<Camera3DComponent>(new_entity, target_comp);
         }
-        if (src.has<PathComponent>()) {
-            const PathComponent& source_comp = src.get<PathComponent>();
+        if (source->has<PathComponent>(old_entity)) {
+            const PathComponent& source_comp = source->get<PathComponent>(old_entity);
             PathComponent target_comp;
             target_comp.markers = source_comp.markers;
             target_comp.speed = source_comp.speed;
-            dst.add<PathComponent>(target_comp);
+            target->add<PathComponent>(new_entity, target_comp);
         }
-        if (src.has<LightComponent>()) {
-            const LightComponent& source_comp = src.get<LightComponent>();
+        if (source->has<LightComponent>(old_entity)) {
+            const LightComponent& source_comp = source->get<LightComponent>(old_entity);
             LightComponent target_comp;
             target_comp.colour = source_comp.colour;
             target_comp.brightness = source_comp.brightness;
-            dst.add<LightComponent>(target_comp);
+            target->add<LightComponent>(new_entity, target_comp);
         }
-        if (src.has<SunComponent>()) {
-            const SunComponent& source_comp = src.get<SunComponent>();
+        if (source->has<SunComponent>(old_entity)) {
+            const SunComponent& source_comp = source->get<SunComponent>(old_entity);
             SunComponent target_comp;
             target_comp.colour = source_comp.colour;
             target_comp.brightness = source_comp.brightness;
             target_comp.direction = source_comp.direction;
             target_comp.shadows = source_comp.shadows;
-            dst.add<SunComponent>(target_comp);
+            target->add<SunComponent>(new_entity, target_comp);
         }
-        if (src.has<AmbienceComponent>()) {
-            const AmbienceComponent& source_comp = src.get<AmbienceComponent>();
+        if (source->has<AmbienceComponent>(old_entity)) {
+            const AmbienceComponent& source_comp = source->get<AmbienceComponent>(old_entity);
             AmbienceComponent target_comp;
             target_comp.colour = source_comp.colour;
             target_comp.brightness = source_comp.brightness;
-            dst.add<AmbienceComponent>(target_comp);
+            target->add<AmbienceComponent>(new_entity, target_comp);
         }
-        if (src.has<ParticleComponent>()) {
-            const ParticleComponent& source_comp = src.get<ParticleComponent>();
+        if (source->has<ParticleComponent>(old_entity)) {
+            const ParticleComponent& source_comp = source->get<ParticleComponent>(old_entity);
             ParticleComponent target_comp;
             target_comp.interval = source_comp.interval;
             target_comp.velocity = source_comp.velocity;
@@ -584,31 +509,31 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.scale = source_comp.scale;
             target_comp.life = source_comp.life;
             target_comp.accumulator = source_comp.accumulator;
-            dst.add<ParticleComponent>(target_comp);
+            target->add<ParticleComponent>(new_entity, target_comp);
         }
-        if (src.has<MeshAnimationComponent>()) {
-            const MeshAnimationComponent& source_comp = src.get<MeshAnimationComponent>();
+        if (source->has<MeshAnimationComponent>(old_entity)) {
+            const MeshAnimationComponent& source_comp = source->get<MeshAnimationComponent>(old_entity);
             MeshAnimationComponent target_comp;
             target_comp.name = source_comp.name;
             target_comp.time = source_comp.time;
             target_comp.speed = source_comp.speed;
-            dst.add<MeshAnimationComponent>(target_comp);
+            target->add<MeshAnimationComponent>(new_entity, target_comp);
         }
-        if (src.has<CollisionEvent>()) {
-            const CollisionEvent& source_comp = src.get<CollisionEvent>();
+        if (source->has<CollisionEvent>(old_entity)) {
+            const CollisionEvent& source_comp = source->get<CollisionEvent>(old_entity);
             CollisionEvent target_comp;
             target_comp.entity_a = transform_entity(id_remapper, source_comp.entity_a);
             target_comp.entity_b = transform_entity(id_remapper, source_comp.entity_b);
-            dst.add<CollisionEvent>(target_comp);
+            target->add<CollisionEvent>(new_entity, target_comp);
         }
-        if (src.has<PhysicsSingleton>()) {
-            const PhysicsSingleton& source_comp = src.get<PhysicsSingleton>();
+        if (source->has<PhysicsSingleton>(old_entity)) {
+            const PhysicsSingleton& source_comp = source->get<PhysicsSingleton>(old_entity);
             PhysicsSingleton target_comp;
             target_comp.physics_runtime = source_comp.physics_runtime;
-            dst.add<PhysicsSingleton>(target_comp);
+            target->add<PhysicsSingleton>(new_entity, target_comp);
         }
-        if (src.has<InputSingleton>()) {
-            const InputSingleton& source_comp = src.get<InputSingleton>();
+        if (source->has<InputSingleton>(old_entity)) {
+            const InputSingleton& source_comp = source->get<InputSingleton>(old_entity);
             InputSingleton target_comp;
             target_comp.keyboard = source_comp.keyboard;
             target_comp.mouse = source_comp.mouse;
@@ -620,34 +545,34 @@ void Copy(spkt::registry* source, spkt::registry* target)
             target_comp.window_width = source_comp.window_width;
             target_comp.window_height = source_comp.window_height;
             target_comp.window_resized = source_comp.window_resized;
-            dst.add<InputSingleton>(target_comp);
+            target->add<InputSingleton>(new_entity, target_comp);
         }
-        if (src.has<GameGridSingleton>()) {
-            const GameGridSingleton& source_comp = src.get<GameGridSingleton>();
+        if (source->has<GameGridSingleton>(old_entity)) {
+            const GameGridSingleton& source_comp = source->get<GameGridSingleton>(old_entity);
             GameGridSingleton target_comp;
             target_comp.hovered_square_entity = transform_entity(id_remapper, source_comp.hovered_square_entity);
             target_comp.clicked_square_entity = transform_entity(id_remapper, source_comp.clicked_square_entity);
             target_comp.hovered_square = source_comp.hovered_square;
             target_comp.clicked_square = source_comp.clicked_square;
-            dst.add<GameGridSingleton>(target_comp);
+            target->add<GameGridSingleton>(new_entity, target_comp);
         }
-        if (src.has<TileMapSingleton>()) {
-            const TileMapSingleton& source_comp = src.get<TileMapSingleton>();
+        if (source->has<TileMapSingleton>(old_entity)) {
+            const TileMapSingleton& source_comp = source->get<TileMapSingleton>(old_entity);
             TileMapSingleton target_comp;
             target_comp.tiles = transform_entity(id_remapper, source_comp.tiles);
-            dst.add<TileMapSingleton>(target_comp);
+            target->add<TileMapSingleton>(new_entity, target_comp);
         }
-        if (src.has<CameraSingleton>()) {
-            const CameraSingleton& source_comp = src.get<CameraSingleton>();
+        if (source->has<CameraSingleton>(old_entity)) {
+            const CameraSingleton& source_comp = source->get<CameraSingleton>(old_entity);
             CameraSingleton target_comp;
             target_comp.camera_entity = transform_entity(id_remapper, source_comp.camera_entity);
-            dst.add<CameraSingleton>(target_comp);
+            target->add<CameraSingleton>(new_entity, target_comp);
         }
-        if (src.has<ParticleSingleton>()) {
-            const ParticleSingleton& source_comp = src.get<ParticleSingleton>();
+        if (source->has<ParticleSingleton>(old_entity)) {
+            const ParticleSingleton& source_comp = source->get<ParticleSingleton>(old_entity);
             ParticleSingleton target_comp;
             target_comp.particle_manager = source_comp.particle_manager;
-            dst.add<ParticleSingleton>(target_comp);
+            target->add<ParticleSingleton>(new_entity, target_comp);
         }
     }
 }

--- a/Sprocket/Scene/Loader.dm.cpp
+++ b/Sprocket/Scene/Loader.dm.cpp
@@ -85,12 +85,12 @@ DATAMATIC_END
     }
 }
 
-spkt::entity Copy(spkt::registry* reg, spkt::entity entity)
+apx::entity Copy(spkt::registry* reg, apx::entity entity)
 {
-    spkt::entity e = apx::create_from(*reg);
+    apx::entity e = reg->create();
 DATAMATIC_BEGIN
-    if (entity.has<{{Comp::name}}>()) {
-        e.add<{{Comp::name}}>(entity.get<{{Comp::name}}>());
+    if (reg->has<{{Comp::name}}>(entity)) {
+        reg->add<{{Comp::name}}>(e, reg->get<{{Comp::name}}>(entity));
     }
 DATAMATIC_END
     return e;

--- a/Sprocket/Scene/Loader.dmx.py
+++ b/Sprocket/Scene/Loader.dmx.py
@@ -1,0 +1,21 @@
+def wrap(cpp_type, expression):
+    if "apx::entity" in cpp_type:
+        return f"transform_entity(id_remapper, {expression})"
+    return expression
+
+
+def main(reg):
+
+    @reg.attrmethod
+    def parse_value_from_spec(ctx):
+        name = ctx.attr["name"]
+        cpp_type = ctx.attr["type"]
+        expression = f"spec[\"{name}\"].as<{cpp_type}>()"
+        return wrap(cpp_type, expression)
+
+    @reg.attrmethod
+    def parse_value_copy(ctx):
+        name = ctx.attr["name"]
+        cpp_type = ctx.attr["type"]
+        expression = f"source_comp.{name}"
+        return wrap(cpp_type, expression)

--- a/Sprocket/Scene/Loader.h
+++ b/Sprocket/Scene/Loader.h
@@ -11,7 +11,7 @@ void Load(const std::string& file, spkt::registry* reg);
 
 // Creates a copy of the given Entity within the given Scene. The given
 // entity can be from a different scene.
-spkt::entity Copy(spkt::registry* scene, spkt::entity entity);
+apx::entity Copy(spkt::registry* scene, apx::entity entity);
 
 // Copies one scene into another. The target scene is first cleared.
 void Copy(spkt::registry* source, spkt::registry* target);


### PR DESCRIPTION
* Replace to use of `spkt::entity` with `apx::entity` in a lot of cases. Eventually we will make a type erased registry and just use `apx` types directly.
* Spotted and fixed and issue with the scene loader: types that contain entities, eg `std::unordered_map<glm::ivce2, apx::entity>`, was not performing remapping. Changed the transform function to result in a compiler error if we introduce a new type that fails to do this. This was achieved by wrapping any type with `apx::entity` in the name with the transform function using a datamatic plugin, and then having that transform static_assert if it does not transform rather than just passing the value through like before. This then started failing to compile until I added a branch for unordered maps. This is not ideal but at least prevents us from getting into a case where remapping is not happening.