### PR TITLE
Update to use Rangified Apecs

### DIFF
--- a/Anvil/Anvil.cpp
+++ b/Anvil/Anvil.cpp
@@ -40,7 +40,7 @@ bool SubstringCI(std::string_view string, std::string_view substr) {
 
 }
 
-Anvil::Anvil(spkt::Window* window) 
+Anvil::Anvil(spkt::Window* window)
     : d_window(window)
     , d_asset_manager()
     , d_entity_renderer(&d_asset_manager)
@@ -59,8 +59,8 @@ Anvil::Anvil(spkt::Window* window)
 {
     d_window->SetCursorVisibility(true);
 
-    d_scene = std::make_shared<spkt::scene>(); 
-    spkt::add_singleton(d_scene->registry);   
+    d_scene = std::make_shared<spkt::scene>();
+    spkt::add_singleton(d_scene->registry);
     spkt::load_registry_from_file(d_sceneFile, d_scene->registry);
     d_activeScene = d_scene;
 }
@@ -262,7 +262,7 @@ void Anvil::on_render()
             search = "";
         }
         if (ImGui::BeginTabBar("##Tabs")) {
-            
+
             if (ImGui::BeginTabItem("Entities")) {
                 ImGui::BeginChild("Entity List");
                 int i = 0;
@@ -322,7 +322,7 @@ void Anvil::on_render()
                         }
                         ImGui::PopID();
                         ImGui::Separator();
-                        
+
                         ImGui::PushID(hasher("Roughness"));
                         ImGui::Text("Roughness");
                         ImGui::Checkbox("Use Map", &material->useRoughnessMap);
@@ -351,6 +351,32 @@ void Anvil::on_render()
 
     if (ImGui::Begin("Options")) {
         ImGui::Checkbox("Show Colliders", &d_showColliders);
+        ImGui::Text("# Runtime: %i", registry.view<spkt::Runtime>().size());
+        ImGui::Text("# Singleton: %i", registry.view<spkt::Singleton>().size());
+        ImGui::Text("# Event: %i", registry.view<spkt::Event>().size());
+        ImGui::Text("# NameComponent: %i", registry.view<spkt::NameComponent>().size());
+        ImGui::Text("# Transform2DComponent: %i", registry.view<spkt::Transform2DComponent>().size());
+        ImGui::Text("# Transform3DComponent: %i", registry.view<spkt::Transform3DComponent>().size());
+        ImGui::Text("# StaticModelComponent: %i", registry.view<spkt::StaticModelComponent>().size());
+        ImGui::Text("# AnimatedModelComponent: %i", registry.view<spkt::AnimatedModelComponent>().size());
+        ImGui::Text("# RigidBody3DComponent: %i", registry.view<spkt::RigidBody3DComponent>().size());
+        ImGui::Text("# BoxCollider3DComponent: %i", registry.view<spkt::BoxCollider3DComponent>().size());
+        ImGui::Text("# SphereCollider3DComponent: %i", registry.view<spkt::SphereCollider3DComponent>().size());
+        ImGui::Text("# CapsuleCollider3DComponent: %i", registry.view<spkt::CapsuleCollider3DComponent>().size());
+        ImGui::Text("# ScriptComponent: %i", registry.view<spkt::ScriptComponent>().size());
+        ImGui::Text("# Camera3DComponent: %i", registry.view<spkt::Camera3DComponent>().size());
+        ImGui::Text("# PathComponent: %i", registry.view<spkt::PathComponent>().size());
+        ImGui::Text("# LightComponent: %i", registry.view<spkt::LightComponent>().size());
+        ImGui::Text("# SunComponent: %i", registry.view<spkt::SunComponent>().size());
+        ImGui::Text("# AmbienceComponent: %i", registry.view<spkt::AmbienceComponent>().size());
+        ImGui::Text("# ParticleComponent: %i", registry.view<spkt::ParticleComponent>().size());
+        ImGui::Text("# CollisionEvent: %i", registry.view<spkt::CollisionEvent>().size());
+        ImGui::Text("# PhysicsSingleton: %i", registry.view<spkt::PhysicsSingleton>().size());
+        ImGui::Text("# InputSingleton: %i", registry.view<spkt::InputSingleton>().size());
+        ImGui::Text("# GameGridSingleton: %i", registry.view<spkt::GameGridSingleton>().size());
+        ImGui::Text("# TileMapSingleton: %i", registry.view<spkt::TileMapSingleton>().size());
+        ImGui::Text("# CameraSingleton: %i", registry.view<spkt::CameraSingleton>().size());
+        ImGui::Text("# ParticleSingleton: %i", registry.view<spkt::ParticleSingleton>().size());
         ImGui::End();
     }
 

--- a/Anvil/Anvil.dm.cpp
+++ b/Anvil/Anvil.dm.cpp
@@ -1,0 +1,370 @@
+#include "Anvil.h"
+
+#include <Anvil/Inspector.h>
+
+#include <Sprocket/Scene/Camera.h>
+#include <Sprocket/Scene/Loader.h>
+#include <Sprocket/Scene/Systems/basic_systems.h>
+#include <Sprocket/Scene/Systems/particle_system.h>
+#include <Sprocket/Scene/Systems/physics_system.h>
+#include <Sprocket/UI/ImGuiXtra.h>
+#include <Sprocket/Utility/FileBrowser.h>
+#include <Sprocket/Utility/KeyboardCodes.h>
+#include <Sprocket/Utility/Log.h>
+#include <Sprocket/Utility/Maths.h>
+#include <Sprocket/Vendor/imgui/imgui.h>
+
+#include <glm/glm.hpp>
+
+#include <string_view>
+#include <ranges>
+
+namespace {
+
+std::string entiy_name(spkt::registry& registry, spkt::entity entity)
+{
+    if (registry.has<spkt::NameComponent>(entity)) {
+        return registry.get<spkt::NameComponent>(entity).name;
+    }
+    return "Entity";
+}
+
+bool SubstringCI(std::string_view string, std::string_view substr) {
+    auto it = std::search(
+        string.begin(), string.end(),
+        substr.begin(), substr.end(),
+        [] (char c1, char c2) { return std::toupper(c1) == std::toupper(c2); }
+    );
+    return it != string.end();
+}
+
+}
+
+Anvil::Anvil(spkt::Window* window) 
+    : d_window(window)
+    , d_asset_manager()
+    , d_entity_renderer(&d_asset_manager)
+    , d_skybox_renderer(&d_asset_manager)
+    , d_skybox({
+        "Resources/Textures/Skybox/Skybox_X_Pos.png",
+        "Resources/Textures/Skybox/Skybox_X_Neg.png",
+        "Resources/Textures/Skybox/Skybox_Y_Pos.png",
+        "Resources/Textures/Skybox/Skybox_Y_Neg.png",
+        "Resources/Textures/Skybox/Skybox_Z_Pos.png",
+        "Resources/Textures/Skybox/Skybox_Z_Neg.png"
+    })
+    , d_editor_camera(d_window, {0.0, 0.0, 0.0})
+    , d_viewport(1280, 720)
+    , d_ui(d_window)
+{
+    d_window->SetCursorVisibility(true);
+
+    d_scene = std::make_shared<spkt::scene>(); 
+    spkt::add_singleton(d_scene->registry);   
+    spkt::load_registry_from_file(d_sceneFile, d_scene->registry);
+    d_activeScene = d_scene;
+}
+
+void Anvil::on_event(spkt::event& event)
+{
+    using namespace spkt;
+
+    if (auto data = event.get_if<keyboard_pressed_event>()) {
+        if (data->key == Keyboard::ESC) {
+            if (d_playingGame) {
+                d_playingGame = false;
+                d_activeScene = d_scene;
+                d_window->SetCursorVisibility(true);
+            }
+            else if (d_selected != spkt::null) {
+                d_selected = spkt::null;
+            }
+            else if (d_window->IsFullscreen()) {
+                d_window->SetWindowed(1280, 720);
+            }
+            event.consume();
+        } else if (data->key == Keyboard::F11) {
+            if (d_window->IsFullscreen()) {
+                d_window->SetWindowed(1280, 720);
+            }
+            else {
+                d_window->SetFullscreen();
+            }
+            event.consume();
+        }
+    }
+
+    d_ui.on_event(event);
+    d_activeScene->on_event(event);
+    if (!d_playingGame) {
+        d_editor_camera.on_event(event);
+    }
+}
+
+void Anvil::on_update(double dt)
+{
+    auto& registry = d_activeScene->registry;
+
+    d_ui.on_update(dt);
+
+    if (d_paused) {
+        return;
+    }
+
+    d_activeScene->on_update(dt);
+
+    if (d_is_viewport_focused && !d_playingGame) {
+        d_editor_camera.on_update(dt);
+    }
+}
+
+glm::mat4 Anvil::get_proj_matrix() const
+{
+    auto& registry = d_activeScene->registry;
+    return d_playingGame ? spkt::make_proj(registry, d_runtimeCamera) : d_editor_camera.Proj();
+}
+
+glm::mat4 Anvil::get_view_matrix() const
+{
+    auto& registry = d_activeScene->registry;
+    return d_playingGame ? spkt::make_view(registry, d_runtimeCamera) : d_editor_camera.View();
+}
+
+void Anvil::on_render()
+{
+    auto& registry = d_activeScene->registry;
+
+    // If the size of the viewport has changed since the previous frame, recreate
+    // the framebuffer.
+    if (d_viewport_size != d_viewport.Size() && d_viewport_size.x > 0 && d_viewport_size.y > 0) {
+        d_viewport.SetScreenSize(d_viewport_size.x, d_viewport_size.y);
+    }
+
+    d_viewport.Bind();
+
+    glm::mat4 proj = get_proj_matrix();
+    glm::mat4 view = get_view_matrix();
+
+    d_entity_renderer.Draw(registry, proj, view);
+    d_skybox_renderer.Draw(d_skybox, proj, view);
+    if (d_showColliders) {
+        d_collider_renderer.Draw(registry, proj, view);
+    }
+
+    d_viewport.Unbind();
+
+
+    d_ui.StartFrame();
+
+    ImGui::DockSpaceOverViewport();
+
+    if (ImGui::BeginMainMenuBar()) {
+        if (ImGui::BeginMenu("File")) {
+            if (ImGui::MenuItem("New")) {
+                std::string file = spkt::SaveFile(d_window, "*.yaml");
+                if (!file.empty()) {
+                    spkt::log::info("Creating {}...", d_sceneFile);
+                    d_sceneFile = file;
+                    d_activeScene = d_scene = std::make_shared<spkt::scene>();
+                    spkt::log::info("...done!");
+                }
+            }
+            if (ImGui::MenuItem("Open")) {
+                std::string file = spkt::OpenFile(d_window, "*.yaml");
+                if (!file.empty()) {
+                    spkt::log::info("Loading {}...", d_sceneFile);
+                    d_sceneFile = file;
+                    d_activeScene = d_scene = std::make_shared<spkt::scene>();
+                    spkt::load_registry_from_file(file, d_scene->registry);
+                    spkt::log::info("...done!");
+                }
+            }
+            if (ImGui::MenuItem("Save")) {
+                spkt::log::info("Saving {}...", d_sceneFile);
+                spkt::save_registry_to_file(d_sceneFile, d_scene->registry);
+                spkt::log::info("...done!");
+            }
+            if (ImGui::MenuItem("Save As")) {
+                std::string file = spkt::SaveFile(d_window, "*.yaml");
+                if (!file.empty()) {
+                    spkt::log::info("Saving as {}...", file);
+                    d_sceneFile = file;
+                    spkt::save_registry_to_file(file, d_scene->registry);
+                    spkt::log::info("...done!");
+                }
+            }
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Scene")) {
+            if (ImGui::MenuItem("Run")) {
+                d_activeScene = std::make_shared<spkt::scene>();
+
+                spkt::add_singleton(d_activeScene->registry);
+                spkt::copy_registry(d_scene->registry, d_activeScene->registry);
+
+                d_activeScene->systems = {
+                    spkt::physics_system,
+                    spkt::particle_system,
+                    spkt::camera_system,
+                    spkt::script_system,
+                    spkt::animation_system,
+                    spkt::delete_below_50_system,
+                    spkt::clear_events_system
+                };
+
+                d_playingGame = true;
+                d_runtimeCamera = d_activeScene->registry.find<spkt::Camera3DComponent>();
+                d_window->SetCursorVisibility(false);
+            }
+            ImGui::EndMenu();
+        }
+        ImGui::EndMainMenuBar();
+    }
+
+    // VIEWPORT
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{0, 0});
+    if (ImGui::Begin("Viewport", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+        d_is_viewport_hovered = ImGui::IsWindowHovered();
+        d_is_viewport_focused = ImGui::IsWindowFocused();
+        d_ui.BlockEvents(!d_is_viewport_focused || !d_is_viewport_hovered);
+
+        ImVec2 size = ImGui::GetContentRegionAvail();
+        d_viewport_size = glm::ivec2{size.x, size.y};
+
+        //auto viewportMouse = ImGuiXtra::GetMousePosWindowCoords();
+
+        spkt::ImGuiXtra::Image(d_viewport.GetTexture());
+
+        if (!is_game_running() && registry.valid(d_selected) && registry.has<spkt::Transform3DComponent>(d_selected)) {
+            auto& c = registry.get<spkt::Transform3DComponent>(d_selected);
+            auto tr = spkt::Maths::Transform(c.position, c.orientation, c.scale);
+            spkt::ImGuiXtra::Guizmo(&tr, view, proj, d_inspector.Operation(), d_inspector.Mode());
+            spkt::Maths::Decompose(tr, &c.position, &c.orientation, &c.scale);
+        }
+        ImGui::End();
+    }
+    ImGui::PopStyleVar();
+
+    // INSPECTOR
+    static bool showInspector = true;
+    if (ImGui::Begin("Inspector", &showInspector)) {
+        d_inspector.Show(*this);
+        ImGui::End();
+    }
+
+    // EXPLORER
+    static std::string search;
+    static bool showExplorer = true;
+    if (ImGui::Begin("Explorer", &showExplorer)) {
+        spkt::ImGuiXtra::TextModifiable(search);
+        ImGui::SameLine();
+        if (ImGui::Button("X")) {
+            search = "";
+        }
+        if (ImGui::BeginTabBar("##Tabs")) {
+            
+            if (ImGui::BeginTabItem("Entities")) {
+                ImGui::BeginChild("Entity List");
+                int i = 0;
+                for (auto entity : registry.all()) {
+                    if (SubstringCI(entiy_name(registry, entity), search)) {
+                        ImGui::PushID(i);
+                        if (ImGui::Selectable(entiy_name(registry, entity).c_str())) {
+                            d_selected = entity;
+                        }
+                        ImGui::PopID();
+                    }
+                    ++i;
+                }
+                ImGui::EndChild();
+                ImGui::EndTabItem();
+            }
+
+            const auto hasher = [](const std::string& str) {
+                return static_cast<int>(std::hash<std::string>{}(str));
+            };
+
+            if (ImGui::BeginTabItem("Materials")) {
+                ImGui::BeginChild("Material List");
+                for (auto& [file, material] : d_asset_manager.Materials()) {
+                    ImGui::PushID(hasher(material->file));
+                    if (ImGui::CollapsingHeader(material->name.c_str())) {
+                        ImGui::Text(file.c_str());
+                        ImGui::Separator();
+
+                        ImGui::PushID(hasher("Albedo"));
+                        ImGui::Text("Albedo");
+                        ImGui::Checkbox("Use Map", &material->useAlbedoMap);
+                        if (material->useAlbedoMap) {
+                            material_ui(material->albedoMap);
+                        } else {
+                            ImGui::ColorEdit3("##Albedo", &material->albedo.x);
+                        }
+                        ImGui::PopID();
+                        ImGui::Separator();
+
+                        ImGui::PushID(hasher("Normal"));
+                        ImGui::Text("Normal");
+                        ImGui::Checkbox("Use Map", &material->useNormalMap);
+                        if (material->useNormalMap) {
+                            material_ui(material->normalMap);
+                        }
+                        ImGui::PopID();
+                        ImGui::Separator();
+
+                        ImGui::PushID(hasher("Metallic"));
+                        ImGui::Text("Metallic");
+                        ImGui::Checkbox("Use Map", &material->useMetallicMap);
+                        if (material->useMetallicMap) {
+                            material_ui(material->metallicMap);
+                        } else {
+                            ImGui::DragFloat("##Metallic", &material->metallic, 0.01f, 0.0f, 1.0f);
+                        }
+                        ImGui::PopID();
+                        ImGui::Separator();
+                        
+                        ImGui::PushID(hasher("Roughness"));
+                        ImGui::Text("Roughness");
+                        ImGui::Checkbox("Use Map", &material->useRoughnessMap);
+                        if (material->useRoughnessMap) {
+                            material_ui(material->roughnessMap);
+                        } else {
+                            ImGui::DragFloat("##Roughness", &material->roughness, 0.01f, 0.0f, 1.0f);
+                        }
+                        ImGui::PopID();
+                        ImGui::Separator();
+
+                        if (ImGui::Button("Save")) {
+                            material->Save();
+                        }
+                    }
+                    ImGui::PopID();
+                }
+                ImGui::EndChild();
+                ImGui::EndTabItem();
+            }
+
+            ImGui::EndTabBar();
+        }
+        ImGui::End();
+    }
+
+    if (ImGui::Begin("Options")) {
+        ImGui::Checkbox("Show Colliders", &d_showColliders);
+DATAMATIC_BEGIN
+        ImGui::Text("# {{Comp::name}}: %i", registry.view<spkt::{{Comp::name}}>().size());
+DATAMATIC_END
+        ImGui::End();
+    }
+
+    d_ui.EndFrame();
+}
+
+void Anvil::material_ui(std::string& texture)
+{
+    if (ImGui::Button("X")) {
+        texture = "";
+    }
+    ImGui::SameLine();
+    spkt::ImGuiXtra::File("File", d_window, &texture, "*.png");
+}

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -486,8 +486,6 @@ void Inspector::Show(Anvil& editor)
         ImGui::EndMenu();
     }
     ImGui::Separator();
