### PR TITLE
Remove `ev` Namespace

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -60,8 +60,8 @@ Anvil::Anvil(spkt::Window* window)
     d_window->SetCursorVisibility(true);
 
     d_scene = std::make_shared<spkt::Scene>(); 
-    spkt::add_singleton(d_scene->Entities());   
-    spkt::load_registry_from_file(d_sceneFile, d_scene->Entities());
+    spkt::add_singleton(d_scene->registry());   
+    spkt::load_registry_from_file(d_sceneFile, d_scene->registry());
     d_activeScene = d_scene;
 }
 
@@ -103,7 +103,7 @@ void Anvil::on_event(spkt::ev::Event& event)
 
 void Anvil::on_update(double dt)
 {
-    auto& registry = d_activeScene->Entities();
+    auto& registry = d_activeScene->registry();
 
     d_ui.on_update(dt);
 
@@ -120,19 +120,19 @@ void Anvil::on_update(double dt)
 
 glm::mat4 Anvil::get_proj_matrix() const
 {
-    auto& registry = d_activeScene->Entities();
+    auto& registry = d_activeScene->registry();
     return d_playingGame ? spkt::make_proj(registry, d_runtimeCamera) : d_editor_camera.Proj();
 }
 
 glm::mat4 Anvil::get_view_matrix() const
 {
-    auto& registry = d_activeScene->Entities();
+    auto& registry = d_activeScene->registry();
     return d_playingGame ? spkt::make_view(registry, d_runtimeCamera) : d_editor_camera.View();
 }
 
 void Anvil::on_render()
 {
-    auto& registry = d_activeScene->Entities();
+    auto& registry = d_activeScene->registry();
 
     // If the size of the viewport has changed since the previous frame, recreate
     // the framebuffer.
@@ -175,13 +175,13 @@ void Anvil::on_render()
                     spkt::log::info("Loading {}...", d_sceneFile);
                     d_sceneFile = file;
                     d_activeScene = d_scene = std::make_shared<spkt::Scene>();
-                    spkt::load_registry_from_file(file, d_scene->Entities());
+                    spkt::load_registry_from_file(file, d_scene->registry());
                     spkt::log::info("...done!");
                 }
             }
             if (ImGui::MenuItem("Save")) {
                 spkt::log::info("Saving {}...", d_sceneFile);
-                spkt::save_registry_to_file(d_sceneFile, d_scene->Entities());
+                spkt::save_registry_to_file(d_sceneFile, d_scene->registry());
                 spkt::log::info("...done!");
             }
             if (ImGui::MenuItem("Save As")) {
@@ -189,7 +189,7 @@ void Anvil::on_render()
                 if (!file.empty()) {
                     spkt::log::info("Saving as {}...", file);
                     d_sceneFile = file;
-                    spkt::save_registry_to_file(file, d_scene->Entities());
+                    spkt::save_registry_to_file(file, d_scene->registry());
                     spkt::log::info("...done!");
                 }
             }
@@ -199,8 +199,8 @@ void Anvil::on_render()
             if (ImGui::MenuItem("Run")) {
                 d_activeScene = std::make_shared<spkt::Scene>();
 
-                spkt::add_singleton(d_activeScene->Entities());
-                spkt::copy_registry(d_scene->Entities(), d_activeScene->Entities());
+                spkt::add_singleton(d_activeScene->registry());
+                spkt::copy_registry(d_scene->registry(), d_activeScene->registry());
 
                 d_activeScene->add(spkt::physics_system);
                 d_activeScene->add(spkt::particle_system);
@@ -211,7 +211,7 @@ void Anvil::on_render()
                 d_activeScene->add(spkt::clear_events_system);
 
                 d_playingGame = true;
-                d_runtimeCamera = d_activeScene->Entities().find<spkt::Camera3DComponent>();
+                d_runtimeCamera = d_activeScene->registry().find<spkt::Camera3DComponent>();
                 d_window->SetCursorVisibility(false);
             }
             ImGui::EndMenu();

--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -65,11 +65,11 @@ Anvil::Anvil(spkt::Window* window)
     d_activeScene = d_scene;
 }
 
