### PR TITLE
Generalise Buffer Class

### DIFF
--- a/Sprocket/Core/Window.cpp
+++ b/Sprocket/Core/Window.cpp
@@ -271,12 +271,12 @@ void Window::SetCallback(EventCallback cb)
 	d_data.callback = cb;
 }
 
-const char* Window::GetClipboardData()
+const char* Window::GetClipboardData() const
 {
 	return glfwGetClipboardString(d_impl->window);
 }
 
-void Window::SetClipboardData(const std::string& text)
+void Window::SetClipboardData(const std::string& text) const
 {
 	glfwSetClipboardString(d_impl->window, text.c_str());
 }

--- a/Sprocket/Core/Window.h
+++ b/Sprocket/Core/Window.h
@@ -81,8 +81,8 @@ public:
 	glm::vec2 GetMouseOffset() const;
 
 	// Clipboard Utilities
-	const char* GetClipboardData();
-	void SetClipboardData(const std::string& text);
+	const char* GetClipboardData() const;
+	void SetClipboardData(const std::string& text) const;
 
 	// Low level Utilities
 	void* NativeWindow() const;

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -149,7 +149,7 @@ void Scene3DRenderer::Draw(
 
     std::unordered_map<
         std::pair<std::string, std::string>,
-        std::vector<model_instance>,
+        std::vector<spkt::model_instance>,
         spkt::hash_pair
     > commands;
 
@@ -173,7 +173,7 @@ void Scene3DRenderer::Draw(
     // If the scene has a ParticleSingleton, then render the particles that it contains.
     for (auto entity : registry.view<ParticleSingleton>()) {
         const auto& ps = registry.get<ParticleSingleton>(entity);
-        std::vector<model_instance> instance_data(NUM_PARTICLES);
+        std::vector<spkt::model_instance> instance_data(NUM_PARTICLES);
         for (const auto& particle : *ps.particles) {
             if (particle.life > 0.0) {
                 instance_data.push_back({

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.h
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.h
@@ -35,7 +35,7 @@ private:
     shader d_staticShader;
     shader d_animatedShader;
     
-    buffer<model_instance> d_instanceBuffer;
+    spkt::vertex_buffer<spkt::model_instance> d_instanceBuffer;
 
     Scene3DRenderer(const Scene3DRenderer&) = delete;
     Scene3DRenderer& operator=(const Scene3DRenderer&) = delete;

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -1,6 +1,6 @@
 #include "ShadowMap.h"
 
-#include <Sprocket/Graphics/RenderContext.h>
+#include <Sprocket/Graphics/render_context.h>
 #include <Sprocket/Scene/ecs.h>
 
 #include <glad/glad.h>

--- a/Sprocket/Graphics/ShadowMap.h
+++ b/Sprocket/Graphics/ShadowMap.h
@@ -26,7 +26,7 @@ class ShadowMap
 
     DepthBuffer d_shadowMap;
 
-    spkt::buffer<model_instance> d_instance_buffer;
+    spkt::vertex_buffer<spkt::model_instance> d_instance_buffer;
 
 public:
     ShadowMap(AssetManager* assetManager);

--- a/Sprocket/Graphics/buffer.cpp
+++ b/Sprocket/Graphics/buffer.cpp
@@ -53,25 +53,4 @@ void set_data(std::uint32_t vbo, std::size_t size, const void* data, buffer_usag
 
 }
 
-index_buffer::index_buffer()
-    : d_vbo(detail::new_vbo())
-    , d_size(0)
-{}
-
-index_buffer::~index_buffer()
-{
-    detail::delete_vbo(d_vbo);
-}
-
-void index_buffer::bind() const
-{
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, d_vbo);
-}
-
-void index_buffer::set_data(std::span<const std::uint32_t> data)
-{
-    d_size = data.size();
-    detail::set_data(d_vbo, data.size_bytes(), data.data(), buffer_usage::STATIC);
-}
-
 }

--- a/Sprocket/Graphics/buffer.cpp
+++ b/Sprocket/Graphics/buffer.cpp
@@ -41,6 +41,11 @@ void unbind_vbo()
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
+void bind_index_buffer(std::uint32_t vbo)
+{
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo);
+}
+
 void set_data(std::uint32_t vbo, std::size_t size, const void* data, buffer_usage usage)
 {
     glNamedBufferData(vbo, size, data, get_usage(usage));

--- a/Sprocket/Graphics/buffer.cpp
+++ b/Sprocket/Graphics/buffer.cpp
@@ -12,6 +12,7 @@ int get_usage(buffer_usage usage)
     switch (usage) {
         case buffer_usage::STATIC: return GL_STATIC_DRAW;
         case buffer_usage::DYNAMIC: return GL_DYNAMIC_DRAW;
+        case buffer_usage::STREAM: return GL_STREAM_DRAW;
     }
 }
 
@@ -29,16 +30,6 @@ std::uint32_t new_vbo()
 void delete_vbo(std::uint32_t vbo)
 {
     glDeleteBuffers(1, &vbo);
-}
-
-void bind_vbo(std::uint32_t vbo)
-{
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-}
-
-void unbind_vbo()
-{
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void bind_index_buffer(std::uint32_t vbo)

--- a/Sprocket/Graphics/buffer.h
+++ b/Sprocket/Graphics/buffer.h
@@ -19,8 +19,6 @@ namespace detail {
 
 std::uint32_t new_vbo();
 void delete_vbo(std::uint32_t vbo);
-void bind_vbo(std::uint32_t vbo);
-void unbind_vbo();
 void bind_index_buffer(std::uint32_t vbo);
 void set_data(std::uint32_t vbo, std::size_t size, const void* data, buffer_usage usage);
 
@@ -42,9 +40,7 @@ public:
 
     void bind() const
     {
-        detail::bind_vbo(d_vbo);
-        T::set_buffer_attributes();
-        detail::unbind_vbo();
+        T::set_buffer_attributes(d_vbo);
     }
 
     void set_data(std::span<const T> data)
@@ -56,7 +52,7 @@ public:
     std::size_t size() const { return d_size; }
 };
 
-template <spkt::buffer_element T, buffer_usage Usage = buffer_usage::STATIC>
+template <std::unsigned_integral T, buffer_usage Usage = buffer_usage::STATIC>
 class ibuffer
 {
     std::uint32_t d_vbo;
@@ -66,7 +62,7 @@ class ibuffer
     ibuffer& operator=(const ibuffer&) = delete;
 
 public:
-    ibuffer(std::span<const T> data) : buffer() { set_data(data); }
+    ibuffer(std::span<const T> data) : ibuffer() { set_data(data); }
     ibuffer() : d_vbo(detail::new_vbo()), d_size(0) {}
     ~ibuffer() { detail::delete_vbo(d_vbo); }
 
@@ -84,23 +80,6 @@ public:
     std::size_t size() const { return d_size; }
 };
 
-class index_buffer
-{
-    std::uint32_t d_vbo;
-    std::size_t   d_size;
-
-    index_buffer(const index_buffer&) = delete;
-    index_buffer& operator=(const index_buffer&) = delete;
-
-public:
-    index_buffer(std::span<const std::uint32_t> data) : index_buffer() { set_data(data); }
-    index_buffer();
-    ~index_buffer();
-
-    void bind() const;
-    void set_data(std::span<const std::uint32_t> data);
-
-    std::size_t size() const { return d_size; }
-};
+using index_buffer = ibuffer<std::uint32_t>;
 
 }

--- a/Sprocket/Graphics/buffer.h
+++ b/Sprocket/Graphics/buffer.h
@@ -21,6 +21,7 @@ std::uint32_t new_vbo();
 void delete_vbo(std::uint32_t vbo);
 void bind_vbo(std::uint32_t vbo);
 void unbind_vbo();
+void bind_index_buffer(std::uint32_t vbo);
 void set_data(std::uint32_t vbo, std::size_t size, const void* data, buffer_usage usage);
 
 }
@@ -44,6 +45,34 @@ public:
         detail::bind_vbo(d_vbo);
         T::set_buffer_attributes();
         detail::unbind_vbo();
+    }
+
+    void set_data(std::span<const T> data)
+    {
+        d_size = data.size();
+        detail::set_data(d_vbo, data.size_bytes(), data.data(), Usage);
+    }
+
+    std::size_t size() const { return d_size; }
+};
+
+template <spkt::buffer_element T, buffer_usage Usage = buffer_usage::STATIC>
+class ibuffer
+{
+    std::uint32_t d_vbo;
+    std::size_t   d_size;
+
+    ibuffer(const ibuffer&) = delete;
+    ibuffer& operator=(const ibuffer&) = delete;
+
+public:
+    ibuffer(std::span<const T> data) : buffer() { set_data(data); }
+    ibuffer() : d_vbo(detail::new_vbo()), d_size(0) {}
+    ~ibuffer() { detail::delete_vbo(d_vbo); }
+
+    void bind() const
+    {
+        detail::bind_index_buffer(d_vbo);
     }
 
     void set_data(std::span<const T> data)

--- a/Sprocket/Graphics/buffer.h
+++ b/Sprocket/Graphics/buffer.h
@@ -51,11 +51,9 @@ public:
 };
 
 template <spkt::buffer_element T, buffer_usage Usage = buffer_usage::STATIC>
-using buffer = basic_buffer<T, Usage, T::set_buffer_attributes>;
+using vertex_buffer = basic_buffer<T, Usage, T::set_buffer_attributes>;
 
 template <std::unsigned_integral T, buffer_usage Usage = buffer_usage::STATIC>
-using ibuffer = basic_buffer<T, Usage, detail::bind_index_buffer>;
-
-using index_buffer = ibuffer<std::uint32_t>;
+using index_buffer = basic_buffer<T, Usage, detail::bind_index_buffer>;
 
 }

