### PR TITLE
Input System

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -97,6 +97,10 @@
         "stop_token": "cpp",
         "typeindex": "cpp",
         "typeinfo": "cpp",
-        "coroutine": "cpp"
+        "coroutine": "cpp",
+        "charconv": "cpp",
+        "format": "cpp",
+        "span": "cpp",
+        "sstream": "cpp"
     }
 }

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -47,7 +47,8 @@ Anvil::Anvil(Window* window)
 {
     d_window->SetCursorVisibility(true);
 
-    d_scene = std::make_shared<Scene>();    
+    d_scene = std::make_shared<Scene>(); 
+    spkt::add_singleton(d_scene->Entities());   
     spkt::load_registry_from_file(d_sceneFile, &d_scene->Entities());
     d_activeScene = d_scene;
 }
@@ -183,8 +184,9 @@ void Anvil::on_render()
         if (ImGui::BeginMenu("Scene")) {
             if (ImGui::MenuItem("Run")) {
                 d_activeScene = std::make_shared<Scene>();
-                spkt::copy_registry(&d_scene->Entities(), &d_activeScene->Entities());
 
+                spkt::add_singleton(d_activeScene->Entities());
+                spkt::copy_registry(&d_scene->Entities(), &d_activeScene->Entities());
                 spkt::particle_system_init(d_activeScene->Entities(), &d_particle_manager);
 
                 d_activeScene->add(spkt::physics_system);

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -47,7 +47,7 @@ Anvil::Anvil(Window* window)
 {
     d_window->SetCursorVisibility(true);
 
-    d_scene = std::make_shared<Scene>(window);    
+    d_scene = std::make_shared<Scene>();    
     spkt::load_registry_from_file(d_sceneFile, &d_scene->Entities());
     d_activeScene = d_scene;
 }
@@ -150,7 +150,7 @@ void Anvil::on_render()
                 if (!file.empty()) {
                     log::info("Creating {}...", d_sceneFile);
                     d_sceneFile = file;
-                    d_activeScene = d_scene = std::make_shared<Scene>(d_window);
+                    d_activeScene = d_scene = std::make_shared<Scene>();
                     log::info("...done!");
                 }
             }
@@ -159,7 +159,7 @@ void Anvil::on_render()
                 if (!file.empty()) {
                     log::info("Loading {}...", d_sceneFile);
                     d_sceneFile = file;
-                    d_activeScene = d_scene = std::make_shared<Scene>(d_window);
+                    d_activeScene = d_scene = std::make_shared<Scene>();
                     spkt::load_registry_from_file(file, &d_scene->Entities());
                     log::info("...done!");
                 }
@@ -182,7 +182,7 @@ void Anvil::on_render()
         }
         if (ImGui::BeginMenu("Scene")) {
             if (ImGui::MenuItem("Run")) {
-                d_activeScene = std::make_shared<Scene>(d_window);
+                d_activeScene = std::make_shared<Scene>();
                 spkt::copy_registry(&d_scene->Entities(), &d_activeScene->Entities());
 
                 spkt::particle_system_init(d_activeScene->Entities(), &d_particle_manager);

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -309,6 +309,7 @@ void Inspector::Show(Anvil& editor)
             ;
             ;
             ImGui::DragFloat2("Mouse Position", &c.mouse_pos.x, 0.1f);
+            ImGui::DragFloat2("Mouse Position Last Frame", &c.mouse_pos_last_frame.x, 0.1f);
             ImGui::DragFloat2("Mouse Offset", &c.mouse_offset.x, 0.1f);
             ImGui::DragFloat2("Mouse Scrolled", &c.mouse_scrolled.x, 0.1f);
             ImGui::DragFloat("Window Width", &c.window_width, 0.01f);

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -108,6 +108,7 @@ void Game::load_scene(std::string_view file)
 {
     using namespace spkt;
     
+    spkt::add_singleton(d_scene.Entities());
     spkt::load_registry_from_file(std::string(file), &d_scene.Entities());
 
     d_scene.add(spkt::game_grid_system);

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -70,7 +70,7 @@ void ShaderInfoPanel(DevUI& ui, Shader& shader)
 
 Game::Game(Window* window) 
     : d_window(window)
-    , d_scene(window)
+    , d_scene()
     , d_assetManager()
     , d_mode(Mode::PLAYER)
     , d_entityRenderer(&d_assetManager)

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -7,7 +7,7 @@ const auto SPACE_DARK  = spkt::from_hex(0x2C3A47);
 
 Runtime::Runtime(spkt::Window* window) 
     : d_window(window)
-    , d_scene(window)
+    , d_scene()
     , d_assetManager()
     , d_entityRenderer(&d_assetManager)
     , d_skyboxRenderer(&d_assetManager)

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -24,9 +24,10 @@ Runtime::Runtime(spkt::Window* window)
     d_window->SetCursorVisibility(false);
     d_entityRenderer.EnableParticles(&d_particleManager);
 
+    spkt::add_singleton(d_scene.Entities());
     spkt::particle_system_init(d_scene.Entities(), &d_particleManager);
-
     spkt::load_registry_from_file("Resources/Anvil.yaml", &d_scene.Entities());
+    
     d_scene.add(spkt::physics_system);
     d_scene.add(spkt::particle_system);
     d_scene.add(spkt::script_system);

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(Sprocket STATIC
             Scene/Systems/PhysicsEngine3D.cpp
             Scene/Systems/GameGrid.cpp
             Scene/Systems/basic_systems.cpp
+            Scene/Systems/input_system.cpp
 
             Graphics/AssetManager.cpp
             Graphics/Animation.cpp

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -653,6 +653,12 @@
                     "default": "{0.0, 0.0}"
                 },
                 {
+                    "name": "mouse_pos_last_frame",
+                    "display_name": "Mouse Position Last Frame",
+                    "type": "glm::vec2",
+                    "default": "{0.0, 0.0}"
+                },
+                {
                     "name": "mouse_offset",
                     "display_name": "Mouse Offset",
                     "type": "glm::vec2",

--- a/Sprocket/Scene/Components.h
+++ b/Sprocket/Scene/Components.h
@@ -177,6 +177,7 @@ struct InputSingleton
     std::array<bool, 5> mouse_click = {};
     std::array<bool, 5> mouse_unclick = {};
     glm::vec2 mouse_pos = {0.0, 0.0};
+    glm::vec2 mouse_pos_last_frame = {0.0, 0.0};
     glm::vec2 mouse_offset = {0.0, 0.0};
     glm::vec2 mouse_scrolled = {0.0, 0.0};
     float window_width = 1280.0f;

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -7,8 +7,7 @@
 
 namespace spkt {
 
-Scene::Scene(Window* window)
-    : d_window(window)
+Scene::Scene()
 {
     auto singleton = d_registry.create();
     d_registry.emplace<Runtime>(singleton);

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -7,13 +7,13 @@
 
 namespace spkt {
 
-Scene::Scene()
+void add_singleton(apx::registry& registry)
 {
-    auto singleton = d_registry.create();
-    d_registry.emplace<Runtime>(singleton);
-    d_registry.emplace<Singleton>(singleton);
-    d_registry.emplace<NameComponent>(singleton, "::RuntimeSingleton");
-    d_registry.emplace<InputSingleton>(singleton);
+    auto singleton = registry.create();
+    registry.emplace<Runtime>(singleton);
+    registry.emplace<Singleton>(singleton);
+    registry.emplace<NameComponent>(singleton, "::RuntimeSingleton");
+    registry.emplace<InputSingleton>(singleton);
 }
 
 Scene::~Scene()

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -1,6 +1,7 @@
 #include "Scene.h"
 #include "Components.h"
 #include "Loader.h"
+#include "input_system.h"
 
 #include <ranges>
 
@@ -28,58 +29,14 @@ void Scene::add(const system_t& system)
 
 void Scene::on_update(double dt)
 {
+    spkt::input_system_begin(d_registry, dt);
     std::ranges::for_each(d_systems, [&](auto&& system) { system(d_registry, dt); });
-
-    auto singleton = d_registry.find<Singleton>();
-    if (d_registry.valid(singleton)) {
-        auto& input = d_registry.get<InputSingleton>(singleton);
-        input.mouse_click.fill(false);
-        input.mouse_unclick.fill(false);
-        input.mouse_offset = {0.0, 0.0};
-        input.mouse_scrolled = {0.0, 0.0};
-    }
+    spkt::input_system_end(d_registry, dt);
 }
 
 void Scene::on_event(ev::Event& event)
 {
-    auto singleton = d_registry.find<Singleton>();
-    if (!d_registry.valid(singleton)) {
-        return;
-    }
-
-    auto& input = d_registry.get<InputSingleton>(singleton);
-
-    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
-        if (!event.is_consumed()) {
-            input.keyboard[data->key] = true;
-        }
-    }
-    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
-        input.keyboard[data->key] = false;
-    }
-    else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
-        if (!event.is_consumed()) { 
-            input.mouse[data->button] = true;
-            input.mouse_click[data->button] = true;
-        }
-    }
-    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
-        input.mouse[data->button] = false;
-        input.mouse_unclick[data->button] = true;
-    }
-    else if (auto data = event.get_if<ev::MouseScrolled>()) {
-        input.mouse_scrolled.x += data->x_offset;
-        input.mouse_scrolled.y += data->y_offset;
-    }
-    else if (auto data = event.get_if<ev::WindowResize>()) {
-        input.window_resized = true;
-    }
-
-    input.mouse_pos = d_window->GetMousePos();
-    input.mouse_offset = d_window->GetMouseOffset();
-
-    input.window_width = d_window->Width() > 0 ? (float)d_window->Width() : 1.0f;;
-    input.window_height = d_window->Height() > 0 ? (float)d_window->Height() : 1.0f;;
+    spkt::input_system_on_event(d_registry, event);
 }
 
 }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -11,6 +11,8 @@
 
 namespace spkt {
 
+void add_singleton(apx::registry& registry);
+
 template <typename Comp>
 Comp& get_singleton(apx::registry& registry)
 {
@@ -30,7 +32,6 @@ private:
     std::vector<system_t> d_systems;
 
 public:
-    Scene();
     ~Scene();
 
     apx::registry& Entities() { return d_registry; }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -26,14 +26,11 @@ public:
     using system_t = std::function<void(apx::registry&, double)>;
 
 private:
-    // Temporary, will be removed when then the InputSingleton gets updated via a system.
-    Window* d_window;
-
     apx::registry d_registry;
     std::vector<system_t> d_systems;
 
 public:
-    Scene(Window* window);
+    Scene();
     ~Scene();
 
     apx::registry& Entities() { return d_registry; }

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -3,6 +3,7 @@
 #include "LuaScript.h"
 #include "LuaLibrary.h"
 #include "LuaMaths.h"
+#include "Scene.h"
 
 #include <glm/gtx/norm.hpp>
 #include <utility>
@@ -60,12 +61,7 @@ void animation_system(apx::registry& registry, double dt)
 
 void camera_system(apx::registry& registry, double dt)
 {
-    auto singleton = registry.find<Singleton>();
-    if (!registry.valid(singleton)) {
-        return;
-    }
-
-    const auto& input = registry.get<InputSingleton>(singleton);
+    const auto& input = get_singleton<InputSingleton>(registry);
     float aspect_ratio = input.window_width / input.window_height;
 
     for (auto entity : registry.view<Camera3DComponent>()) {

--- a/Sprocket/Scene/Systems/input_system.cpp
+++ b/Sprocket/Scene/Systems/input_system.cpp
@@ -1,0 +1,57 @@
+#include "input_system.h"
+#include "Components.h"
+#include "Scene.h"
+
+namespace spkt {
+
+void input_system_on_event(apx::registry& registry, ev::Event& event)
+{
+    auto& input = get_singleton<InputSingleton>(registry);
+    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+        if (!event.is_consumed()) {
+            input.keyboard[data->key] = true;
+        }
+    }
+    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
+        input.keyboard[data->key] = false;
+    }
+    else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+        if (!event.is_consumed()) { 
+            input.mouse[data->button] = true;
+            input.mouse_click[data->button] = true;
+        }
+    }
+    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+        input.mouse[data->button] = false;
+        input.mouse_unclick[data->button] = true;
+    }
+    else if (auto data = event.get_if<ev::MouseScrolled>()) {
+        input.mouse_scrolled.x += data->x_offset;
+        input.mouse_scrolled.y += data->y_offset;
+    }
+    else if (auto data = event.get_if<ev::WindowResize>()) {
+        input.window_resized = true;
+        input.window_width = (float)data->width;
+        input.window_height = (float)data->height;
+    }
+    else if (auto data = event.get_if<ev::MouseMoved>()) {
+        input.mouse_pos = {data->x_pos, data->y_pos};
+    }
+}
+
+void input_system_begin(apx::registry& registry, double dt)
+{
+    auto& input = get_singleton<InputSingleton>(registry);
+    input.mouse_offset = input.mouse_pos - input.mouse_pos_last_frame;
+}
+
+void input_system_end(apx::registry& registry, double dt)
+{
+    auto& input = get_singleton<InputSingleton>(registry);
+    input.mouse_click.fill(false);
+    input.mouse_unclick.fill(false);
+    input.mouse_scrolled = {0.0, 0.0};
+    input.mouse_pos_last_frame = input.mouse_pos;
+}
+    
+}

--- a/Sprocket/Scene/Systems/input_system.h
+++ b/Sprocket/Scene/Systems/input_system.h
@@ -4,8 +4,20 @@
 
 namespace spkt {
 
+// This is a special system which is designed to get input information (keyboard,
+// mouse and window) into the ECS for systems to make use of. As such, it requires
+// a function that hooks into the event loop. Also, because of frame sensitive information
+// such as mouse offsets, this requires two "system" functions, a begin and end.
+
+// Processes events to build up the InputSingleton for the current frame.
 void input_system_on_event(apx::registry& registry, ev::Event& event);
+
+// Sets any per-frame information. Currently, this is just the mouse offset. This should be
+// the first system added to any scene.
 void input_system_begin(apx::registry& registry, double dt);
+
+// Resets are per-frame information such as how much the mouse was scrolled or which
+// button were pressed this frame. This should be the last system added to any scene.
 void input_system_end(apx::registry& registry, double dt);
 
 }

--- a/Sprocket/Scene/Systems/input_system.h
+++ b/Sprocket/Scene/Systems/input_system.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "Events.h"
+#include "apecs.hpp"
+
+namespace spkt {
+
+void input_system_on_event(apx::registry& registry, ev::Event& event);
+void input_system_begin(apx::registry& registry, double dt);
+void input_system_end(apx::registry& registry, double dt);
+
+}

--- a/Sprocket/Sprocket.h
+++ b/Sprocket/Sprocket.h
@@ -28,6 +28,7 @@
 #include "Scene/Systems/ParticleSystem.h"
 #include "Scene/Systems/PhysicsEngine3D.h"
 #include "Scene/Systems/GameGrid.h"
+#include "Scene/Systems/input_system.h"
 
 // UTILITY
 #include "Utility/Log.h"


### PR DESCRIPTION
* Add `input_system` functions, which is currently built into `Scene`.
* `Scene` no longer needs access to the window as the input system tracks the mouse and the mouse offset via events.
* Adding a singleton to a scene is no longer the default and must be done by calling `spkt::add_singleton(registry)`.
* The `InputSingleton` now has `mouse_pos_last_frame`, this is used to calculate the mouse offset each frame.