-void Anvil::on_event(spkt::ev::Event& event)
+void Anvil::on_event(spkt::event& event)
 {
     using namespace spkt;
 
-    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+    if (auto data = event.get_if<KeyboardButtonPressed>()) {
         if (data->key == Keyboard::ESC) {
             if (d_playingGame) {
                 d_playingGame = false;

--- a/Anvil/Anvil.h
+++ b/Anvil/Anvil.h
@@ -67,7 +67,7 @@ class Anvil
 public:
     Anvil(spkt::Window* window);
 
-    void on_event(spkt::ev::Event& event);
+    void on_event(spkt::event& event);
     void on_update(double dt);
     void on_render();
 

--- a/Anvil/Camera.cpp
+++ b/Anvil/Camera.cpp
@@ -1,6 +1,7 @@
 #include "Camera.h"
 
 #include <Sprocket/Core/Events.h>
+#include <Sprocket/Core/Window.h>
 #include <Sprocket/Graphics/Viewport.h>
 #include <Sprocket/Utility/KeyboardCodes.h>
 
@@ -83,11 +84,11 @@ void Camera::on_update(double dt)
     }
 }
 
-void Camera::on_event(spkt::ev::Event& event)
+void Camera::on_event(spkt::event& event)
 {
     d_input.on_event(event);
 
-    if (auto data = event.get_if<spkt::ev::MouseScrolled>()) {
+    if (auto data = event.get_if<spkt::MouseScrolled>()) {
         if (event.is_consumed()) { return; }
         d_absVert -= data->y_offset;
         d_absVert = std::clamp(d_absVert, d_absMin, d_absMax);

--- a/Anvil/Camera.h
+++ b/Anvil/Camera.h
@@ -1,9 +1,12 @@
 #pragma once
-#include <Sprocket/Core/Events.h>
-#include <Sprocket/Core/Window.h>
 #include <Sprocket/Utility/InputProxy.h>
 
 #include <glm/glm.hpp>
+
+namespace spkt {
+    class Window;
+    class event;
+}
 
 class Camera
 {
@@ -27,7 +30,7 @@ public:
     Camera(spkt::Window* window, const glm::vec3& target);
 
     void on_update(double dt);
-    void on_event(spkt::ev::Event& event);
+    void on_event(spkt::event& event);
 
     glm::mat4 Proj() const;
     glm::mat4 View() const;

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -13,7 +13,7 @@
 
 void Inspector::Show(Anvil& editor)
 {
-    spkt::registry& registry = editor.active_scene()->Entities();
+    spkt::registry& registry = editor.active_scene()->registry();
     spkt::entity entity = editor.selected();
 
     if (!registry.valid(entity)) {
@@ -485,7 +485,7 @@ void Inspector::Show(Anvil& editor)
     }
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
-        spkt::entity copy = spkt::copy_entity(editor.active_scene()->Entities(), entity);
+        spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry(), entity);
         editor.set_selected(copy);
     }
     if (ImGui::Button("Delete Entity")) {

--- a/Anvil/Inspector.dm.cpp
+++ b/Anvil/Inspector.dm.cpp
@@ -13,7 +13,7 @@
 
 void Inspector::Show(Anvil& editor)
 {
-    spkt::registry& registry = editor.active_scene()->Entities();
+    spkt::registry& registry = editor.active_scene()->registry();
     spkt::entity entity = editor.selected();
 
     if (!registry.valid(entity)) {
@@ -57,7 +57,7 @@ DATAMATIC_END
     }
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
-        spkt::entity copy = spkt::copy_entity(editor.active_scene()->Entities(), entity);
+        spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry(), entity);
         editor.set_selected(copy);
     }
     if (ImGui::Button("Delete Entity")) {

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -6,6 +6,7 @@
 
 #include <Sprocket/Audio/Listener.h>
 #include <Sprocket/Core/Events.h>
+#include <Sprocket/Core/Window.h>
 #include <Sprocket/Graphics/PostProcessing/GaussianBlur.h>
 #include <Sprocket/Scene/Camera.h>
 #include <Sprocket/Scene/ecs.h>

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -148,12 +148,12 @@ void Game::load_scene(std::string_view file)
     assert(registry.valid(d_camera));
 }
 
-void Game::on_event(spkt::ev::Event& event)
+void Game::on_event(spkt::event& event)
 {
     using namespace spkt;
 
     // Escape Menu event handling
-    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+    if (auto data = event.get_if<KeyboardButtonPressed>()) {
         if (!event.is_consumed() && data->key == Keyboard::ESC) {
             d_paused = !d_paused;
             event.consume();
@@ -177,11 +177,11 @@ void Game::on_event(spkt::ev::Event& event)
     // Game World event handling
     d_hoveredEntityUI.on_event(event);
 
-    if (auto data = event.get_if<ev::WindowResize>()) {
+    if (auto data = event.get_if<WindowResize>()) {
         d_postProcessor.SetScreenSize(data->width, data->height);
     }
 
-    if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+    if (auto data = event.get_if<MouseButtonPressed>()) {
         auto& tr = registry.get<Transform3DComponent>(d_camera);
         if (data->mods & KeyModifier::CTRL) {
             glm::vec3 cameraPos = tr.position;

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -106,7 +106,7 @@ Game::Game(Window* window)
 
     d_cycle.SetAngle(3.14195f);
 
-    auto& registry = d_scene.Entities();
+    auto& registry = d_scene.registry();
     auto sun_entity = registry.find<SunComponent>();
     auto& sun = registry.get<SunComponent>(sun_entity);
     sun.direction = d_cycle.GetSunDir();
@@ -118,7 +118,7 @@ Game::Game(Window* window)
 
 void Game::load_scene(std::string_view file)
 {
-    auto& registry = d_scene.Entities();
+    auto& registry = d_scene.registry();
     
     spkt::add_singleton(registry);
     spkt::game_grid_system_init(registry);
@@ -160,7 +160,7 @@ void Game::on_event(spkt::ev::Event& event)
         }
     }
 
-    auto& registry = d_scene.Entities();
+    auto& registry = d_scene.registry();
     auto tile_entity = registry.find<TileMapSingleton>();
     const auto& tiles = registry.get<TileMapSingleton>(tile_entity).tiles;
 
@@ -233,7 +233,7 @@ void Game::on_event(spkt::ev::Event& event)
 void Game::on_update(double dt)
 {
     using namespace spkt;
-    auto& registry = d_scene.Entities();
+    auto& registry = d_scene.registry();
 
     spkt::set_listener(registry, d_camera);
 
@@ -270,8 +270,8 @@ void Game::on_update(double dt)
 void Game::on_render()
 {
     using namespace spkt;
-    const auto& game_grid = get_singleton<GameGridSingleton>(d_scene.Entities());
-    auto& registry = d_scene.Entities();
+    const auto& game_grid = get_singleton<GameGridSingleton>(d_scene.registry());
+    auto& registry = d_scene.registry();
 
     // Create the Shadow Map
     float lambda = 5.0f; // TODO: Calculate the floor intersection point
@@ -297,7 +297,7 @@ void Game::on_render()
     }
 
     if (!d_paused) {
-        auto& registry = d_scene.Entities();
+        auto& registry = d_scene.registry();
         auto tile_entity = registry.find<TileMapSingleton>();
         const auto& tiles = registry.get<TileMapSingleton>(tile_entity).tiles;
 
@@ -440,7 +440,7 @@ void Game::on_render()
     buttonRegion.y += 60;
     if (d_escapeMenu.Button("Save", buttonRegion)) {
         spkt::log::info("Saving to {}", d_sceneFile);
-        spkt::save_registry_to_file(d_sceneFile, d_scene.Entities());
+        spkt::save_registry_to_file(d_sceneFile, d_scene.registry());
         spkt::log::info("Done!");
     }
     

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <Game/CircadianCycle.h>
 
-#include <Sprocket/Core/Window.h>
 #include <Sprocket/Graphics/AssetManager.h>
 #include <Sprocket/Graphics/PostProcessing/PostProcessor.h>
 #include <Sprocket/Graphics/Rendering/Scene3DRenderer.h>
@@ -14,6 +13,11 @@
 #include <memory>
 #include <random>
 #include <string_view>
+
+namespace spkt {
+    class Window;
+    class event;
+}
 
 enum class Mode { PLAYER, EDITOR };
 

--- a/Game/Game.h
+++ b/Game/Game.h
@@ -53,7 +53,7 @@ class Game
 public:
     Game(spkt::Window* window);
 
-    void on_event(spkt::ev::Event& event);
+    void on_event(spkt::event& event);
     void on_update(double dt);
     void on_render();
 

--- a/Runtime/Console.cpp
+++ b/Runtime/Console.cpp
@@ -1,10 +1,11 @@
 #include "Console.h"
 
-#include <Sprocket/Utility/Colour.h>
 #include <Sprocket/Core/Events.h>
-#include <Sprocket/Utility/KeyboardCodes.h>
-#include <Sprocket/UI/SimpleUI.h>
+#include <Sprocket/Core/Window.h>
 #include <Sprocket/Scripting/LuaScript.h>
+#include <Sprocket/UI/SimpleUI.h>
+#include <Sprocket/Utility/Colour.h>
+#include <Sprocket/Utility/KeyboardCodes.h>
 
 #include <filesystem>
 #include <format>

--- a/Runtime/Console.cpp
+++ b/Runtime/Console.cpp
@@ -32,9 +32,9 @@ void Console::on_update(double dt)
     d_ui.on_update(dt);
 }
 
-void Console::on_event(spkt::ev::Event& event)
+void Console::on_event(spkt::event& event)
 {
-    auto data = event.get_if<spkt::ev::KeyboardButtonPressed>();
+    auto data = event.get_if<spkt::KeyboardButtonPressed>();
     if (data && data->key == spkt::Keyboard::ENTER) {
         d_consoleLines.push_front({d_commandLine, glm::vec4{1.0, 1.0, 1.0, 1.0}});
         HandleCommand(d_commandLine);

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -1,10 +1,14 @@
-#include <Sprocket/Core/Window.h>
 #include <Sprocket/UI/SimpleUI.h>
 
 #include <glm/glm.hpp>
 
 #include <deque>
 #include <string_view>
+
+namespace spkt {
+    class Window;
+    class event;
+}
 
 struct ConsoleLine
 {

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -26,6 +26,6 @@ public:
     Console(spkt::Window* window);
 
     void on_update(double dt);
-    void on_event(spkt::ev::Event& event);
+    void on_event(spkt::event& event);
     void Draw();
 };

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -1,5 +1,7 @@
 #include "Runtime.h"
 
+#include <Sprocket/Core/Events.h>
+#include <Sprocket/Core/Window.h>
 #include <Sprocket/Scene/Loader.h>
 #include <Sprocket/Scene/Systems/basic_systems.h>
 #include <Sprocket/Scene/Systems/particle_system.h>

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -44,9 +44,9 @@ Runtime::Runtime(spkt::Window* window)
     d_runtimeCamera = d_scene.registry().find<spkt::Camera3DComponent>();
 }
 
-void Runtime::on_event(spkt::ev::Event& event)
+void Runtime::on_event(spkt::event& event)
 {
-    if (auto data = event.get_if<spkt::ev::KeyboardTyped>()) {
+    if (auto data = event.get_if<spkt::KeyboardTyped>()) {
         if (data->key == spkt::Keyboard::BACK_TICK) {
             d_consoleActive = !d_consoleActive;
             event.consume();
@@ -75,7 +75,7 @@ void Runtime::on_update(double dt)
 void Runtime::on_render()
 {
     auto& registry = d_scene.registry();
-    
+
     d_skyboxRenderer.Draw(d_skybox, registry, d_runtimeCamera);
     d_entityRenderer.Draw(registry, d_runtimeCamera);
 

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -30,8 +30,8 @@ Runtime::Runtime(spkt::Window* window)
 {
     d_window->SetCursorVisibility(false);
 
-    spkt::add_singleton(d_scene.Entities());
-    spkt::load_registry_from_file("Resources/Anvil.yaml", d_scene.Entities());
+    spkt::add_singleton(d_scene.registry());
+    spkt::load_registry_from_file("Resources/Anvil.yaml", d_scene.registry());
     
     d_scene.add(spkt::physics_system);
     d_scene.add(spkt::particle_system);
@@ -41,7 +41,7 @@ Runtime::Runtime(spkt::Window* window)
     d_scene.add(spkt::delete_below_50_system);
     d_scene.add(spkt::clear_events_system);
 
-    d_runtimeCamera = d_scene.Entities().find<spkt::Camera3DComponent>();
+    d_runtimeCamera = d_scene.registry().find<spkt::Camera3DComponent>();
 }
 
 void Runtime::on_event(spkt::ev::Event& event)
@@ -74,7 +74,8 @@ void Runtime::on_update(double dt)
 
 void Runtime::on_render()
 {
-    auto& registry = d_scene.Entities();
+    auto& registry = d_scene.registry();
+    
     d_skyboxRenderer.Draw(d_skybox, registry, d_runtimeCamera);
     d_entityRenderer.Draw(registry, d_runtimeCamera);
 

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -34,7 +34,7 @@ class Runtime
 public:
     Runtime(spkt::Window* window);
 
-    void on_event(spkt::ev::Event& event);
+    void on_event(spkt::event& event);
     void on_update(double dt);
     void on_render();
 };

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Console.h"
 
-#include <Sprocket/Core/Window.h>
 #include <Sprocket/Graphics/AssetManager.h>
 #include <Sprocket/Graphics/Rendering/Scene3DRenderer.h>
 #include <Sprocket/Graphics/Rendering/SkyboxRenderer.h>
@@ -11,6 +10,10 @@
 
 #include <memory>
 #include <random>
+
+namespace spkt {
+    class Window;
+}
 
 class Runtime
 {

--- a/Sprocket/Core/Events.h
+++ b/Sprocket/Core/Events.h
@@ -7,16 +7,15 @@
 #include <typeinfo> // TODO: Replace with own version
 
 namespace spkt {
-namespace ev {
 
-class Event
+class event
 {
 	std::any d_event;
 	bool     d_consumed = false;
 
 public:
 	template <typename T, typename... Args>
-	explicit Event(std::in_place_type_t<T>, Args&&... args)
+	explicit event(std::in_place_type_t<T>, Args&&... args)
 		: d_event(std::in_place_type<T>, std::forward<Args>(args)...)
 	{}
 
@@ -34,9 +33,9 @@ public:
 };
 
 template <typename T, typename... Args>
-Event make_event(Args&&... args)
+event make_event(Args&&... args)
 {
-	return Event(std::in_place_type<T>, std::forward<Args>(args)...);
+	return event(std::in_place_type<T>, std::forward<Args>(args)...);
 }
 
 // KEYBOARD EVENTS 
@@ -105,7 +104,5 @@ struct WindowGotFocus {};
 struct WindowLostFocus {};
 struct WindowMaximize {};
 struct WindowMinimize {};
-
-}
 
 }

--- a/Sprocket/Core/GameLoop.h
+++ b/Sprocket/Core/GameLoop.h
@@ -17,7 +17,7 @@ struct RunOptions
 };
 
 template <typename T>
-concept runnable = requires(T t, ev::Event& event, double dt)
+concept runnable = requires(T t, event& event, double dt)
 {
     { t.on_event(event) } -> std::same_as<void>;
     { t.on_update(dt) } -> std::same_as<void>;
@@ -30,7 +30,7 @@ int Run(App& app, Window& window, const RunOptions& options = {})
     std::string name = window.GetWindowName();
     Stopwatch watch;
 
-    window.SetCallback([&app](ev::Event& event) {
+    window.SetCallback([&app](event& event) {
         app.on_event(event);
     });
 

--- a/Sprocket/Core/Window.cpp
+++ b/Sprocket/Core/Window.cpp
@@ -1,5 +1,6 @@
 #include "Window.h"
 
+#include <Sprocket/Core/Events.h>
 #include <Sprocket/Utility/Log.h>
 
 #include <glad/glad.h>

--- a/Sprocket/Core/Window.cpp
+++ b/Sprocket/Core/Window.cpp
@@ -76,7 +76,7 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 		glViewport(0, 0, width, height);
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (!data->focused) return;
-		auto event = ev::make_event<ev::WindowResize>(width, height);
+		auto event = spkt::make_event<WindowResize>(width, height);
 		data->width = width;
 		data->height = height;
 		data->callback(event);
@@ -86,7 +86,7 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 	{
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (!data->focused) return;
-		auto event = ev::make_event<ev::WindowClosed>();
+		auto event = spkt::make_event<WindowClosed>();
 		data->running = false;
 		data->callback(event);
 	});
@@ -97,15 +97,15 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 		switch (action)
 		{
 			case GLFW_PRESS: {
-				auto event = ev::make_event<ev::KeyboardButtonPressed>(key, scancode, mods);
+				auto event = spkt::make_event<KeyboardButtonPressed>(key, scancode, mods);
 				data->callback(event);
 			} break;
 			case GLFW_RELEASE: {
-				auto event = ev::make_event<ev::KeyboardButtonReleased>(key, scancode, mods);
+				auto event = spkt::make_event<KeyboardButtonReleased>(key, scancode, mods);
 				data->callback(event);
 			} break;
 			case GLFW_REPEAT: {
-				auto event = ev::make_event<ev::KeyboardButtonHeld>(key, scancode, mods);
+				auto event = spkt::make_event<KeyboardButtonHeld>(key, scancode, mods);
 				data->callback(event);
 			} break;
 		}
@@ -117,11 +117,11 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 		switch (action)
 		{
 		case GLFW_PRESS: {
-			auto event = ev::make_event<ev::MouseButtonPressed>(button, action, mods);
+			auto event = spkt::make_event<MouseButtonPressed>(button, action, mods);
 			data->callback(event);
 		} break;
 		case GLFW_RELEASE: {
-			auto event = ev::make_event<ev::MouseButtonReleased>(button, action, mods);
+			auto event = spkt::make_event<MouseButtonReleased>(button, action, mods);
 			data->callback(event);
 		} break;
 		}
@@ -130,26 +130,26 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 	glfwSetCursorPosCallback(d_impl->window, [](GLFWwindow* window, double x_pos, double y_pos) {
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (!data->focused) return;
-		auto event = ev::make_event<ev::MouseMoved>(x_pos, y_pos);
+		auto event = spkt::make_event<MouseMoved>(x_pos, y_pos);
 		data->callback(event);
 	});
 
 	glfwSetScrollCallback(d_impl->window, [](GLFWwindow* window, double x_offset, double y_offset) {
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (!data->focused) return;
-		auto event = ev::make_event<ev::MouseScrolled>(x_offset, y_offset);
+		auto event = spkt::make_event<MouseScrolled>(x_offset, y_offset);
 		data->callback(event);
 	});
 
 	glfwSetWindowFocusCallback(d_impl->window, [](GLFWwindow* window, int focused) {
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (focused) {
-			auto event = ev::make_event<ev::WindowGotFocus>();
+			auto event = spkt::make_event<WindowGotFocus>();
 			data->focused = true;
 			data->callback(event);
 		}
 		else {
-			auto event = ev::make_event<ev::WindowLostFocus>();
+			auto event = spkt::make_event<WindowLostFocus>();
 			data->focused = false;
 			data->callback(event);
 		}
@@ -158,11 +158,11 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 	glfwSetWindowMaximizeCallback(d_impl->window, [](GLFWwindow* window, int maximized) {
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (maximized) {
-			auto event = ev::make_event<ev::WindowMaximize>();
+			auto event = spkt::make_event<WindowMaximize>();
 			data->callback(event);
 		}
 		else {
-			auto event = ev::make_event<ev::WindowMinimize>();
+			auto event = spkt::make_event<WindowMinimize>();
 			data->callback(event);
 		}
 	});
@@ -170,7 +170,7 @@ Window::Window(const std::string& name, std::uint32_t width, std::uint32_t heigh
 	glfwSetCharCallback(d_impl->window, [](GLFWwindow* window, std::uint32_t key) {
 		WindowData* data = (WindowData*)glfwGetWindowUserPointer(window);
 		if (!data->focused) return;
-		auto event = ev::make_event<ev::KeyboardTyped>(key);
+		auto event = spkt::make_event<KeyboardTyped>(key);
 		data->callback(event);
 	});
 }

--- a/Sprocket/Core/Window.h
+++ b/Sprocket/Core/Window.h
@@ -14,7 +14,7 @@
 
 namespace spkt {
 
-using EventCallback = std::function<void(ev::Event&)>;
+using EventCallback = std::function<void(event&)>;
 
 struct WindowImpl;
 
@@ -28,7 +28,7 @@ struct WindowData
 	bool running = true;
 	bool focused = true;
 
-	EventCallback callback = [](ev::Event&) {};
+	EventCallback callback = [](event&) {};
 };
 
 class Window

--- a/Sprocket/Core/Window.h
+++ b/Sprocket/Core/Window.h
@@ -1,12 +1,10 @@
 #pragma once
-#include <Sprocket/Core/Events.h>
-
 #include <glm/glm.hpp>
 
-#include <string>
+#include <cstddef>
 #include <functional>
 #include <memory>
-#include <map>
+#include <string>
 
 #ifndef _WIN32
 #error "Sprocket currently only supports Windows"
@@ -14,7 +12,9 @@
 
 namespace spkt {
 
-using EventCallback = std::function<void(event&)>;
+class event;
+
+using EventCallback = std::function<void(spkt::event&)>;
 
 struct WindowImpl;
 
@@ -28,7 +28,7 @@ struct WindowData
 	bool running = true;
 	bool focused = true;
 
-	EventCallback callback = [](event&) {};
+	EventCallback callback = [](spkt::event&) {};
 };
 
 class Window

--- a/Sprocket/Graphics/AssetManager.h
+++ b/Sprocket/Graphics/AssetManager.h
@@ -11,6 +11,10 @@
 
 namespace spkt {
 
+using mesh_ptr = std::unique_ptr<Mesh>;
+using texture_ptr = std::unique_ptr<Texture>;
+using material_ptr = std::unique_ptr<Material>;
+
 class AssetManager
 {
     // Background Loaders
@@ -18,16 +22,16 @@ class AssetManager
     std::unordered_map<std::string, std::future<std::unique_ptr<TextureData>>> d_loadingTextures;
 
     // Primitives
-    std::unordered_map<std::string, const std::unique_ptr<Mesh>>    d_meshes;
-    std::unordered_map<std::string, const std::unique_ptr<Texture>> d_textures;
+    std::unordered_map<std::string, const spkt::mesh_ptr>    d_meshes;
+    std::unordered_map<std::string, const spkt::texture_ptr> d_textures;
     
     // Composites
-    std::unordered_map<std::string, const std::unique_ptr<Material>> d_materials;
+    std::unordered_map<std::string, const spkt::material_ptr> d_materials;
 
     // Defaults
-    std::unique_ptr<Mesh>     d_defaultMesh;
-    std::unique_ptr<Texture>  d_defaultTexture;
-    std::unique_ptr<Material> d_defaultMaterial;
+    spkt::mesh_ptr     d_defaultMesh;
+    spkt::texture_ptr  d_defaultTexture;
+    spkt::material_ptr d_defaultMaterial;
 
 public:
     template <typename T>

--- a/Sprocket/Graphics/PostProcessing/GaussianBlur.h
+++ b/Sprocket/Graphics/PostProcessing/GaussianBlur.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Effect.h"
+#include <Sprocket/Graphics/PostProcessing/Effect.h>
 
 namespace spkt {
 

--- a/Sprocket/Graphics/PostProcessing/Negative.h
+++ b/Sprocket/Graphics/PostProcessing/Negative.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Effect.h"
+#include <Sprocket/Graphics/PostProcessing/Effect.h>
 
 namespace spkt {
 

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -1,6 +1,7 @@
 #include "ColliderRenderer.h"
 
 #include <Sprocket/Graphics/RenderContext.h>
+#include <Sprocket/Graphics/VertexArray.h>
 #include <Sprocket/Scene/Camera.h>
 #include <Sprocket/Utility/Maths.h>
 

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.h
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <Sprocket/Graphics/Shader.h>
-#include <Sprocket/Graphics/VertexArray.h>
 #include <Sprocket/Scene/ecs.h>
 
 #include <glm/glm.hpp>
@@ -8,6 +7,8 @@
 #include <memory>
 
 namespace spkt {
+
+class VertexArray;
 
 class ColliderRenderer
 {

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -1,7 +1,10 @@
 #include "Scene3DRenderer.h"
 
+#include <Sprocket/Graphics/AssetManager.h>
+#include <Sprocket/Graphics/Buffer.h>
 #include <Sprocket/Graphics/BufferLayout.h>
 #include <Sprocket/Graphics/RenderContext.h>
+#include <Sprocket/Graphics/VertexArray.h>
 #include <Sprocket/Scene/Camera.h>
 #include <Sprocket/Utility/Hashing.h>
 #include <Sprocket/Utility/Maths.h>

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.h
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.h
@@ -1,14 +1,15 @@
 #pragma once
-#include <Sprocket/Graphics/AssetManager.h>
-#include <Sprocket/Graphics/Buffer.h>
 #include <Sprocket/Graphics/Shader.h>
 #include <Sprocket/Graphics/ShadowMap.h>
-#include <Sprocket/Graphics/VertexArray.h>
 #include <Sprocket/Scene/ecs.h>
 
 #include <memory>
 
 namespace spkt {
+
+class AssetManager;
+class Buffer;
+class VertexArray;
 
 class Scene3DRenderer
 // Renders a scene as a 3D Scene. This makes use of components such as

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
@@ -1,6 +1,8 @@
 #include "SkyboxRenderer.h"
 
 #include <Sprocket/Graphics/AssetManager.h>
+#include <Sprocket/Graphics/CubeMap.h>
+#include <Sprocket/Graphics/VertexArray.h>
 #include <Sprocket/Scene/Camera.h>
 
 #include <glm/glm.hpp>

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.h
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.h
@@ -1,8 +1,6 @@
 #pragma once
-#include <Sprocket/Graphics/CubeMap.h>
 #include <Sprocket/Graphics/Shader.h>
 #include <Sprocket/Scene/ecs.h>
-#include <Sprocket/Graphics/VertexArray.h>
 
 #include <glm/glm.hpp>
 
@@ -11,6 +9,8 @@
 namespace spkt {
 
 class AssetManager;
+class CubeMap;
+class VertexArray;
 
 class SkyboxRenderer
 {

--- a/Sprocket/Scene/Scene.cpp
+++ b/Sprocket/Scene/Scene.cpp
@@ -35,7 +35,7 @@ void Scene::on_update(double dt)
     spkt::input_system_end(d_registry, dt);
 }
 
-void Scene::on_event(ev::Event& event)
+void Scene::on_event(spkt::event& event)
 {
     spkt::input_system_on_event(d_registry, event);
 }

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -32,7 +32,7 @@ private:
 public:
     ~Scene();
 
-    spkt::registry& Entities() { return d_registry; }
+    spkt::registry& registry() { return d_registry; }
 
     void add(const system_t& system);
     void on_update(double dt);

--- a/Sprocket/Scene/Scene.h
+++ b/Sprocket/Scene/Scene.h
@@ -7,7 +7,7 @@
 
 namespace spkt {
 
-namespace ev { class Event; }
+class event;
 
 spkt::entity add_singleton(spkt::registry& registry);
 
@@ -36,7 +36,7 @@ public:
 
     void add(const system_t& system);
     void on_update(double dt);
-    void on_event(ev::Event& event);
+    void on_event(spkt::event& event);
 };
 
 }

--- a/Sprocket/Scene/Systems/input_system.cpp
+++ b/Sprocket/Scene/Systems/input_system.cpp
@@ -6,37 +6,37 @@
 
 namespace spkt {
 
-void input_system_on_event(spkt::registry& registry, ev::Event& event)
+void input_system_on_event(spkt::registry& registry, spkt::event& event)
 {
     auto& input = get_singleton<InputSingleton>(registry);
-    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+    if (auto data = event.get_if<KeyboardButtonPressed>()) {
         if (!event.is_consumed()) {
             input.keyboard[data->key] = true;
         }
     }
-    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
+    else if (auto data = event.get_if<KeyboardButtonReleased>()) {
         input.keyboard[data->key] = false;
     }
-    else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+    else if (auto data = event.get_if<MouseButtonPressed>()) {
         if (!event.is_consumed()) { 
             input.mouse[data->button] = true;
             input.mouse_click[data->button] = true;
         }
     }
-    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+    else if (auto data = event.get_if<MouseButtonReleased>()) {
         input.mouse[data->button] = false;
         input.mouse_unclick[data->button] = true;
     }
-    else if (auto data = event.get_if<ev::MouseScrolled>()) {
+    else if (auto data = event.get_if<MouseScrolled>()) {
         input.mouse_scrolled.x += data->x_offset;
         input.mouse_scrolled.y += data->y_offset;
     }
-    else if (auto data = event.get_if<ev::WindowResize>()) {
+    else if (auto data = event.get_if<WindowResize>()) {
         input.window_resized = true;
         input.window_width = (float)data->width;
         input.window_height = (float)data->height;
     }
-    else if (auto data = event.get_if<ev::MouseMoved>()) {
+    else if (auto data = event.get_if<MouseMoved>()) {
         input.mouse_pos = {data->x_pos, data->y_pos};
     }
 }

--- a/Sprocket/Scene/Systems/input_system.h
+++ b/Sprocket/Scene/Systems/input_system.h
@@ -3,7 +3,7 @@
 
 namespace spkt {
 
-namespace ev { class Event; }
+class event;
 
 // This is a special system which is designed to get input information (keyboard,
 // mouse and window) into the ECS for systems to make use of. As such, it requires
@@ -11,7 +11,7 @@ namespace ev { class Event; }
 // such as mouse offsets, this requires two "system" functions, a begin and end.
 
 // Processes events to build up the InputSingleton for the current frame.
-void input_system_on_event(spkt::registry& registry, ev::Event& event);
+void input_system_on_event(spkt::registry& registry, spkt::event& event);
 
 // Sets any per-frame information. Currently, this is just the mouse offset. This should be
 // the first system added to any scene.

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -171,38 +171,38 @@ DevUI::DevUI(Window* window)
     
 }
 
-void DevUI::on_event(ev::Event& event)
+void DevUI::on_event(event& event)
 {
     ImGuiIO& io = ImGui::GetIO();
-
-    if (auto data = event.get_if<ev::MouseButtonPressed>()) {    
+    
+    if (auto data = event.get_if<MouseButtonPressed>()) {    
         if (event.is_consumed()) { return; }
         io.MouseDown[data->button] = true;
         if (d_blockEvents && io.WantCaptureMouse) { event.consume(); }
     }
     
-    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+    else if (auto data = event.get_if<MouseButtonReleased>()) {
         io.MouseDown[data->button] = false;
     }
 
-    else if (auto data = event.get_if<ev::MouseMoved>()) {
+    else if (auto data = event.get_if<MouseMoved>()) {
         io.MousePos = ImVec2(data->x_pos, data->y_pos);
         if (ImGui::IsAnyItemHovered()) { event.consume(); }
         if (d_blockEvents && io.WantCaptureMouse) { event.consume(); }
     }
 
-    else if (auto data = event.get_if<ev::MouseScrolled>()) {
+    else if (auto data = event.get_if<MouseScrolled>()) {
         io.MouseWheel += data->y_offset;
         io.MouseWheelH += data->x_offset;
         if (d_blockEvents && io.WantCaptureMouse) { event.consume(); }
     }
 
-    else if (auto data = event.get_if<ev::WindowResize>()) {
+    else if (auto data = event.get_if<WindowResize>()) {
         io.DisplaySize = ImVec2((float)data->width, (float)data->height);
         io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
     }
 
-    else if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+    else if (auto data = event.get_if<KeyboardButtonPressed>()) {
         if (event.is_consumed()) { return; }
         io.KeysDown[data->key] = true;
         io.KeyCtrl  = data->mods & KeyModifier::CTRL;
@@ -212,7 +212,7 @@ void DevUI::on_event(ev::Event& event)
         if (d_blockEvents && io.WantCaptureKeyboard) { event.consume(); }
     }
 
-    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
+    else if (auto data = event.get_if<KeyboardButtonReleased>()) {
         io.KeysDown[data->key] = false;
         io.KeyCtrl  = data->mods & KeyModifier::CTRL;
         io.KeyShift = data->mods & KeyModifier::SHIFT;
@@ -220,7 +220,7 @@ void DevUI::on_event(ev::Event& event)
         io.KeySuper = data->mods & KeyModifier::SUPER;
     }
 
-    else if (auto data = event.get_if<ev::KeyboardTyped>()) {
+    else if (auto data = event.get_if<KeyboardTyped>()) {
         if (event.is_consumed()) { return; }
         if (data->key > 0 && data->key < 0x10000) {
             io.AddInputCharacter((unsigned short)data->key);

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -11,7 +11,7 @@
 namespace spkt {
 
 class Window;
-namespace ev { class Event; }
+class event;
 
 class DevUI
 // A class that wraps the setup and rendering of ImGui.
@@ -28,7 +28,7 @@ class DevUI
 public:
     DevUI(Window* window);
 
-    void on_event(ev::Event& event);
+    void on_event(event& event);
     void on_update(double dt);
 
     void BlockEvents(bool val) { d_blockEvents = val; }

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -1,6 +1,7 @@
 #include "SimpleUI.h"
 
 #include <Sprocket/Core/Window.h>
+#include <Sprocket/Core/Events.h>
 #include <Sprocket/Utility/KeyboardCodes.h>
 
 #include <fmt/core.h>
@@ -52,7 +53,7 @@ SimpleUI::SimpleUI(Window* window)
 {
 }
 
-void SimpleUI::on_event(ev::Event& event)
+void SimpleUI::on_event(event& event)
 {
     d_engine.on_event(event);
 }

--- a/Sprocket/UI/SimpleUI.h
+++ b/Sprocket/UI/SimpleUI.h
@@ -1,8 +1,8 @@
 #pragma once
-#include <glm/glm.hpp>
-
 #include <Sprocket/UI/Font/Font.h>
 #include <Sprocket/UI/UIEngine.h>
+
+#include <glm/glm.hpp>
 
 #include <string>
 #include <string_view>
@@ -10,7 +10,7 @@
 namespace spkt {
 
 class Window;
-namespace ev { class Event; }
+class event;
 
 struct SimpleUITheme
 {
@@ -37,7 +37,7 @@ public:
 
     Font* GetFont() { return &d_font; }
     
-    void on_event(ev::Event& event);
+    void on_event(event& event);
     void on_update(double dt);
 
     void StartFrame();

--- a/Sprocket/UI/SinglePanelUI.cpp
+++ b/Sprocket/UI/SinglePanelUI.cpp
@@ -47,7 +47,7 @@ SinglePanelUI::SinglePanelUI(Window* window)
 {
 }
 
-void SinglePanelUI::on_event(ev::Event& event)
+void SinglePanelUI::on_event(event& event)
 {
     d_engine.on_event(event);
 }

--- a/Sprocket/UI/SinglePanelUI.h
+++ b/Sprocket/UI/SinglePanelUI.h
@@ -9,7 +9,7 @@
 namespace spkt {
 
 class Window;
-namespace ev { class Event; }
+class event;
 
 struct SinglePanelUITheme
 {
@@ -36,7 +36,7 @@ public:
 
     Font* GetFont() { return &d_font; }
 
-    void on_event(ev::Event& event);
+    void on_event(event& event);
     void on_update(double dt);
 
     void StartFrame();

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -214,20 +214,20 @@ DrawCommand& UIEngine::GetDrawCommand()
     return d_currentPanel->mainCommand;
 }
 
-void UIEngine::on_event(ev::Event& event)
+void UIEngine::on_event(spkt::event& event)
 {
     if (d_focused != 0 && !event.is_consumed()) {
-        if (auto data = event.get_if<ev::KeyboardTyped>()) {
+        if (auto data = event.get_if<KeyboardTyped>()) {
             d_keyPresses.push_back(data->key);
             event.consume();
         }
-        else if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+        else if (auto data = event.get_if<KeyboardButtonPressed>()) {
             if (data->key == Keyboard::BACKSPACE) {
                 d_keyPresses.push_back(Keyboard::BACKSPACE);
                 event.consume();
             }
         }
-        else if (auto data = event.get_if<ev::KeyboardButtonHeld>()) {
+        else if (auto data = event.get_if<KeyboardButtonHeld>()) {
             if (data->key == Keyboard::BACKSPACE) {
                 d_keyPresses.push_back(Keyboard::BACKSPACE);
                 event.consume();
@@ -235,13 +235,13 @@ void UIEngine::on_event(ev::Event& event)
         }
     }
 
-    if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+    if (auto data = event.get_if<MouseButtonPressed>()) {
         if (data->button == Mouse::LEFT) {
             d_mouseClicked = true;
         }
         if (d_consumeMouseEvents) { event.consume(); }
     }
-    if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+    if (auto data = event.get_if<MouseButtonReleased>()) {
         if (data->button == Mouse::LEFT) {
             d_widgetTimes[d_clicked].unclickedTime = d_time;
             d_clicked = 0;

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -15,9 +15,8 @@
 namespace spkt {
 
 class Window;
-
 class Font;
-namespace ev { class Event; }
+class event;
 
 enum class Alignment
 {
@@ -203,7 +202,7 @@ public:
     // Submits an extra draw command for the current panel. Asserts if there is no current panel.
     void SubmitDrawCommand(const DrawCommand& cmd);
 
-    void on_event(ev::Event& event);
+    void on_event(spkt::event& event);
     void on_update(double dt);
 
     void StartFrame();

--- a/Sprocket/Utility/InputProxy.cpp
+++ b/Sprocket/Utility/InputProxy.cpp
@@ -12,20 +12,20 @@ InputProxy::InputProxy()
     d_mouse.fill(false);
 }
   
-void InputProxy::on_event(ev::Event& event)
+void InputProxy::on_event(spkt::event& event)
 {
-    if (auto data = event.get_if<ev::KeyboardButtonPressed>()) {
+    if (auto data = event.get_if<KeyboardButtonPressed>()) {
         if (event.is_consumed()) { return; }
         d_keyboard[data->key] = true;
     }
-    else if (auto data = event.get_if<ev::KeyboardButtonReleased>()) {
+    else if (auto data = event.get_if<KeyboardButtonReleased>()) {
         d_keyboard[data->key] = false;
     }
-    else if (auto data = event.get_if<ev::MouseButtonPressed>()) {
+    else if (auto data = event.get_if<MouseButtonPressed>()) {
         if (event.is_consumed()) { return; }
         d_mouse[data->button] = true;
     }
-    else if (auto data = event.get_if<ev::MouseButtonReleased>()) {
+    else if (auto data = event.get_if<MouseButtonReleased>()) {
         d_mouse[data->button] = false;
     }
 }

--- a/Sprocket/Utility/InputProxy.h
+++ b/Sprocket/Utility/InputProxy.h
@@ -2,7 +2,8 @@
 #include <array>
 
 namespace spkt {
-namespace ev { class Event; }
+
+class event;
 
 class InputProxy
 {
@@ -16,7 +17,7 @@ private:
 public:
     InputProxy();
 
-    void on_event(ev::Event& event);
+    void on_event(spkt::event& event);
 
     bool is_mouse_down(int button) const;
     bool is_keyboard_down(int key) const;


### PR DESCRIPTION
* All event related code is now simply in the `spkt` namespace.
* `Event` has been renamed to `event`.
* `Scene::Entities` is now `Scene::registry`.
* Removed some more cases of the `Window.h` being included in headers when only a pointer is referenced.
* Typedef some pointers in the `AssetManager`.