--- a/Sprocket/Graphics/buffer.h
+++ b/Sprocket/Graphics/buffer.h
@@ -45,7 +45,7 @@ public:
     void set_data(std::span<const T> data)
     {
         d_size = data.size();
-        detail::set_data(d_vbo, data.size() * sizeof(T), data.data(), Usage);
+        detail::set_data(d_vbo, data.size_bytes(), data.data(), Usage);
     }
 
     std::size_t size() const { return d_size; }

--- a/Sprocket/Graphics/buffer.h
+++ b/Sprocket/Graphics/buffer.h
@@ -13,7 +13,8 @@ namespace spkt {
 enum class buffer_usage
 {
     STATIC,
-    DYNAMIC
+    DYNAMIC,
+    STREAM
 };
 
 namespace detail {
@@ -44,7 +45,7 @@ public:
     void set_data(std::span<const T> data)
     {
         d_size = data.size();
-        detail::set_data(d_vbo, data.size_bytes(), data.data(), Usage);
+        detail::set_data(d_vbo, data.size() * sizeof(T), data.data(), Usage);
     }
 
     std::size_t size() const { return d_size; }

--- a/Sprocket/Graphics/buffer_element_types.cpp
+++ b/Sprocket/Graphics/buffer_element_types.cpp
@@ -6,8 +6,9 @@
 
 namespace spkt {
 
-void static_vertex::set_buffer_attributes()
+void static_vertex::set_buffer_attributes(std::uint32_t vbo)
 {
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     for (int index : std::views::iota(0, 5)) {
         glEnableVertexAttribArray(index);
         glVertexAttribDivisor(index, 0);
@@ -18,10 +19,13 @@ void static_vertex::set_buffer_attributes()
     glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(static_vertex), (void*)offsetof(static_vertex, normal));
     glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(static_vertex), (void*)offsetof(static_vertex, tangent));
     glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(static_vertex), (void*)offsetof(static_vertex, bitangent));
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void animated_vertex::set_buffer_attributes()
+void animated_vertex::set_buffer_attributes(std::uint32_t vbo)
 {
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     for (int index : std::views::iota(0, 7)) {
         glEnableVertexAttribArray(index);
         glVertexAttribDivisor(index, 0);
@@ -34,10 +38,13 @@ void animated_vertex::set_buffer_attributes()
     glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(animated_vertex), (void*)offsetof(animated_vertex, bitangent));
     glVertexAttribIPointer(5, 4, GL_INT, sizeof(animated_vertex), (void*)offsetof(animated_vertex, boneIndices));
     glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(animated_vertex), (void*)offsetof(animated_vertex, boneWeights));
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void ui_vertex::set_buffer_attributes()
+void ui_vertex::set_buffer_attributes(std::uint32_t vbo)
 {
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     for (int index : std::views::iota(0, 3)) {
         glEnableVertexAttribArray(index);
         glVertexAttribDivisor(index, 0);
@@ -46,10 +53,13 @@ void ui_vertex::set_buffer_attributes()
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(ui_vertex), (void*)offsetof(ui_vertex, position));
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(ui_vertex), (void*)offsetof(ui_vertex, colour));
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(ui_vertex), (void*)offsetof(ui_vertex, textureCoords));
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void model_instance::set_buffer_attributes()
+void model_instance::set_buffer_attributes(std::uint32_t vbo)
 {
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
     for (int index : std::views::iota(5, 8)) {
         glEnableVertexAttribArray(index);
         glVertexAttribDivisor(index, 1);
@@ -58,6 +68,8 @@ void model_instance::set_buffer_attributes()
     glVertexAttribPointer(5, 3, GL_FLOAT, GL_FALSE, sizeof(model_instance), (void*)offsetof(model_instance, position));
     glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(model_instance), (void*)offsetof(model_instance, orientation));
     glVertexAttribPointer(7, 3, GL_FLOAT, GL_FALSE, sizeof(model_instance), (void*)offsetof(model_instance, scale));
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 }

--- a/Sprocket/Graphics/buffer_element_types.h
+++ b/Sprocket/Graphics/buffer_element_types.h
@@ -7,7 +7,7 @@ namespace spkt {
 template <typename T>
 concept buffer_element = requires
 {
-    { T::set_buffer_attributes() } -> std::same_as<void>;
+    { T::set_buffer_attributes(std::uint32_t{}) } -> std::same_as<void>;
 };
 
 struct static_vertex
@@ -19,7 +19,7 @@ struct static_vertex
     glm::vec3 tangent;
     glm::vec3 bitangent;
 
-    static void set_buffer_attributes();
+    static void set_buffer_attributes(std::uint32_t vbo);
 };
 
 struct animated_vertex
@@ -34,7 +34,7 @@ struct animated_vertex
     glm::ivec4 boneIndices = {-1, -1, -1, -1};
     glm::vec4  boneWeights = {0.0, 0.0, 0.0, 0.0};
 
-    static void set_buffer_attributes();
+    static void set_buffer_attributes(std::uint32_t vbo);
 };
 
 struct ui_vertex