-
-    ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry, entity);
         editor.set_selected(copy);

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -486,6 +486,8 @@ void Inspector::Show(Anvil& editor)
         ImGui::EndMenu();
     }
     ImGui::Separator();
+
+    ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry, entity);
         editor.set_selected(copy);

--- a/Anvil/Inspector.cpp
+++ b/Anvil/Inspector.cpp
@@ -96,7 +96,7 @@ void Inspector::Show(Anvil& editor)
 
     if (registry.has<spkt::StaticModelComponent>(entity)) {
         auto& c = registry.get<spkt::StaticModelComponent>(entity);
-        if (ImGui::CollapsingHeader("Model")) {
+        if (ImGui::CollapsingHeader("Static Model")) {
             ImGui::PushID(count++);
             spkt::ImGuiXtra::File("Mesh", editor.window(), &c.mesh, "*.obj");
             spkt::ImGuiXtra::File("Material", editor.window(), &c.material, "*.yaml");
@@ -108,7 +108,7 @@ void Inspector::Show(Anvil& editor)
 
     if (registry.has<spkt::AnimatedModelComponent>(entity)) {
         auto& c = registry.get<spkt::AnimatedModelComponent>(entity);
-        if (ImGui::CollapsingHeader("Model")) {
+        if (ImGui::CollapsingHeader("Animated Model")) {
             ImGui::PushID(count++);
             spkt::ImGuiXtra::File("Mesh", editor.window(), &c.mesh, "*.obj");
             spkt::ImGuiXtra::File("Material", editor.window(), &c.material, "*.yaml");
@@ -403,11 +403,11 @@ void Inspector::Show(Anvil& editor)
             spkt::Transform3DComponent c;
             registry.add<spkt::Transform3DComponent>(entity, c);
         }
-        if (!registry.has<spkt::StaticModelComponent>(entity) && ImGui::Selectable("Model")) {
+        if (!registry.has<spkt::StaticModelComponent>(entity) && ImGui::Selectable("Static Model")) {
             spkt::StaticModelComponent c;
             registry.add<spkt::StaticModelComponent>(entity, c);
         }
-        if (!registry.has<spkt::AnimatedModelComponent>(entity) && ImGui::Selectable("Model")) {
+        if (!registry.has<spkt::AnimatedModelComponent>(entity) && ImGui::Selectable("Animated Model")) {
             spkt::AnimatedModelComponent c;
             registry.add<spkt::AnimatedModelComponent>(entity, c);
         }
@@ -485,6 +485,8 @@ void Inspector::Show(Anvil& editor)
         }
         ImGui::EndMenu();
     }
+    ImGui::Separator();
+
     ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry, entity);

--- a/Anvil/Inspector.dm.cpp
+++ b/Anvil/Inspector.dm.cpp
@@ -56,6 +56,8 @@ DATAMATIC_END
         ImGui::EndMenu();
     }
     ImGui::Separator();
+
+    ImGui::Separator();
     if (ImGui::Button("Duplicate")) {
         spkt::entity copy = spkt::copy_entity(editor.active_scene()->registry, entity);
         editor.set_selected(copy);

--- a/Resources/Scripts/LightOnBounce.lua
+++ b/Resources/Scripts/LightOnBounce.lua
@@ -11,6 +11,10 @@ function on_update(entity, dt)
             toggle_light(entity)
         end
     end
+
+    local x = vec3.new(1, 1, 1)
+    local y = vec3.new(1, 1, 1)
+    print(x == y)
 end
 
 function toggle_light(entity)

--- a/Resources/Scripts/LightOnBounce.lua
+++ b/Resources/Scripts/LightOnBounce.lua
@@ -11,10 +11,6 @@ function on_update(entity, dt)
             toggle_light(entity)
         end
     end
-
-    local x = vec3.new(1, 1, 1)
-    local y = vec3.new(1, 1, 1)
-    print(x == y)
 end
 
 function toggle_light(entity)

--- a/Resources/Scripts/LightOnBounce.lua
+++ b/Resources/Scripts/LightOnBounce.lua
@@ -5,9 +5,9 @@ end
 function on_update(entity, dt)
     for event in view_CollisionEvent() do
         local collision = GetCollisionEvent(event)
-        local a = entity_from_id(collision.entity_a)
-        local b = entity_from_id(collision.entity_b)
-        if AreEntitiesEqual(entity, a) or AreEntitiesEqual(entity, b) then
+        local a = collision.entity_a
+        local b = collision.entity_b
+        if entity == a or entity == b then
             toggle_light(entity)
         end
     end

--- a/Resources/Shaders/Entity_PBR.frag
+++ b/Resources/Shaders/Entity_PBR.frag
@@ -37,9 +37,10 @@ uniform float u_metallic;
 uniform float u_roughness;
 
 // Lighting Information
-uniform vec3  u_light_pos[5];
-uniform vec3  u_light_colour[5];
-uniform float u_light_brightness[5];
+const int MAX_NUM_LIGHTS = 50;
+uniform vec3  u_light_pos[MAX_NUM_LIGHTS];
+uniform vec3  u_light_colour[MAX_NUM_LIGHTS];
+uniform float u_light_brightness[MAX_NUM_LIGHTS];
 
 uniform vec3  u_sun_direction;
 uniform vec3  u_sun_colour;
@@ -52,7 +53,6 @@ uniform float u_ambience_brightness;
 uniform sampler2D shadow_map;
 
 const float PI = 3.14159265359;
-const int MAX_NUM_LIGHTS = 50;
 
 vec3 fresnel_schlick(float cosTheta, vec3 F0)
 {

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -96,7 +96,7 @@
         },
         {
             "name": "StaticModelComponent",
-            "display_name": "Model",
+            "display_name": "Static Model",
             "attributes": [
                 {
                     "name": "mesh",
@@ -122,7 +122,7 @@
         },
         {
             "name": "AnimatedModelComponent",
-            "display_name": "Model",
+            "display_name": "Animated Model",
             "attributes": [
                 {
                     "name": "mesh",

--- a/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/ColliderRenderer.cpp
@@ -29,26 +29,22 @@ void ColliderRenderer::Draw(
     d_shader.load("u_view_matrix", view);
     
     static auto s_cube = static_mesh::from_file("Resources/Models/Cube.obj");
-    for (auto entity : registry.view<BoxCollider3DComponent>()) {
-        const auto& c = registry.get<BoxCollider3DComponent>(entity);
-        auto tr = registry.get<Transform3DComponent>(entity);
-        glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
-        transform *= Maths::Transform(c.position, c.orientation);
-        transform = glm::scale(transform, c.halfExtents);
-        if (c.applyScale) {
-            transform = glm::scale(transform, tr.scale);
+    for (auto [bc, tc] : registry.view_get<BoxCollider3DComponent, Transform3DComponent>()) {
+        glm::mat4 transform = Maths::Transform(tc.position, tc.orientation);
+        transform *= Maths::Transform(bc.position, bc.orientation);
+        transform = glm::scale(transform, bc.halfExtents);
+        if (bc.applyScale) {
+            transform = glm::scale(transform, tc.scale);
         }
         d_shader.load("u_model_matrix", transform);
         spkt::draw(s_cube.get());
     }
 
     static auto s_sphere = static_mesh::from_file("Resources/Models/LowPolySphere.obj");
-    for (auto entity : registry.view<SphereCollider3DComponent>()) {
-        const auto& c = registry.get<SphereCollider3DComponent>(entity);
-        auto tr = registry.get<Transform3DComponent>(entity);
+    for (auto [sc, tr] : registry.view_get<SphereCollider3DComponent, Transform3DComponent>()) {
         glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
-        transform *= Maths::Transform(c.position, c.orientation);
-        transform = glm::scale(transform, {c.radius, c.radius, c.radius});
+        transform *= Maths::Transform(sc.position, sc.orientation);
+        transform = glm::scale(transform, {sc.radius, sc.radius, sc.radius});
         d_shader.load("u_model_matrix", transform);
         spkt::draw(s_sphere.get());
     }
@@ -56,35 +52,31 @@ void ColliderRenderer::Draw(
     static auto s_hemisphere = static_mesh::from_file("Resources/Models/Hemisphere.obj");
     static auto s_cylinder = static_mesh::from_file("Resources/Models/Cylinder.obj");
 
-    for (auto entity : registry.view<CapsuleCollider3DComponent>()) {
-        const auto& c = registry.get<CapsuleCollider3DComponent>(entity);
+    for (auto [cc, tc] : registry.view_get<CapsuleCollider3DComponent, Transform3DComponent>()) {
 
         {  // Top Hemisphere
-            auto tr = registry.get<Transform3DComponent>(entity);
-            glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
-            transform *= Maths::Transform(c.position, c.orientation);
-            transform = glm::translate(transform, {0.0, c.height/2, 0.0});
-            transform = glm::scale(transform, {c.radius, c.radius, c.radius});
+            glm::mat4 transform = Maths::Transform(tc.position, tc.orientation);
+            transform *= Maths::Transform(cc.position, cc.orientation);
+            transform = glm::translate(transform, {0.0, cc.height/2, 0.0});
+            transform = glm::scale(transform, {cc.radius, cc.radius, cc.radius});
             d_shader.load("u_model_matrix", transform);
             spkt::draw(s_hemisphere.get());
         }
 
         {  // Middle Cylinder
-            auto tr = registry.get<Transform3DComponent>(entity);
-            glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
-            transform *= Maths::Transform(c.position, c.orientation);
-            transform = glm::scale(transform, {c.radius, c.height, c.radius});
+            glm::mat4 transform = Maths::Transform(tc.position, tc.orientation);
+            transform *= Maths::Transform(cc.position, cc.orientation);
+            transform = glm::scale(transform, {cc.radius, cc.height, cc.radius});
             d_shader.load("u_model_matrix", transform);
             spkt::draw(s_cylinder.get());
         }
 
         {  // Bottom Hemisphere
-            auto tr = registry.get<Transform3DComponent>(entity);
-            glm::mat4 transform = Maths::Transform(tr.position, tr.orientation);
-            transform *= Maths::Transform(c.position, c.orientation);
-            transform = glm::translate(transform, {0.0, -c.height/2, 0.0});
+            glm::mat4 transform = Maths::Transform(tc.position, tc.orientation);
+            transform *= Maths::Transform(cc.position, cc.orientation);
+            transform = glm::translate(transform, {0.0, -cc.height/2, 0.0});
             transform = glm::rotate(transform, glm::pi<float>(), {1, 0, 0});
-            transform = glm::scale(transform, {c.radius, c.radius, c.radius});
+            transform = glm::scale(transform, {cc.radius, cc.radius, cc.radius});
             d_shader.load("u_model_matrix", transform);
             spkt::draw(s_hemisphere.get());
         }

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -7,6 +7,7 @@
 #include <Sprocket/Scene/camera.h>
 #include <Sprocket/Utility/Hashing.h>
 #include <Sprocket/Utility/Maths.h>
+#include <Sprocket/Utility/views.h>
 
 #include <algorithm>
 #include <array>
@@ -19,8 +20,8 @@
 namespace spkt {
 namespace {
 
-std::array<glm::mat4, Scene3DRenderer::MAX_BONES> DefaultBoneTransforms() {
-    std::array<glm::mat4, Scene3DRenderer::MAX_BONES> arr;
+std::array<glm::mat4, MAX_BONES> DefaultBoneTransforms() {
+    std::array<glm::mat4, MAX_BONES> arr;
     std::ranges::fill(arr, glm::mat4(1.0));
     return arr;
 };
@@ -53,23 +54,20 @@ void upload_uniforms(
     }
     
     // Load point lights to shader
-    std::array<glm::vec3, Scene3DRenderer::MAX_NUM_LIGHTS> positions = {};
-    std::array<glm::vec3, Scene3DRenderer::MAX_NUM_LIGHTS> colours = {};
-    std::array<float, Scene3DRenderer::MAX_NUM_LIGHTS> brightnesses = {};
+    std::array<glm::vec3, MAX_NUM_LIGHTS> positions = {};
+    std::array<glm::vec3, MAX_NUM_LIGHTS> colours = {};
+    std::array<float, MAX_NUM_LIGHTS> brightnesses = {};
 
-    auto entity_view = registry.view<LightComponent, Transform3DComponent>()
-        | std::views::take(Scene3DRenderer::MAX_NUM_LIGHTS);
-
-    std::size_t idx = 0; 
-    for (auto entity : entity_view) {
-        auto position = registry.get<Transform3DComponent>(entity).position;
-        auto light = registry.get<LightComponent>(entity);
-        
-        positions[idx] = position;
-        colours[idx] = light.colour;
-        brightnesses[idx] = light.brightness;
-        ++idx;
+    for (auto [index, data] : registry.view_get<LightComponent, Transform3DComponent>()
+                            | std::views::take(MAX_NUM_LIGHTS)
+                            | spkt::views::enumerate())
+    {
+        auto [light, transform] = data;
+        positions[index] = transform.position;
+        colours[index] = light.colour;
+        brightnesses[index] = light.brightness;
     }
+
     shader.load("u_light_pos", positions);
     shader.load("u_light_colour", colours);
     shader.load("u_light_brightness", brightnesses);
@@ -81,10 +79,10 @@ void UploadMaterial(
     AssetManager* assetManager
 )
 {
-    assetManager->GetTexture(material->albedoMap)->Bind(Scene3DRenderer::ALBEDO_SLOT);
-    assetManager->GetTexture(material->normalMap)->Bind(Scene3DRenderer::NORMAL_SLOT);
-    assetManager->GetTexture(material->metallicMap)->Bind(Scene3DRenderer::METALLIC_SLOT);
-    assetManager->GetTexture(material->roughnessMap)->Bind(Scene3DRenderer::ROUGHNESS_SLOT);
+    assetManager->GetTexture(material->albedoMap)->Bind(ALBEDO_SLOT);
+    assetManager->GetTexture(material->normalMap)->Bind(NORMAL_SLOT);
+    assetManager->GetTexture(material->metallicMap)->Bind(METALLIC_SLOT);
+    assetManager->GetTexture(material->roughnessMap)->Bind(ROUGHNESS_SLOT);
 
     shader.load("u_use_albedo_map", material->useAlbedoMap ? 1.0f : 0.0f);
     shader.load("u_use_normal_map", material->useNormalMap ? 1.0f : 0.0f);
@@ -143,9 +141,7 @@ void Scene3DRenderer::Draw(
     > commands;
 
     d_staticShader.bind();
-    for (auto entity : registry.view<StaticModelComponent, Transform3DComponent>()) {
-        const auto& tc = registry.get<Transform3DComponent>(entity);
-        const auto& mc = registry.get<StaticModelComponent>(entity);
+    for (auto [mc, tc] : registry.view_get<StaticModelComponent, Transform3DComponent>()) {
         commands[{ mc.mesh, mc.material }].push_back({ tc.position, tc.orientation, tc.scale });
     }
 
@@ -159,8 +155,7 @@ void Scene3DRenderer::Draw(
     }
 
     // If the scene has a ParticleSingleton, then render the particles that it contains.
-    for (auto entity : registry.view<ParticleSingleton>()) {
-        const auto& ps = registry.get<ParticleSingleton>(entity);
+    for (auto [ps] : registry.view_get<ParticleSingleton>()) {
         std::vector<spkt::model_instance> instance_data(NUM_PARTICLES);
         for (const auto& particle : *ps.particles) {
             if (particle.life > 0.0) {
@@ -174,11 +169,8 @@ void Scene3DRenderer::Draw(
     }
 
     d_animatedShader.bind();
-    for (auto entity : registry.view<AnimatedModelComponent, Transform3DComponent>()) {
-        const auto& tc = registry.get<Transform3DComponent>(entity);
-        const auto& mc = registry.get<AnimatedModelComponent>(entity);
+    for (auto [mc, tc] : registry.view_get<AnimatedModelComponent, Transform3DComponent>()) {
         auto mesh = d_assetManager->get_animated_mesh(mc.mesh);
-
         auto material = d_assetManager->GetMaterial(mc.material);
         UploadMaterial(d_animatedShader, material, d_assetManager);
 

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -56,17 +56,19 @@ void upload_uniforms(
     std::array<glm::vec3, Scene3DRenderer::MAX_NUM_LIGHTS> positions = {};
     std::array<glm::vec3, Scene3DRenderer::MAX_NUM_LIGHTS> colours = {};
     std::array<float, Scene3DRenderer::MAX_NUM_LIGHTS> brightnesses = {};
-    std::size_t i = 0;
-    for (auto entity : registry.view<LightComponent, Transform3DComponent>()) {
-        if (i == Scene3DRenderer::MAX_NUM_LIGHTS) { break; }
 
+    auto entity_view = registry.view<LightComponent, Transform3DComponent>()
+        | std::views::take(Scene3DRenderer::MAX_NUM_LIGHTS);
+
+    std::size_t idx = 0; 
+    for (auto entity : entity_view) {
         auto position = registry.get<Transform3DComponent>(entity).position;
         auto light = registry.get<LightComponent>(entity);
         
-        positions[i] = position;
-        colours[i] = light.colour;
-        brightnesses[i] = light.brightness;
-        ++i;
+        positions[idx] = position;
+        colours[idx] = light.colour;
+        brightnesses[idx] = light.brightness;
+        ++idx;
     }
     shader.load("u_light_pos", positions);
     shader.load("u_light_colour", colours);

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.h
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.h
@@ -11,28 +11,26 @@ namespace spkt {
 class AssetManager;
 class VertexArray;
 
+// PBR Texture Slots
+static constexpr int ALBEDO_SLOT = 0;
+static constexpr int NORMAL_SLOT = 1;
+static constexpr int METALLIC_SLOT = 2;
+static constexpr int ROUGHNESS_SLOT = 3;
+
+// Shadow Map Texture Slot
+static constexpr int SHADOW_MAP_SLOT = 4;
+
+// Animation Data
+static constexpr int MAX_BONES = 50;
+
+// Light Data
+static constexpr int MAX_NUM_LIGHTS = 50;
+
 class Scene3DRenderer
 // Renders a scene as a 3D Scene. This makes use of components such as
 // Transform3DComponent and ModelComponent, and will ignore 2D components
 // such as Transform2DComponent and SpriteComponent.
 {
-public:
-    // PBR Texture Slots
-    static constexpr int ALBEDO_SLOT = 0;
-    static constexpr int NORMAL_SLOT = 1;
-    static constexpr int METALLIC_SLOT = 2;
-    static constexpr int ROUGHNESS_SLOT = 3;
-
-    // Shadow Map Texture Slot
-    static constexpr int SHADOW_MAP_SLOT = 4;
-
-    // Animation Data
-    static constexpr int MAX_BONES = 50;
-
-    // Light Data
-    static constexpr int MAX_NUM_LIGHTS = 50;
-
-private:
     AssetManager*    d_assetManager;
 
     shader d_staticShader;

--- a/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/SkyboxRenderer.cpp
@@ -34,11 +34,7 @@ void SkyboxRenderer::Draw(const CubeMap& skybox,
 
 void SkyboxRenderer::Draw(const CubeMap& skybox, const spkt::registry& registry, spkt::entity camera)
 {
-    Draw(
-        skybox,
-        spkt::make_proj(registry, camera),
-        spkt::make_view(registry, camera)
-    );
+    Draw(skybox, spkt::make_proj(registry, camera), spkt::make_view(registry, camera));
 }
 
 }

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -38,9 +38,7 @@ void ShadowMap::Draw(
     glClear(GL_DEPTH_BUFFER_BIT);
 
     std::unordered_map<std::string, std::vector<model_instance>> commands;
-    for (auto entity : registry.view<StaticModelComponent, Transform3DComponent>()) {
-        const auto& tc = registry.get<Transform3DComponent>(entity);
-        const auto& mc = registry.get<StaticModelComponent>(entity);
+    for (auto [mc, tc] : registry.view_get<StaticModelComponent, Transform3DComponent>()) {
         commands[mc.mesh].push_back({ tc.position, tc.orientation, tc.scale });
     }
 

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -33,6 +33,7 @@ void script_system(spkt::registry& registry, double dt)
             lua::Script& script = *sc.script_runtime;
             lua::load_vec3_functions(script);
             lua::load_vec2_functions(script);
+            lua::load_entity_functions(script);
             lua::load_registry_functions(script, registry);
             lua::load_entity_transformation_functions(script);
             lua::load_entity_component_functions(script);

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -38,13 +38,13 @@ void script_system(spkt::registry& registry, double dt)
             lua::load_entity_component_functions(script);
             if (script.has_function(INIT_FUNCTION)) {
                 script.set_value("__command_list__", &commands);
-                script.call_function<void>(INIT_FUNCTION, spkt::handle{registry, entity});
+                script.call_function<void>(INIT_FUNCTION, entity);
             }
         }
         else {
             lua::Script& script = *sc.script_runtime;
             script.set_value("__command_list__", &commands);
-            script.call_function<void>(UPDATE_FUNCTION, spkt::handle{registry, entity}, dt);
+            script.call_function<void>(UPDATE_FUNCTION, entity, dt);
         }
     }
 

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -24,7 +24,7 @@ void script_system(spkt::registry& registry, double dt)
 {
     std::vector<std::function<void()>> commands;
 
-    for (spkt::entity entity : registry.view<ScriptComponent>()) {
+    for (auto entity : registry.view<ScriptComponent>()) {
         auto& sc = registry.get<ScriptComponent>(entity);
         if (!sc.active) { continue; }
 
@@ -55,8 +55,7 @@ void script_system(spkt::registry& registry, double dt)
 
 void animation_system(spkt::registry& registry, double dt)
 {
-    for (auto entity : registry.view<AnimatedModelComponent>()) {
-        auto& ac = registry.get<AnimatedModelComponent>(entity);
+    for (auto [ac] : registry.view_get<AnimatedModelComponent>()) {
         ac.animation_time += (float)dt * ac.animation_speed;
     }
 }
@@ -66,18 +65,15 @@ void camera_system(spkt::registry& registry, double dt)
     const auto& input = get_singleton<InputSingleton>(registry);
     float aspect_ratio = input.window_width / input.window_height;
 
-    for (auto entity : registry.view<Camera3DComponent>()) {
-        auto& cam = registry.get<Camera3DComponent>(entity);
+    for (auto [cam] : registry.view_get<Camera3DComponent>()) {
         cam.projection = glm::perspective(cam.fov, aspect_ratio, 0.1f, 1000.0f);
     }
 }
 
 void path_follower_system(spkt::registry& registry, double dt)
 {
-    for (auto entity : registry.view<PathComponent>()) {
-        auto& transform = registry.get<Transform3DComponent>(entity);
-        auto& path = registry.get<PathComponent>(entity);
-        if (path.markers.empty()) { return; }
+    for (auto [path, transform] : registry.view_get<PathComponent, Transform3DComponent>()) {
+        if (path.markers.empty()) { continue; }
         
         glm::vec3 to_dest = path.markers.front() - transform.position;
         glm::vec3 direction = glm::normalize(to_dest);

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -94,7 +94,7 @@ void path_follower_system(spkt::registry& registry, double dt)
 
 void delete_below_50_system(spkt::registry& registry, double)
 {
-    registry.erase_if<Transform3DComponent>([&](spkt::entity entity) {
+    registry.destroy_if<Transform3DComponent>([&](spkt::entity entity) {
         const auto& t = registry.get<Transform3DComponent>(entity);
         return t.position.y < -50.0f;
     });
@@ -102,7 +102,7 @@ void delete_below_50_system(spkt::registry& registry, double)
 
 void clear_events_system(spkt::registry& registry, double dt)
 {
-    registry.erase_if<Event>([](spkt::entity) { return true; });
+    registry.destroy_if<Event>([](spkt::entity) { return true; });
 }
 
 }

--- a/Sprocket/Scene/Systems/particle_system.cpp
+++ b/Sprocket/Scene/Systems/particle_system.cpp
@@ -52,10 +52,7 @@ void particle_system(spkt::registry& registry, double dt)
 
     // Go through all particle emitter entities and check to see if they need to emit
     // any particles this frame. If they do, add them to the particle array.
-    for (auto entity : registry.view<ParticleComponent>()) {
-        auto& tc = registry.get<Transform3DComponent>(entity);
-        auto& pc = registry.get<ParticleComponent>(entity);
-
+    for (auto [pc, tc] : registry.view_get<ParticleComponent, Transform3DComponent>()) {
         pc.accumulator += (float)dt;
         while (pc.accumulator > pc.interval) {
             // Add a particle to the particle array

--- a/Sprocket/Scene/Systems/physics_system.cpp
+++ b/Sprocket/Scene/Systems/physics_system.cpp
@@ -268,7 +268,7 @@ void physics_system(spkt::registry& registry, double dt)
     auto& runtime = *ps.physics_runtime;
 
     // Pre Update
-    for (spkt::entity entity : registry.view<RigidBody3DComponent>()) {
+    for (auto entity : registry.view<RigidBody3DComponent>()) {
         const auto& tc = registry.get<Transform3DComponent>(entity);
         auto& physics = registry.get<RigidBody3DComponent>(entity);
 
@@ -337,9 +337,7 @@ void physics_system(spkt::registry& registry, double dt)
     }
 
     // Post Update
-    for (auto entity : registry.view<RigidBody3DComponent>()) {
-        auto& tc = registry.get<Transform3DComponent>(entity);
-        auto& rc = registry.get<RigidBody3DComponent>(entity);
+    for (auto [rc, tc] : registry.view_get<RigidBody3DComponent, Transform3DComponent>()) {
         const rp3d::RigidBody* body = rc.runtime->body;
 
         tc.position = convert(body->getTransform().getPosition());

--- a/Sprocket/Scene/ecs.h
+++ b/Sprocket/Scene/ecs.h
@@ -252,6 +252,4 @@ using registry = apx::registry<
     ParticleSingleton
 >;
 
-using handle = typename registry::handle_type;
-
 }

--- a/Sprocket/Scripting/LuaConverter.cpp
+++ b/Sprocket/Scripting/LuaConverter.cpp
@@ -98,14 +98,14 @@ void* Converter<void*>::read(lua_State* L, int index)
 
 void Converter<spkt::entity>::push(lua_State* L, const spkt::entity& value)
 {
-    spkt::entity* handle = static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
+    spkt::entity* handle = (spkt::entity*)lua_newuserdata(L, sizeof(spkt::entity));
     *handle = value;
+    luaL_setmetatable(L, "entity_id");
 }
 
 spkt::entity Converter<spkt::entity>::read(lua_State* L, int index)
 {
-    assert(lua_isuserdata(L, index));
-    return *static_cast<spkt::entity*>(lua_touserdata(L, index));
+    return *(spkt::entity*)luaL_checkudata(L, index, "entity_id");
 }
 
 void Converter<glm::vec2>::push(lua_State* L, const glm::vec2& value)

--- a/Sprocket/Scripting/LuaConverter.cpp
+++ b/Sprocket/Scripting/LuaConverter.cpp
@@ -98,14 +98,14 @@ void* Converter<void*>::read(lua_State* L, int index)
 
 void Converter<spkt::entity>::push(lua_State* L, const spkt::entity& value)
 {
-    std::uint64_t id = static_cast<uint64_t>(value);
-    lua_pushnumber(L, id);
+    spkt::entity* handle = static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
+    *handle = value;
 }
 
 spkt::entity Converter<spkt::entity>::read(lua_State* L, int index)
 {
-    assert(lua_isnumber(L, index));
-    return static_cast<spkt::entity>(lua_tonumber(L, index));
+    assert(lua_isuserdata(L, index));
+    return *static_cast<spkt::entity*>(lua_touserdata(L, index));
 }
 
 void Converter<glm::vec2>::push(lua_State* L, const glm::vec2& value)

--- a/Sprocket/Scripting/LuaConverter.cpp
+++ b/Sprocket/Scripting/LuaConverter.cpp
@@ -96,28 +96,16 @@ void* Converter<void*>::read(lua_State* L, int index)
     return lua_touserdata(L, index);
 }
 
-void Converter<spkt::handle>::push(lua_State* L, const spkt::handle& value)
-{
-    spkt::handle* handle = static_cast<spkt::handle*>(lua_newuserdata(L, sizeof(spkt::handle)));
-    *handle = value;
-}
-
-spkt::handle Converter<spkt::handle>::read(lua_State* L, int index)
-{
-    assert(lua_isuserdata(L, index));
-    return *static_cast<spkt::handle*>(lua_touserdata(L, index));
-}
-
 void Converter<spkt::entity>::push(lua_State* L, const spkt::entity& value)
 {
-    spkt::entity* handle = static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
-    *handle = value;
+    std::uint64_t id = static_cast<uint64_t>(value);
+    lua_pushnumber(L, id);
 }
 
 spkt::entity Converter<spkt::entity>::read(lua_State* L, int index)
 {
-    assert(lua_isuserdata(L, index));
-    return *static_cast<spkt::entity*>(lua_touserdata(L, index));
+    assert(lua_isnumber(L, index));
+    return static_cast<spkt::entity>(lua_tonumber(L, index));
 }
 
 void Converter<glm::vec2>::push(lua_State* L, const glm::vec2& value)

--- a/Sprocket/Scripting/LuaConverter.h
+++ b/Sprocket/Scripting/LuaConverter.h
@@ -82,12 +82,6 @@ template <typename T> struct Converter<T*>
     }
 };
 
-template <> struct Converter<spkt::handle>
-{
-    static void push(lua_State* L, const spkt::handle& value);
-    static spkt::handle read(lua_State* L, int index);
-};
-
 template <> struct Converter<spkt::entity>
 {
     static void push(lua_State* L, const spkt::entity& value);

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -100,8 +100,7 @@ int view_next(lua_State* L) {
     auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
     auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
     if (iter != view.end()) {
-        auto& entity = *static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
-        entity = *iter;
+        Converter<spkt::entity>::push(L, *iter);
         ++iter;
     } else {
         delete &view;

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -12,6 +12,7 @@
 #include <glm/trigonometric.hpp>
 
 #include <format>
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,9 +20,6 @@
 namespace spkt {
 namespace lua {
 namespace {
-
-template <typename... Ts>
-using view_iterator = typename spkt::registry::iterator<Ts...>;
 
 void do_file(lua_State* L, const char* file)
 {
@@ -80,20 +78,30 @@ void add_command(lua_State* L, const std::function<void()>& command)
 template <typename... Comps>
 int view_init(lua_State* L) {
     if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-    auto view = new view_iterator<Comps...>(get_pointer<spkt::registry>(L, "__registry__")->view<Comps...>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    using view_t = decltype(reg.view<Comps...>());
+    using iter_t = decltype(std::declval<view_t>().begin());
+
+    auto view = new view_t(reg.view<Comps...>());
+    auto iter = new iter_t(view->begin());
     lua_pushlightuserdata(L, static_cast<void*>(view));
-    return 1;
+    lua_pushlightuserdata(L, static_cast<void*>(iter));
+    return 2;
 }
 
 template <typename... Comps>
 int view_next(lua_State* L) {
-    if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-    auto& view = *static_cast<view_iterator<Comps...>*>(lua_touserdata(L, 1));
-    if (view.valid()) {
+    if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    using view_t = decltype(reg.view<Comps...>());
+    using iter_t = decltype(std::declval<view_t>().begin());
+    
+    auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
+    auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
+    if (iter != view.end()) {
         auto& entity = *static_cast<spkt::handle*>(lua_newuserdata(L, sizeof(spkt::handle)));
-        entity = spkt::handle(registry, *view);
-        ++view;
+        entity = spkt::handle(reg, *iter);
+        ++iter;
     } else {
         delete &view;
         lua_pushnil(L);
@@ -105,8 +113,8 @@ std::string view_source_code(std::string_view name)
 {
     return std::format(R"lua(
         function view_{0}()
-            local view = _view_{0}_init()
-            return function() return _view_{0}_next(view) end
+            local view, iter = _view_{0}_init()
+            return function() return _view_{0}_next(view, iter) end
         end
     )lua", name);
 }

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -54,16 +54,18 @@ bool check_arg_count(lua_State* L, int argc)
 template <typename T> int has_impl(lua_State* L)
 {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    auto entity = Converter<spkt::handle>::read(L, 1);
-    Converter<bool>::push(L, entity.has<T>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto entity = Converter<spkt::entity>::read(L, 1);
+    Converter<bool>::push(L, reg.has<T>(entity));
     return 1;
 }
 
 template <typename T> int remove_impl(lua_State* L)
 {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    auto entity = Converter<spkt::handle>::read(L, 1);
-    add_command(L, [entity]() mutable { entity.remove<T>(); });
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto entity = Converter<spkt::entity>::read(L, 1);
+    add_command(L, [reg, entity]() mutable { reg.remove<T>(entity); });
     return 0;
 }
 
@@ -98,8 +100,8 @@ int view_next(lua_State* L) {
     auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
     auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
     if (iter != view.end()) {
-        auto& entity = *static_cast<spkt::handle*>(lua_newuserdata(L, sizeof(spkt::handle)));
-        entity = spkt::handle(reg, *iter);
+        auto& entity = *static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
+        entity = *iter;
         ++iter;
     } else {
         delete &view;
@@ -126,10 +128,11 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
         if (!check_arg_count(L, 3)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& tr = reg.get<Transform3DComponent>(entity);
         tr.position = p;
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, t, {0.0, 1.0, 0.0})));
         return 0;
@@ -137,8 +140,9 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "RotateY", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); };
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
         return 0;
@@ -146,13 +150,13 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetForwardsDir", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         auto o = tr.orientation;
 
-        if (entity.has<Camera3DComponent>()) {
-            auto pitch = entity.get<Camera3DComponent>().pitch;
-            o = glm::rotate(o, pitch, {1, 0, 0});
+        if (auto* pc = reg.get_if<Camera3DComponent>(entity)) {
+            o = glm::rotate(o, pc->pitch, {1, 0, 0});
         }
 
         Converter<glm::vec3>::push(L, Maths::Forwards(o));
@@ -161,16 +165,18 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetRightDir", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
         return 1;
     });
 
     lua_register(L, "MakeUpright", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         float yaw = Converter<float>::read(L, 2);
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
@@ -178,8 +184,8 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "AreEntitiesEqual", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity1 = Converter<spkt::handle>::read(L, 1);
-        spkt::handle entity2 = Converter<spkt::handle>::read(L, 2);
+        auto entity1 = Converter<spkt::entity>::read(L, 1);
+        auto entity2 = Converter<spkt::entity>::read(L, 2);
         Converter<bool>::push(L, entity1 == entity2);
         return 1;
     });
@@ -195,88 +201,80 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     // Add functions for creating and destroying entities.
     lua_register(L, "NewEntity", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto new_entity = spkt::handle(registry, registry.create());
-        Converter<spkt::handle>::push(L, new_entity);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        Converter<spkt::entity>::push(L, reg.create());
         return 1;
     });
 
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        add_command(L, [entity]() mutable { entity.destroy(); });
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        add_command(L, [reg, entity]() mutable { reg.destroy(entity); });
         return 0;
-    });
-
-    lua_register(L, "entity_from_id", [](lua_State* L) {
-        if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto id = Converter<spkt::entity>::read(L, 1);
-        Converter<spkt::handle>::push(L, {registry, id});
-        return 1;
     });
 
     lua_register(L, "entity_singleton", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        Converter<spkt::handle>::push(L, {registry, singleton});
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = reg.find<Singleton>();
+        Converter<spkt::entity>::push(L, singleton);
         return 1;
     });
 
     // Input access via the singleton component.
     lua_register(L, "IsKeyDown", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseClicked", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "GetMousePos", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_pos);
         return 1;
     });
 
     lua_register(L, "GetMouseOffset", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_offset);
         return 1;
     });
 
     lua_register(L, "GetMouseScrolled", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_scrolled);
         return 1;
     });
@@ -364,9 +362,9 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
 
 int _GetNameComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<NameComponent>());
-    const auto& c = e.get<NameComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<NameComponent>(e);
     Converter<std::string>::push(L, c.name);
     return 1;
 }
@@ -374,8 +372,9 @@ int _GetNameComponent(lua_State* L) {
 int _SetNameComponent(lua_State* L) {
     if (!check_arg_count(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<NameComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<NameComponent>(e);
     c.name = Converter<std::string>::read(L, ++ptr);
     return 0;
 }
@@ -383,11 +382,12 @@ int _SetNameComponent(lua_State* L) {
 int _AddNameComponent(lua_State* L) {
     if (!check_arg_count(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<NameComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<NameComponent>(e));
     NameComponent c;
     c.name = Converter<std::string>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<NameComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<NameComponent>(e, c); });
     return 0;
 }
 
@@ -395,9 +395,9 @@ int _AddNameComponent(lua_State* L) {
 
 int _GetTransform2DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<Transform2DComponent>());
-    const auto& c = e.get<Transform2DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<Transform2DComponent>(e);
     Converter<glm::vec2>::push(L, c.position);
     Converter<float>::push(L, c.rotation);
     Converter<glm::vec2>::push(L, c.scale);
@@ -407,8 +407,9 @@ int _GetTransform2DComponent(lua_State* L) {
 int _SetTransform2DComponent(lua_State* L) {
     if (!check_arg_count(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<Transform2DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<Transform2DComponent>(e);
     c.position = Converter<glm::vec2>::read(L, ++ptr);
     c.rotation = Converter<float>::read(L, ++ptr);
     c.scale = Converter<glm::vec2>::read(L, ++ptr);
@@ -418,13 +419,14 @@ int _SetTransform2DComponent(lua_State* L) {
 int _AddTransform2DComponent(lua_State* L) {
     if (!check_arg_count(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<Transform2DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<Transform2DComponent>(e));
     Transform2DComponent c;
     c.position = Converter<glm::vec2>::read(L, ++ptr);
     c.rotation = Converter<float>::read(L, ++ptr);
     c.scale = Converter<glm::vec2>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<Transform2DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<Transform2DComponent>(e, c); });
     return 0;
 }
 
@@ -432,9 +434,9 @@ int _AddTransform2DComponent(lua_State* L) {
 
 int _GetTransform3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<Transform3DComponent>());
-    const auto& c = e.get<Transform3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<Transform3DComponent>(e);
     Converter<glm::vec3>::push(L, c.position);
     Converter<glm::vec3>::push(L, c.scale);
     return 2;
@@ -443,8 +445,9 @@ int _GetTransform3DComponent(lua_State* L) {
 int _SetTransform3DComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<Transform3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<Transform3DComponent>(e);
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
     return 0;
@@ -453,12 +456,13 @@ int _SetTransform3DComponent(lua_State* L) {
 int _AddTransform3DComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<Transform3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<Transform3DComponent>(e));
     Transform3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<Transform3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<Transform3DComponent>(e, c); });
     return 0;
 }
 
@@ -466,9 +470,9 @@ int _AddTransform3DComponent(lua_State* L) {
 
 int _GetStaticModelComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<StaticModelComponent>());
-    const auto& c = e.get<StaticModelComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<StaticModelComponent>(e);
     Converter<std::string>::push(L, c.mesh);
     Converter<std::string>::push(L, c.material);
     return 2;
@@ -477,8 +481,9 @@ int _GetStaticModelComponent(lua_State* L) {
 int _SetStaticModelComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<StaticModelComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<StaticModelComponent>(e);
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
     return 0;
@@ -487,12 +492,13 @@ int _SetStaticModelComponent(lua_State* L) {
 int _AddStaticModelComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<StaticModelComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<StaticModelComponent>(e));
     StaticModelComponent c;
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<StaticModelComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<StaticModelComponent>(e, c); });
     return 0;
 }
 
@@ -500,9 +506,9 @@ int _AddStaticModelComponent(lua_State* L) {
 
 int _GetAnimatedModelComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<AnimatedModelComponent>());
-    const auto& c = e.get<AnimatedModelComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<AnimatedModelComponent>(e);
     Converter<std::string>::push(L, c.mesh);
     Converter<std::string>::push(L, c.material);
     Converter<std::string>::push(L, c.animation_name);
@@ -514,8 +520,9 @@ int _GetAnimatedModelComponent(lua_State* L) {
 int _SetAnimatedModelComponent(lua_State* L) {
     if (!check_arg_count(L, 5 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<AnimatedModelComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<AnimatedModelComponent>(e);
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
     c.animation_name = Converter<std::string>::read(L, ++ptr);
@@ -527,15 +534,16 @@ int _SetAnimatedModelComponent(lua_State* L) {
 int _AddAnimatedModelComponent(lua_State* L) {
     if (!check_arg_count(L, 5 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<AnimatedModelComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<AnimatedModelComponent>(e));
     AnimatedModelComponent c;
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
     c.animation_name = Converter<std::string>::read(L, ++ptr);
     c.animation_time = Converter<float>::read(L, ++ptr);
     c.animation_speed = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<AnimatedModelComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<AnimatedModelComponent>(e, c); });
     return 0;
 }
 
@@ -543,9 +551,9 @@ int _AddAnimatedModelComponent(lua_State* L) {
 
 int _GetRigidBody3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<RigidBody3DComponent>());
-    const auto& c = e.get<RigidBody3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<RigidBody3DComponent>(e);
     Converter<glm::vec3>::push(L, c.velocity);
     Converter<bool>::push(L, c.gravity);
     Converter<bool>::push(L, c.frozen);
@@ -560,8 +568,9 @@ int _GetRigidBody3DComponent(lua_State* L) {
 int _SetRigidBody3DComponent(lua_State* L) {
     if (!check_arg_count(L, 8 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<RigidBody3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<RigidBody3DComponent>(e);
     c.velocity = Converter<glm::vec3>::read(L, ++ptr);
     c.gravity = Converter<bool>::read(L, ++ptr);
     c.frozen = Converter<bool>::read(L, ++ptr);
@@ -576,8 +585,9 @@ int _SetRigidBody3DComponent(lua_State* L) {
 int _AddRigidBody3DComponent(lua_State* L) {
     if (!check_arg_count(L, 8 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<RigidBody3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<RigidBody3DComponent>(e));
     RigidBody3DComponent c;
     c.velocity = Converter<glm::vec3>::read(L, ++ptr);
     c.gravity = Converter<bool>::read(L, ++ptr);
@@ -587,7 +597,7 @@ int _AddRigidBody3DComponent(lua_State* L) {
     c.rollingResistance = Converter<float>::read(L, ++ptr);
     c.force = Converter<glm::vec3>::read(L, ++ptr);
     c.onFloor = Converter<bool>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<RigidBody3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<RigidBody3DComponent>(e, c); });
     return 0;
 }
 
@@ -595,9 +605,9 @@ int _AddRigidBody3DComponent(lua_State* L) {
 
 int _GetBoxCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<BoxCollider3DComponent>());
-    const auto& c = e.get<BoxCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<BoxCollider3DComponent>(e);
     Converter<glm::vec3>::push(L, c.position);
     Converter<float>::push(L, c.mass);
     Converter<glm::vec3>::push(L, c.halfExtents);
@@ -608,8 +618,9 @@ int _GetBoxCollider3DComponent(lua_State* L) {
 int _SetBoxCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<BoxCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<BoxCollider3DComponent>(e);
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.halfExtents = Converter<glm::vec3>::read(L, ++ptr);
@@ -620,14 +631,15 @@ int _SetBoxCollider3DComponent(lua_State* L) {
 int _AddBoxCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<BoxCollider3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<BoxCollider3DComponent>(e));
     BoxCollider3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.halfExtents = Converter<glm::vec3>::read(L, ++ptr);
     c.applyScale = Converter<bool>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<BoxCollider3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<BoxCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -635,9 +647,9 @@ int _AddBoxCollider3DComponent(lua_State* L) {
 
 int _GetSphereCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<SphereCollider3DComponent>());
-    const auto& c = e.get<SphereCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<SphereCollider3DComponent>(e);
     Converter<glm::vec3>::push(L, c.position);
     Converter<float>::push(L, c.mass);
     Converter<float>::push(L, c.radius);
@@ -647,8 +659,9 @@ int _GetSphereCollider3DComponent(lua_State* L) {
 int _SetSphereCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<SphereCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<SphereCollider3DComponent>(e);
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
@@ -658,13 +671,14 @@ int _SetSphereCollider3DComponent(lua_State* L) {
 int _AddSphereCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 3 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<SphereCollider3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<SphereCollider3DComponent>(e));
     SphereCollider3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<SphereCollider3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<SphereCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -672,9 +686,9 @@ int _AddSphereCollider3DComponent(lua_State* L) {
 
 int _GetCapsuleCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<CapsuleCollider3DComponent>());
-    const auto& c = e.get<CapsuleCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<CapsuleCollider3DComponent>(e);
     Converter<glm::vec3>::push(L, c.position);
     Converter<float>::push(L, c.mass);
     Converter<float>::push(L, c.radius);
@@ -685,8 +699,9 @@ int _GetCapsuleCollider3DComponent(lua_State* L) {
 int _SetCapsuleCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<CapsuleCollider3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<CapsuleCollider3DComponent>(e);
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
@@ -697,14 +712,15 @@ int _SetCapsuleCollider3DComponent(lua_State* L) {
 int _AddCapsuleCollider3DComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<CapsuleCollider3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<CapsuleCollider3DComponent>(e));
     CapsuleCollider3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
     c.height = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<CapsuleCollider3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<CapsuleCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -712,9 +728,9 @@ int _AddCapsuleCollider3DComponent(lua_State* L) {
 
 int _GetScriptComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<ScriptComponent>());
-    const auto& c = e.get<ScriptComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<ScriptComponent>(e);
     Converter<std::string>::push(L, c.script);
     Converter<bool>::push(L, c.active);
     return 2;
@@ -723,8 +739,9 @@ int _GetScriptComponent(lua_State* L) {
 int _SetScriptComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<ScriptComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<ScriptComponent>(e);
     c.script = Converter<std::string>::read(L, ++ptr);
     c.active = Converter<bool>::read(L, ++ptr);
     return 0;
@@ -733,12 +750,13 @@ int _SetScriptComponent(lua_State* L) {
 int _AddScriptComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<ScriptComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<ScriptComponent>(e));
     ScriptComponent c;
     c.script = Converter<std::string>::read(L, ++ptr);
     c.active = Converter<bool>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<ScriptComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<ScriptComponent>(e, c); });
     return 0;
 }
 
@@ -746,9 +764,9 @@ int _AddScriptComponent(lua_State* L) {
 
 int _GetCamera3DComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<Camera3DComponent>());
-    const auto& c = e.get<Camera3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<Camera3DComponent>(e);
     Converter<float>::push(L, c.fov);
     Converter<float>::push(L, c.pitch);
     return 2;
@@ -757,8 +775,9 @@ int _GetCamera3DComponent(lua_State* L) {
 int _SetCamera3DComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<Camera3DComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<Camera3DComponent>(e);
     c.fov = Converter<float>::read(L, ++ptr);
     c.pitch = Converter<float>::read(L, ++ptr);
     return 0;
@@ -767,12 +786,13 @@ int _SetCamera3DComponent(lua_State* L) {
 int _AddCamera3DComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<Camera3DComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<Camera3DComponent>(e));
     Camera3DComponent c;
     c.fov = Converter<float>::read(L, ++ptr);
     c.pitch = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<Camera3DComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<Camera3DComponent>(e, c); });
     return 0;
 }
 
@@ -780,9 +800,9 @@ int _AddCamera3DComponent(lua_State* L) {
 
 int _GetPathComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<PathComponent>());
-    const auto& c = e.get<PathComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<PathComponent>(e);
     Converter<float>::push(L, c.speed);
     return 1;
 }
@@ -790,8 +810,9 @@ int _GetPathComponent(lua_State* L) {
 int _SetPathComponent(lua_State* L) {
     if (!check_arg_count(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<PathComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<PathComponent>(e);
     c.speed = Converter<float>::read(L, ++ptr);
     return 0;
 }
@@ -799,11 +820,12 @@ int _SetPathComponent(lua_State* L) {
 int _AddPathComponent(lua_State* L) {
     if (!check_arg_count(L, 1 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<PathComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<PathComponent>(e));
     PathComponent c;
     c.speed = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<PathComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<PathComponent>(e, c); });
     return 0;
 }
 
@@ -811,9 +833,9 @@ int _AddPathComponent(lua_State* L) {
 
 int _GetLightComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<LightComponent>());
-    const auto& c = e.get<LightComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<LightComponent>(e);
     Converter<glm::vec3>::push(L, c.colour);
     Converter<float>::push(L, c.brightness);
     return 2;
@@ -822,8 +844,9 @@ int _GetLightComponent(lua_State* L) {
 int _SetLightComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<LightComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<LightComponent>(e);
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
     return 0;
@@ -832,12 +855,13 @@ int _SetLightComponent(lua_State* L) {
 int _AddLightComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<LightComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<LightComponent>(e));
     LightComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<LightComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<LightComponent>(e, c); });
     return 0;
 }
 
@@ -845,9 +869,9 @@ int _AddLightComponent(lua_State* L) {
 
 int _GetSunComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<SunComponent>());
-    const auto& c = e.get<SunComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<SunComponent>(e);
     Converter<glm::vec3>::push(L, c.colour);
     Converter<float>::push(L, c.brightness);
     Converter<glm::vec3>::push(L, c.direction);
@@ -858,8 +882,9 @@ int _GetSunComponent(lua_State* L) {
 int _SetSunComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<SunComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<SunComponent>(e);
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
     c.direction = Converter<glm::vec3>::read(L, ++ptr);
@@ -870,14 +895,15 @@ int _SetSunComponent(lua_State* L) {
 int _AddSunComponent(lua_State* L) {
     if (!check_arg_count(L, 4 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<SunComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<SunComponent>(e));
     SunComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
     c.direction = Converter<glm::vec3>::read(L, ++ptr);
     c.shadows = Converter<bool>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<SunComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<SunComponent>(e, c); });
     return 0;
 }
 
@@ -885,9 +911,9 @@ int _AddSunComponent(lua_State* L) {
 
 int _GetAmbienceComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<AmbienceComponent>());
-    const auto& c = e.get<AmbienceComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<AmbienceComponent>(e);
     Converter<glm::vec3>::push(L, c.colour);
     Converter<float>::push(L, c.brightness);
     return 2;
@@ -896,8 +922,9 @@ int _GetAmbienceComponent(lua_State* L) {
 int _SetAmbienceComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<AmbienceComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<AmbienceComponent>(e);
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
     return 0;
@@ -906,12 +933,13 @@ int _SetAmbienceComponent(lua_State* L) {
 int _AddAmbienceComponent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<AmbienceComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<AmbienceComponent>(e));
     AmbienceComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<AmbienceComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<AmbienceComponent>(e, c); });
     return 0;
 }
 
@@ -919,9 +947,9 @@ int _AddAmbienceComponent(lua_State* L) {
 
 int _GetParticleComponent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<ParticleComponent>());
-    const auto& c = e.get<ParticleComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<ParticleComponent>(e);
     Converter<float>::push(L, c.interval);
     Converter<glm::vec3>::push(L, c.velocity);
     Converter<float>::push(L, c.velocityNoise);
@@ -934,8 +962,9 @@ int _GetParticleComponent(lua_State* L) {
 int _SetParticleComponent(lua_State* L) {
     if (!check_arg_count(L, 6 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<ParticleComponent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<ParticleComponent>(e);
     c.interval = Converter<float>::read(L, ++ptr);
     c.velocity = Converter<glm::vec3>::read(L, ++ptr);
     c.velocityNoise = Converter<float>::read(L, ++ptr);
@@ -948,8 +977,9 @@ int _SetParticleComponent(lua_State* L) {
 int _AddParticleComponent(lua_State* L) {
     if (!check_arg_count(L, 6 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<ParticleComponent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<ParticleComponent>(e));
     ParticleComponent c;
     c.interval = Converter<float>::read(L, ++ptr);
     c.velocity = Converter<glm::vec3>::read(L, ++ptr);
@@ -957,7 +987,7 @@ int _AddParticleComponent(lua_State* L) {
     c.acceleration = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
     c.life = Converter<float>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<ParticleComponent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<ParticleComponent>(e, c); });
     return 0;
 }
 
@@ -965,9 +995,9 @@ int _AddParticleComponent(lua_State* L) {
 
 int _GetCollisionEvent(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<CollisionEvent>());
-    const auto& c = e.get<CollisionEvent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<CollisionEvent>(e);
     Converter<spkt::entity>::push(L, c.entity_a);
     Converter<spkt::entity>::push(L, c.entity_b);
     return 2;
@@ -976,8 +1006,9 @@ int _GetCollisionEvent(lua_State* L) {
 int _SetCollisionEvent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<CollisionEvent>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<CollisionEvent>(e);
     c.entity_a = Converter<spkt::entity>::read(L, ++ptr);
     c.entity_b = Converter<spkt::entity>::read(L, ++ptr);
     return 0;
@@ -986,12 +1017,13 @@ int _SetCollisionEvent(lua_State* L) {
 int _AddCollisionEvent(lua_State* L) {
     if (!check_arg_count(L, 2 + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<CollisionEvent>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<CollisionEvent>(e));
     CollisionEvent c;
     c.entity_a = Converter<spkt::entity>::read(L, ++ptr);
     c.entity_b = Converter<spkt::entity>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<CollisionEvent>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<CollisionEvent>(e, c); });
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -12,7 +12,6 @@
 #include <glm/trigonometric.hpp>
 
 #include <format>
-#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -95,7 +94,7 @@ int view_next(lua_State* L) {
     auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
     using view_t = decltype(reg.view<Comps...>());
     using iter_t = decltype(std::declval<view_t>().begin());
-    
+
     auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
     auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
     if (iter != view.end()) {

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -65,7 +65,7 @@ template <typename T> int remove_impl(lua_State* L)
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
     auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
     auto entity = Converter<spkt::entity>::read(L, 1);
-    add_command(L, [reg, entity]() mutable { reg.remove<T>(entity); });
+    add_command(L, [&, entity]() { reg.remove<T>(entity); });
     return 0;
 }
 
@@ -210,7 +210,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
         auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
         auto entity = Converter<spkt::entity>::read(L, 1);
-        add_command(L, [reg, entity]() mutable { reg.destroy(entity); });
+        add_command(L, [&, entity]() { reg.destroy(entity); });
         return 0;
     });
 
@@ -387,7 +387,7 @@ int _AddNameComponent(lua_State* L) {
     assert(!reg.has<NameComponent>(e));
     NameComponent c;
     c.name = Converter<std::string>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<NameComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<NameComponent>(e, c); });
     return 0;
 }
 
@@ -426,7 +426,7 @@ int _AddTransform2DComponent(lua_State* L) {
     c.position = Converter<glm::vec2>::read(L, ++ptr);
     c.rotation = Converter<float>::read(L, ++ptr);
     c.scale = Converter<glm::vec2>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<Transform2DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<Transform2DComponent>(e, c); });
     return 0;
 }
 
@@ -462,7 +462,7 @@ int _AddTransform3DComponent(lua_State* L) {
     Transform3DComponent c;
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<Transform3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<Transform3DComponent>(e, c); });
     return 0;
 }
 
@@ -498,7 +498,7 @@ int _AddStaticModelComponent(lua_State* L) {
     StaticModelComponent c;
     c.mesh = Converter<std::string>::read(L, ++ptr);
     c.material = Converter<std::string>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<StaticModelComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<StaticModelComponent>(e, c); });
     return 0;
 }
 
@@ -543,7 +543,7 @@ int _AddAnimatedModelComponent(lua_State* L) {
     c.animation_name = Converter<std::string>::read(L, ++ptr);
     c.animation_time = Converter<float>::read(L, ++ptr);
     c.animation_speed = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<AnimatedModelComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<AnimatedModelComponent>(e, c); });
     return 0;
 }
 
@@ -597,7 +597,7 @@ int _AddRigidBody3DComponent(lua_State* L) {
     c.rollingResistance = Converter<float>::read(L, ++ptr);
     c.force = Converter<glm::vec3>::read(L, ++ptr);
     c.onFloor = Converter<bool>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<RigidBody3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<RigidBody3DComponent>(e, c); });
     return 0;
 }
 
@@ -639,7 +639,7 @@ int _AddBoxCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.halfExtents = Converter<glm::vec3>::read(L, ++ptr);
     c.applyScale = Converter<bool>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<BoxCollider3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<BoxCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -678,7 +678,7 @@ int _AddSphereCollider3DComponent(lua_State* L) {
     c.position = Converter<glm::vec3>::read(L, ++ptr);
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<SphereCollider3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<SphereCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -720,7 +720,7 @@ int _AddCapsuleCollider3DComponent(lua_State* L) {
     c.mass = Converter<float>::read(L, ++ptr);
     c.radius = Converter<float>::read(L, ++ptr);
     c.height = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<CapsuleCollider3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<CapsuleCollider3DComponent>(e, c); });
     return 0;
 }
 
@@ -756,7 +756,7 @@ int _AddScriptComponent(lua_State* L) {
     ScriptComponent c;
     c.script = Converter<std::string>::read(L, ++ptr);
     c.active = Converter<bool>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<ScriptComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<ScriptComponent>(e, c); });
     return 0;
 }
 
@@ -792,7 +792,7 @@ int _AddCamera3DComponent(lua_State* L) {
     Camera3DComponent c;
     c.fov = Converter<float>::read(L, ++ptr);
     c.pitch = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<Camera3DComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<Camera3DComponent>(e, c); });
     return 0;
 }
 
@@ -825,7 +825,7 @@ int _AddPathComponent(lua_State* L) {
     assert(!reg.has<PathComponent>(e));
     PathComponent c;
     c.speed = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<PathComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<PathComponent>(e, c); });
     return 0;
 }
 
@@ -861,7 +861,7 @@ int _AddLightComponent(lua_State* L) {
     LightComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<LightComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<LightComponent>(e, c); });
     return 0;
 }
 
@@ -903,7 +903,7 @@ int _AddSunComponent(lua_State* L) {
     c.brightness = Converter<float>::read(L, ++ptr);
     c.direction = Converter<glm::vec3>::read(L, ++ptr);
     c.shadows = Converter<bool>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<SunComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<SunComponent>(e, c); });
     return 0;
 }
 
@@ -939,7 +939,7 @@ int _AddAmbienceComponent(lua_State* L) {
     AmbienceComponent c;
     c.colour = Converter<glm::vec3>::read(L, ++ptr);
     c.brightness = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<AmbienceComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<AmbienceComponent>(e, c); });
     return 0;
 }
 
@@ -987,7 +987,7 @@ int _AddParticleComponent(lua_State* L) {
     c.acceleration = Converter<glm::vec3>::read(L, ++ptr);
     c.scale = Converter<glm::vec3>::read(L, ++ptr);
     c.life = Converter<float>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<ParticleComponent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<ParticleComponent>(e, c); });
     return 0;
 }
 
@@ -1023,7 +1023,7 @@ int _AddCollisionEvent(lua_State* L) {
     CollisionEvent c;
     c.entity_a = Converter<spkt::entity>::read(L, ++ptr);
     c.entity_b = Converter<spkt::entity>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<CollisionEvent>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<CollisionEvent>(e, c); });
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaLibrary.cpp
+++ b/Sprocket/Scripting/LuaLibrary.cpp
@@ -181,14 +181,6 @@ void load_entity_transformation_functions(lua::Script& script)
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
     });
-
-    lua_register(L, "AreEntitiesEqual", [](lua_State* L) {
-        if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        auto entity1 = Converter<spkt::entity>::read(L, 1);
-        auto entity2 = Converter<spkt::entity>::read(L, 2);
-        Converter<bool>::push(L, entity1 == entity2);
-        return 1;
-    });
 }
 
 void load_registry_functions(lua::Script& script, spkt::registry& registry)

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -100,8 +100,7 @@ int view_next(lua_State* L) {
     auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
     auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
     if (iter != view.end()) {
-        auto& entity = *static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
-        entity = *iter;
+        Converter<spkt::entity>::push(L, *iter);
         ++iter;
     } else {
         delete &view;

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -20,9 +20,6 @@ namespace spkt {
 namespace lua {
 namespace {
 
-template <typename... Ts>
-using view_iterator = typename spkt::registry::iterator<Ts...>;
-
 void do_file(lua_State* L, const char* file)
 {
     if (luaL_dofile(L, file)) {

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -54,16 +54,18 @@ bool check_arg_count(lua_State* L, int argc)
 template <typename T> int has_impl(lua_State* L)
 {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    auto entity = Converter<spkt::handle>::read(L, 1);
-    Converter<bool>::push(L, entity.has<T>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto entity = Converter<spkt::entity>::read(L, 1);
+    Converter<bool>::push(L, reg.has<T>(entity));
     return 1;
 }
 
 template <typename T> int remove_impl(lua_State* L)
 {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    auto entity = Converter<spkt::handle>::read(L, 1);
-    add_command(L, [entity]() mutable { entity.remove<T>(); });
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto entity = Converter<spkt::entity>::read(L, 1);
+    add_command(L, [reg, entity]() mutable { reg.remove<T>(entity); });
     return 0;
 }
 
@@ -98,8 +100,8 @@ int view_next(lua_State* L) {
     auto& view = *static_cast<view_t*>(lua_touserdata(L, 1));
     auto& iter = *static_cast<iter_t*>(lua_touserdata(L, 2));
     if (iter != view.end()) {
-        auto& entity = *static_cast<spkt::handle*>(lua_newuserdata(L, sizeof(spkt::handle)));
-        entity = spkt::handle(reg, *iter);
+        auto& entity = *static_cast<spkt::entity*>(lua_newuserdata(L, sizeof(spkt::entity)));
+        entity = *iter;
         ++iter;
     } else {
         delete &view;
@@ -126,10 +128,11 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "SetLookAt", [](lua_State* L) {
         if (!check_arg_count(L, 3)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
         glm::vec3 p = Converter<glm::vec3>::read(L, 2);
         glm::vec3 t = Converter<glm::vec3>::read(L, 3);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& tr = reg.get<Transform3DComponent>(entity);
         tr.position = p;
         tr.orientation = glm::conjugate(glm::quat_cast(glm::lookAt(tr.position, t, {0.0, 1.0, 0.0})));
         return 0;
@@ -137,8 +140,9 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "RotateY", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); };
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         float yaw = (float)lua_tonumber(L, 2);
         tr.orientation = glm::rotate(tr.orientation, yaw, {0, 1, 0});
         return 0;
@@ -146,13 +150,13 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetForwardsDir", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         auto o = tr.orientation;
         
-        if (entity.has<Camera3DComponent>()) {
-            auto pitch = entity.get<Camera3DComponent>().pitch;
-            o = glm::rotate(o, pitch, {1, 0, 0});
+        if (auto* pc = reg.get_if<Camera3DComponent>(entity)) {
+            o = glm::rotate(o, pc->pitch, {1, 0, 0});
         }
 
         Converter<glm::vec3>::push(L, Maths::Forwards(o));
@@ -161,16 +165,18 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "GetRightDir", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         Converter<glm::vec3>::push(L, Maths::Right(tr.orientation));
         return 1;
     });
 
     lua_register(L, "MakeUpright", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = Converter<spkt::handle>::read(L, 1);
-        auto& tr = entity.get<Transform3DComponent>();
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        auto& tr = reg.get<Transform3DComponent>(entity);
         float yaw = Converter<float>::read(L, 2);
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
@@ -178,8 +184,8 @@ void load_entity_transformation_functions(lua::Script& script)
 
     lua_register(L, "AreEntitiesEqual", [](lua_State* L) {
         if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity1 = Converter<spkt::handle>::read(L, 1);
-        spkt::handle entity2 = Converter<spkt::handle>::read(L, 2);
+        auto entity1 = Converter<spkt::entity>::read(L, 1);
+        auto entity2 = Converter<spkt::entity>::read(L, 2);
         Converter<bool>::push(L, entity1 == entity2);
         return 1;
     });
@@ -195,88 +201,80 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
     // Add functions for creating and destroying entities.
     lua_register(L, "NewEntity", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto new_entity = spkt::handle(registry, registry.create());
-        Converter<spkt::handle>::push(L, new_entity);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        Converter<spkt::entity>::push(L, reg.create());
         return 1;
     });
 
     lua_register(L, "DeleteEntity", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::handle entity = *static_cast<spkt::handle*>(lua_touserdata(L, 1));
-        add_command(L, [entity]() mutable { entity.destroy(); });
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto entity = Converter<spkt::entity>::read(L, 1);
+        add_command(L, [reg, entity]() mutable { reg.destroy(entity); });
         return 0;
-    });
-
-    lua_register(L, "entity_from_id", [](lua_State* L) {
-        if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto id = Converter<spkt::entity>::read(L, 1);
-        Converter<spkt::handle>::push(L, {registry, id});
-        return 1;
     });
 
     lua_register(L, "entity_singleton", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        auto singleton = registry.find<Singleton>();
-        Converter<spkt::handle>::push(L, {registry, singleton});
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        auto singleton = reg.find<Singleton>();
+        Converter<spkt::entity>::push(L, singleton);
         return 1;
     });
 
     // Input access via the singleton component.
     lua_register(L, "IsKeyDown", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.keyboard[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseClicked", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse_click[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseUnclicked", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse_unclick[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "IsMouseDown", [](lua_State* L) {
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<bool>::push(L, input.mouse[(int)lua_tointeger(L, 1)]);
         return 1;
     });
 
     lua_register(L, "GetMousePos", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_pos);
         return 1;
     });
 
     lua_register(L, "GetMouseOffset", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_offset);
         return 1;
     });
 
     lua_register(L, "GetMouseScrolled", [](lua_State* L) {
         if (!check_arg_count(L, 0)) { return luaL_error(L, "Bad number of args"); }
-        spkt::registry& registry = *get_pointer<spkt::registry>(L, "__registry__");
-        const auto& input = get_singleton<InputSingleton>(registry);
+        auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+        const auto& input = get_singleton<InputSingleton>(reg);
         Converter<glm::vec2>::push(L, input.mouse_scrolled);
         return 1;
     });
@@ -303,9 +301,9 @@ DATAMATIC_BEGIN SCRIPTABLE=true
 
 int _Get{{Comp::name}}(lua_State* L) {
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
-    spkt::handle e = Converter<spkt::handle>::read(L, 1);
-    assert(e.has<{{Comp::name}}>());
-    const auto& c = e.get<{{Comp::name}}>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, 1);
+    const auto& c = reg.get<{{Comp::name}}>(e);
     Converter<{{Attr::type}}>::push(L, c.{{Attr::name}});
     return {{Comp::attr_count}};
 }
@@ -313,8 +311,9 @@ int _Get{{Comp::name}}(lua_State* L) {
 int _Set{{Comp::name}}(lua_State* L) {
     if (!check_arg_count(L, {{Comp::attr_count}} + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    auto& c = e.get<{{Comp::name}}>();
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    auto& c = reg.get<{{Comp::name}}>(e);
     c.{{Attr::name}} = Converter<{{Attr::type}}>::read(L, ++ptr);
     return 0;
 }
@@ -322,11 +321,12 @@ int _Set{{Comp::name}}(lua_State* L) {
 int _Add{{Comp::name}}(lua_State* L) {
     if (!check_arg_count(L, {{Comp::attr_count}} + 1)) { return luaL_error(L, "Bad number of args"); }
     int ptr = 0;
-    spkt::handle e = Converter<spkt::handle>::read(L, ++ptr);
-    assert(!e.has<{{Comp::name}}>());
+    auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
+    auto e = Converter<spkt::entity>::read(L, ++ptr);
+    assert(!reg.has<{{Comp::name}}>(e));
     {{Comp::name}} c;
     c.{{Attr::name}} = Converter<{{Attr::type}}>::read(L, ++ptr);
-    add_command(L, [e, c]() mutable { e.add<{{Comp::name}}>(c); });
+    add_command(L, [reg, e, c]() mutable { reg.add<{{Comp::name}}>(e, c); });
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -181,14 +181,6 @@ void load_entity_transformation_functions(lua::Script& script)
         tr.orientation = glm::quat(glm::vec3(0, yaw, 0));
         return 0;
     });
-
-    lua_register(L, "AreEntitiesEqual", [](lua_State* L) {
-        if (!check_arg_count(L, 2)) { return luaL_error(L, "Bad number of args"); }
-        auto entity1 = Converter<spkt::entity>::read(L, 1);
-        auto entity2 = Converter<spkt::entity>::read(L, 2);
-        Converter<bool>::push(L, entity1 == entity2);
-        return 1;
-    });
 }
 
 void load_registry_functions(lua::Script& script, spkt::registry& registry)

--- a/Sprocket/Scripting/LuaLibrary.dm.cpp
+++ b/Sprocket/Scripting/LuaLibrary.dm.cpp
@@ -65,7 +65,7 @@ template <typename T> int remove_impl(lua_State* L)
     if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
     auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
     auto entity = Converter<spkt::entity>::read(L, 1);
-    add_command(L, [reg, entity]() mutable { reg.remove<T>(entity); });
+    add_command(L, [&, entity]() { reg.remove<T>(entity); });
     return 0;
 }
 
@@ -210,7 +210,7 @@ void load_registry_functions(lua::Script& script, spkt::registry& registry)
         if (!check_arg_count(L, 1)) { return luaL_error(L, "Bad number of args"); }
         auto& reg = *get_pointer<spkt::registry>(L, "__registry__");
         auto entity = Converter<spkt::entity>::read(L, 1);
-        add_command(L, [reg, entity]() mutable { reg.destroy(entity); });
+        add_command(L, [&, entity]() { reg.destroy(entity); });
         return 0;
     });
 
@@ -326,7 +326,7 @@ int _Add{{Comp::name}}(lua_State* L) {
     assert(!reg.has<{{Comp::name}}>(e));
     {{Comp::name}} c;
     c.{{Attr::name}} = Converter<{{Attr::type}}>::read(L, ++ptr);
-    add_command(L, [reg, e, c]() mutable { reg.add<{{Comp::name}}>(e, c); });
+    add_command(L, [&, e, c]() { reg.add<{{Comp::name}}>(e, c); });
     return 0;
 }
 

--- a/Sprocket/Scripting/LuaMaths.cpp
+++ b/Sprocket/Scripting/LuaMaths.cpp
@@ -202,5 +202,22 @@ void load_vec2_functions(lua::Script& script)
     lua_setglobal(L, "vec2");
 }
 
+void load_entity_functions(lua::Script& script)
+{
+    lua_State* L = script.native_handle();
+
+    luaL_newmetatable(L, "entity_id");
+
+    lua_pushcfunction(L, [](lua_State* L) {
+        spkt::entity* self = (spkt::entity*)luaL_checkudata(L, 1, "entity_id");
+        spkt::entity* other = (spkt::entity*)luaL_checkudata(L, 2, "entity_id");
+        Converter<bool>::push(L, *self == *other);
+        return 1;
+    });
+    lua_setfield(L, -2, "__eq");
+
+    lua_setglobal(L, "entity_id");
+}
+
 }
 }

--- a/Sprocket/Scripting/LuaMaths.cpp
+++ b/Sprocket/Scripting/LuaMaths.cpp
@@ -71,6 +71,14 @@ void load_vec3_functions(lua::Script& script)
     lua_setfield(L, -2, "__sub");
 
     lua_pushcfunction(L, [](lua_State* L) {
+        glm::vec3* self = (glm::vec3*)luaL_checkudata(L, 1, "vec3");
+        glm::vec3* other = (glm::vec3*)luaL_checkudata(L, 2, "vec3");
+        Converter<bool>::push(L, *self == *other);
+        return 1;
+    });
+    lua_setfield(L, -2, "__eq");
+
+    lua_pushcfunction(L, [](lua_State* L) {
         if (lua_isnumber(L, 1)) {
             float scalar = (float)luaL_checknumber(L, 1);
             glm::vec3 vec = *(glm::vec3*)luaL_checkudata(L, 2, "vec3");
@@ -154,6 +162,14 @@ void load_vec2_functions(lua::Script& script)
         return 1;
     });
     lua_setfield(L, -2, "__sub");
+
+    lua_pushcfunction(L, [](lua_State* L) {
+        glm::vec2* self = (glm::vec2*)luaL_checkudata(L, 1, "vec2");
+        glm::vec2* other = (glm::vec2*)luaL_checkudata(L, 2, "vec2");
+        Converter<bool>::push(L, *self == *other);
+        return 1;
+    });
+    lua_setfield(L, -2, "__eq");
 
     lua_pushcfunction(L, [](lua_State* L) {
         if (lua_isnumber(L, 1)) {

--- a/Sprocket/Scripting/LuaMaths.h
+++ b/Sprocket/Scripting/LuaMaths.h
@@ -9,6 +9,7 @@ class Script;
 
 void load_vec3_functions(lua::Script& script);
 void load_vec2_functions(lua::Script& script);
+void load_entity_functions(lua::Script& script);
 
 }
 }

--- a/Sprocket/Utility/views.h
+++ b/Sprocket/Utility/views.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstddef>
+#include <ranges>
+
+namespace spkt {
+namespace views {
+
+constexpr auto enumerate(std::size_t i = 0)
+{
+    return std::views::transform([i](const auto& element) mutable {
+        return std::make_pair(i++, std::cref(element));
+    });
+}
+
+}
+}

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,5 +1,5 @@
 [Window][Debug##Default]
-Pos=528,216
+Pos=534,220
 Size=316,368
 Collapsed=0
 
@@ -79,8 +79,8 @@ Size=353,714
 Collapsed=1
 
 [Window][Viewport]
-Pos=0,21
-Size=1040,699
+Pos=238,21
+Size=1442,996
 Collapsed=0
 DockId=0x00000004,0
 
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=1042,336
-Size=238,317
+Pos=1682,639
+Size=238,378
 Collapsed=0
 DockId=0x00000006,0
 
@@ -131,8 +131,8 @@ Size=287,329
 Collapsed=0
 
 [Window][Explorer]
-Pos=1042,21
-Size=238,313
+Pos=1682,21
+Size=238,616
 Collapsed=0
 DockId=0x00000005,0
 
@@ -143,7 +143,7 @@ Collapsed=0
 
 [Window][DockSpaceViewport_11111111]
 Pos=0,21
-Size=1280,699
+Size=1920,996
 Collapsed=0
 
 [Window][Colour Scheme Picker]
@@ -157,17 +157,17 @@ Size=277,422
 Collapsed=0
 
 [Window][Options]
-Pos=1042,655
-Size=238,65
+Pos=0,21
+Size=236,996
 Collapsed=0
-DockId=0x00000002,0
+DockId=0x00000001,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000004 Parent=0x8B93E3BD SizeRef=1040,699 CentralNode=1 Selected=0x995B0CF8
-  DockNode      ID=0x00000008 Parent=0x8B93E3BD SizeRef=238,699 Split=Y Selected=0x1E89CEB8
-    DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=320,632 Split=Y Selected=0xF02CD328
-      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=223,313 Selected=0x1E89CEB8
-      DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=223,317 Selected=0xF02CD328
-    DockNode    ID=0x00000002 Parent=0x00000008 SizeRef=320,65 Selected=0x1F88C31B
+DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1920,996 Split=X Selected=0x995B0CF8
+  DockNode      ID=0x00000001 Parent=0x8B93E3BD SizeRef=236,996 Selected=0x1F88C31B
+  DockNode      ID=0x00000003 Parent=0x8B93E3BD SizeRef=1682,996 Split=X
+    DockNode    ID=0x00000004 Parent=0x00000003 SizeRef=1442,699 CentralNode=1 Selected=0x995B0CF8
+    DockNode    ID=0x00000008 Parent=0x00000003 SizeRef=238,699 Split=Y Selected=0x1E89CEB8
+      DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=223,313 Selected=0x1E89CEB8
+      DockNode  ID=0x00000006 Parent=0x00000008 SizeRef=223,192 Selected=0xF02CD328
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -79,8 +79,8 @@ Size=353,714
 Collapsed=1
 
 [Window][Viewport]
-Pos=238,21
-Size=1442,996
+Pos=235,21
+Size=839,699
 Collapsed=0
 DockId=0x00000004,0
 
@@ -90,8 +90,8 @@ Size=1024,125
 Collapsed=0
 
 [Window][Inspector]
-Pos=1682,639
-Size=238,378
+Pos=1076,455
+Size=204,265
 Collapsed=0
 DockId=0x00000006,0
 
@@ -131,8 +131,8 @@ Size=287,329
 Collapsed=0
 
 [Window][Explorer]
-Pos=1682,21
-Size=238,616
+Pos=1076,21
+Size=204,432
 Collapsed=0
 DockId=0x00000005,0
 
@@ -143,7 +143,7 @@ Collapsed=0
 
 [Window][DockSpaceViewport_11111111]
 Pos=0,21
-Size=1920,996
+Size=1280,699
 Collapsed=0
 
 [Window][Colour Scheme Picker]
@@ -158,16 +158,16 @@ Collapsed=0
 
 [Window][Options]
 Pos=0,21
-Size=236,996
+Size=233,699
 Collapsed=0
 DockId=0x00000001,0
 
 [Docking][Data]
-DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1920,996 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000001 Parent=0x8B93E3BD SizeRef=236,996 Selected=0x1F88C31B
-  DockNode      ID=0x00000003 Parent=0x8B93E3BD SizeRef=1682,996 Split=X
-    DockNode    ID=0x00000004 Parent=0x00000003 SizeRef=1442,699 CentralNode=1 Selected=0x995B0CF8
-    DockNode    ID=0x00000008 Parent=0x00000003 SizeRef=238,699 Split=Y Selected=0x1E89CEB8
+DockSpace       ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,21 Size=1280,699 Split=X Selected=0x995B0CF8
+  DockNode      ID=0x00000001 Parent=0x8B93E3BD SizeRef=233,996 Selected=0x1F88C31B
+  DockNode      ID=0x00000003 Parent=0x8B93E3BD SizeRef=1045,996 Split=X
+    DockNode    ID=0x00000004 Parent=0x00000003 SizeRef=839,699 CentralNode=1 Selected=0x995B0CF8
+    DockNode    ID=0x00000008 Parent=0x00000003 SizeRef=204,699 Split=Y Selected=0x1E89CEB8
       DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=223,313 Selected=0x1E89CEB8
       DockNode  ID=0x00000006 Parent=0x00000008 SizeRef=223,192 Selected=0xF02CD328
 


### PR DESCRIPTION
* Update Apecs.
* Add a debug window in Anvil to show the number of each type of component.
* Remove `spkt::handle`. Lua impl now uses entity IDs rather than handles.
* Replace `AreEntitiesEqual` with a more intuitive equality implementation.
* Use `registry::view_get` in all appropriate places.
* Make the uploading of light uniforms cleaner now that apecs loops can be piped through views.
* Add a simple implementation of an `enumerate` view.
* Add `__eq` to the Lua vec2 and vec3 implementations.