@@ -43,7 +43,7 @@ struct ui_vertex
     glm::vec4 colour;
     glm::vec2 textureCoords = {0.0, 0.0};
 
-    static void set_buffer_attributes();
+    static void set_buffer_attributes(std::uint32_t vbo);
 };
 
 struct model_instance
@@ -52,7 +52,7 @@ struct model_instance
     glm::quat orientation;
     glm::vec3 scale;
 
-    static void set_buffer_attributes();
+    static void set_buffer_attributes(std::uint32_t vbo);
 };
 
 }

--- a/Sprocket/Graphics/mesh.h
+++ b/Sprocket/Graphics/mesh.h
@@ -33,8 +33,8 @@ struct animated_mesh_data
 
 class static_mesh
 {
-    spkt::buffer<spkt::static_vertex> d_vertices;
-    spkt::index_buffer                d_indices;
+    spkt::vertex_buffer<spkt::static_vertex> d_vertices;
+    spkt::index_buffer<std::uint32_t>        d_indices;
 
     static_mesh(const static_mesh&) = delete;
     static_mesh& operator=(const static_mesh&) = delete;
@@ -53,9 +53,9 @@ using static_mesh_ptr = std::unique_ptr<static_mesh>;
 
 class animated_mesh
 {
-    spkt::buffer<spkt::animated_vertex> d_vertices;
-    spkt::index_buffer                  d_indices;
-    spkt::Skeleton                      d_skeleton;
+    spkt::vertex_buffer<spkt::animated_vertex> d_vertices;
+    spkt::index_buffer<std::uint32_t>          d_indices;
+    spkt::Skeleton                             d_skeleton;
 
     animated_mesh(const animated_mesh&) = delete;
     animated_mesh& operator=(const animated_mesh&) = delete;

--- a/Sprocket/Graphics/open_gl.cpp
+++ b/Sprocket/Graphics/open_gl.cpp
@@ -15,7 +15,7 @@ concept bindable = requires(T t)
 };
 
 template <bindable T>
-void draw_impl(T* mesh, spkt::buffer<model_instance>* instances)
+void draw_impl(T* mesh, spkt::vertex_buffer<model_instance>* instances)
 {
     mesh->bind();
     if (instances) {
@@ -28,12 +28,12 @@ void draw_impl(T* mesh, spkt::buffer<model_instance>* instances)
 
 }
 
-void draw(spkt::static_mesh* mesh, spkt::buffer<model_instance>* instances)
+void draw(spkt::static_mesh* mesh, spkt::vertex_buffer<model_instance>* instances)
 {
     draw_impl(mesh, instances);
 }
 
-void draw(spkt::animated_mesh* mesh, spkt::buffer<model_instance>* instances)
+void draw(spkt::animated_mesh* mesh, spkt::vertex_buffer<model_instance>* instances)
 {
     draw_impl(mesh, instances);
 }

--- a/Sprocket/Graphics/open_gl.h
+++ b/Sprocket/Graphics/open_gl.h
@@ -7,7 +7,7 @@
 
 namespace spkt {
 
-void draw(spkt::static_mesh* mesh, spkt::buffer<model_instance>* instances = nullptr);
-void draw(spkt::animated_mesh* mesh, spkt::buffer<model_instance>* instances = nullptr);
+void draw(spkt::static_mesh* mesh, spkt::vertex_buffer<model_instance>* instances = nullptr);
+void draw(spkt::animated_mesh* mesh, spkt::vertex_buffer<model_instance>* instances = nullptr);
 
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -268,9 +268,9 @@ void DevUI::EndFrame()
     rc.scissor_testing(true);
     rc.depth_testing(false);
 
-    ImDrawData* drawData = ImGui::GetDrawData();
+    const ImDrawData* drawData = ImGui::GetDrawData();
 
-    auto proj = glm::ortho(0.0f, drawData->DisplaySize.x, drawData->DisplaySize.y, 0.0f);
+    const auto proj = glm::ortho(0.0f, drawData->DisplaySize.x, drawData->DisplaySize.y, 0.0f);
 
     d_shader.bind();
     d_shader.load("Texture", 0);
@@ -279,16 +279,16 @@ void DevUI::EndFrame()
     d_fontAtlas->Bind(0);
 
     // Render command lists
-    int width = (int)drawData->DisplaySize.x;
-    int height = (int)drawData->DisplaySize.y;
+    const int width = (int)drawData->DisplaySize.x;
+    const int height = (int)drawData->DisplaySize.y;
 
     d_vtx_buffer.bind();
     d_idx_buffer.bind();
     for (int n = 0; n < drawData->CmdListsCount; ++n) {
         const ImDrawList* cmd_list = drawData->CmdLists[n];
 
-        d_vtx_buffer.set_data({cmd_list->VtxBuffer.begin(), cmd_list->VtxBuffer.end()});
-        d_idx_buffer.set_data({cmd_list->IdxBuffer.begin(), cmd_list->IdxBuffer.end()});
+        d_vtx_buffer.set_data(cmd_list->VtxBuffer);
+        d_idx_buffer.set_data(cmd_list->IdxBuffer);
 
         for (int i = 0; i < cmd_list->CmdBuffer.Size; ++i) {
             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[i];

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -21,12 +21,11 @@ using imgui_index_buffer = spkt::index_buffer<ImDrawIdx, buffer_usage::STREAM>;
 class DevUI
 // A class that wraps the setup and rendering of ImGui.
 {
-    Window* d_window;
     shader  d_shader;
     std::unique_ptr<Texture> d_fontAtlas;
 
-    spkt::imgui_vertex_buffer d_vertex_buffer;
-    spkt::imgui_index_buffer  d_index_buffer;
+    spkt::imgui_vertex_buffer d_vtx_buffer;
+    spkt::imgui_index_buffer  d_idx_buffer;
 
     bool d_blockEvents;
 

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Sprocket/Graphics/shader.h>
+#include <Sprocket/Graphics/buffer.h>
 #include <Sprocket/Graphics/Texture.h>
 
 #include <imgui.h>
@@ -12,6 +13,11 @@ namespace spkt {
 class Window;
 class event;
 
+void bind_imgui_vbo(std::uint32_t vbo);
+
+using imgui_vertex_buffer = spkt::basic_buffer<ImDrawVert, buffer_usage::STREAM, bind_imgui_vbo>;
+using imgui_index_buffer = spkt::index_buffer<ImDrawIdx, buffer_usage::STREAM>;
+
 class DevUI
 // A class that wraps the setup and rendering of ImGui.
 {
@@ -19,8 +25,8 @@ class DevUI
     shader  d_shader;
     std::unique_ptr<Texture> d_fontAtlas;
 
-    std::uint32_t d_vertexBuffer;
-    std::uint32_t d_indexBuffer;
+    spkt::imgui_vertex_buffer d_vertex_buffer;
+    spkt::imgui_index_buffer  d_index_buffer;
 
     bool d_blockEvents;
 

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -423,20 +423,19 @@ void UIEngine::ExecuteCommand(const DrawCommand& cmd)
         d_white.Bind(0);
     }
 
-    d_vertices.set_data(cmd.vertices);
     d_vertices.bind();
-    d_indices.set_data(cmd.indices);
     d_indices.bind();
-    glDrawElements(GL_TRIANGLES,  (int)d_indices.size(), GL_UNSIGNED_INT, nullptr);
+
+    d_vertices.set_data(cmd.vertices);
+    d_indices.set_data(cmd.indices);
+    glDrawElements(GL_TRIANGLES, (int)d_indices.size(), GL_UNSIGNED_INT, nullptr);
 
     if (cmd.font) {
         cmd.font->Bind(0);
         d_shader.load("texture_channels", 1);
         d_vertices.set_data(cmd.textVertices);
-        d_vertices.bind();
         d_indices.set_data(cmd.textIndices);
-        d_indices.bind();
-        glDrawElements(GL_TRIANGLES,  (int)d_indices.size(), GL_UNSIGNED_INT, nullptr);
+        glDrawElements(GL_TRIANGLES, (int)d_indices.size(), GL_UNSIGNED_INT, nullptr);
     }
 }
 

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -257,7 +257,7 @@ void UIEngine::StartFrame()
 void UIEngine::MouseClick()
 {
     bool foundClicked = false;
-    glm::vec2 mouse = d_window->GetMousePos();
+    const glm::vec2 mouse = d_window->GetMousePos();
 
     std::size_t moveToFront = 0;
 
@@ -304,7 +304,7 @@ void UIEngine::MouseClick()
 void UIEngine::MouseHover()
 {
     bool foundHovered = false;
-    glm::vec2 mouse = d_window->GetMousePos();
+    const glm::vec2 mouse = d_window->GetMousePos();
 
     for (auto panelHash : d_panelOrder | std::views::reverse) {
         auto it = d_panels.find(panelHash);
@@ -352,13 +352,13 @@ void UIEngine::EndFrame()
     rc.face_culling(false);
     rc.depth_testing(false);
 
-    float w = (float)d_window->Width();
-    float h = (float)d_window->Height();
+    const float w = (float)d_window->Width();
+    const float h = (float)d_window->Height();
 
     // This transformation makes the top left of the screen (0, 0) and the bottom
     // right be (width, height). It flips the y-axis since OpenGL treats the bottom
     // left as (0, 0).
-    auto proj = glm::ortho(0.0f, w, h, 0.0f);
+    const auto proj = glm::ortho(0.0f, w, h, 0.0f);
     d_shader.bind();
     d_shader.load("u_proj_matrix", proj);
 
@@ -375,7 +375,7 @@ void UIEngine::EndFrame()
 void UIEngine::StartPanel(std::string_view name, glm::vec4* region, PanelType type)
 {
     assert(!d_currentPanel);
-    std::size_t hash = std::hash<std::string_view>{}(name);
+    const std::size_t hash = std::hash<std::string_view>{}(name);
 
     if (std::ranges::find(d_panelOrder, hash) == d_panelOrder.end()) {
         d_panelOrder.push_back(hash);

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -140,8 +140,8 @@ class UIEngine
     // Rendering code    
     spkt::shader d_shader;
     
-    spkt::buffer<ui_vertex> d_vertices;
-    spkt::index_buffer      d_indices;
+    spkt::vertex_buffer<spkt::ui_vertex> d_vertices;
+    spkt::index_buffer<std::uint32_t>    d_indices;
     
     // Panel info 
     std::unordered_map<std::size_t, Panel> d_panels;

--- a/imgui.ini
+++ b/imgui.ini
@@ -80,7 +80,7 @@ Collapsed=1
 
 [Window][Viewport]
 Pos=0,21
-Size=1055,699
+Size=643,752
 Collapsed=0
 DockId=0x00000004,0
 
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=1057,336
-Size=223,317
+Pos=645,360
+Size=271,341
 Collapsed=0
 DockId=0x00000006,0
 
@@ -131,8 +131,8 @@ Size=287,329
 Collapsed=0
 
 [Window][Explorer]
-Pos=1057,21
-Size=223,313
+Pos=645,21
+Size=271,337
 Collapsed=0
 DockId=0x00000005,0
 
@@ -143,7 +143,7 @@ Collapsed=0
 
 [Window][DockSpaceViewport_11111111]
 Pos=0,21
-Size=1280,699
+Size=916,752
 Collapsed=0
 
 [Window][Colour Scheme Picker]
@@ -157,15 +157,15 @@ Size=277,422
 Collapsed=0
 
 [Window][Options]
-Pos=1057,655
-Size=223,65
+Pos=645,703
+Size=271,70
 Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=1055,699 CentralNode=1 Selected=0x995B0CF8
-  DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=223,699 Split=Y Selected=0x1E89CEB8
+DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=916,752 Split=X Selected=0x995B0CF8
+  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=643,699 CentralNode=1 Selected=0x995B0CF8
+  DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=271,699 Split=Y Selected=0x1E89CEB8
     DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0xF02CD328
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=223,313 Selected=0x1E89CEB8
       DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=223,317 Selected=0xF02CD328


### PR DESCRIPTION
* Generalise `vertex_buffer` and `index_buffer` into a singular `basic_buffer`. Both of the previous classes are now just template specializations.
* This new buffer type can also be specialized in a really neat way for the imgui wrapper, allowing us to set the data in the buffer just by passing the custom vector class (since it implements `begin` and `end` it can be converted to a `std::span`). Now all uses of buffers are unified in a clean extensible API.
* No longer store a `Window*` in `DevUI`. The window resizing can use the event system instead, and the clipboard functions on the `Window` get set in the constructor.
* Const-ify the clipboard functions on `Window`. 
* Add `buffer_usage::STREAM` to allow `GL_STREAM_DRAW` in buffers.
* Add `spkt::render_context::set_scissor_window`.