### PR TITLE
Clean-up Texture Class

### DIFF
--- a/Sprocket/Graphics/AssetManager.cpp
+++ b/Sprocket/Graphics/AssetManager.cpp
@@ -83,7 +83,7 @@ texture* AssetManager::GetTexture(std::string_view file)
         }
     } else {
         d_loadingTextures[filepath] = std::async(std::launch::async, [filepath]() {
-            return std::make_unique<TextureData>(filepath);
+            return std::make_unique<texture_data>(filepath);
         });
     }
 

--- a/Sprocket/Graphics/AssetManager.cpp
+++ b/Sprocket/Graphics/AssetManager.cpp
@@ -75,7 +75,7 @@ texture* AssetManager::GetTexture(std::string_view file)
 
     if (auto it = d_loadingTextures.find(filepath); it != d_loadingTextures.end()) {
         if (it->second.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-            auto tex = texture::from_data(*(it->second.get()));
+            auto tex = std::make_unique<texture>(*(it->second.get()));
             spkt::texture* ret = tex.get();
             d_loadingTextures.erase(it);
             d_textures.emplace(filepath, std::move(tex));

--- a/Sprocket/Graphics/AssetManager.cpp
+++ b/Sprocket/Graphics/AssetManager.cpp
@@ -83,7 +83,7 @@ texture* AssetManager::GetTexture(std::string_view file)
         }
     } else {
         d_loadingTextures[filepath] = std::async(std::launch::async, [filepath]() {
-            return std::make_unique<texture_data>(filepath);
+            return std::make_unique<texture_data>(texture_data::load(filepath));
         });
     }
 

--- a/Sprocket/Graphics/AssetManager.cpp
+++ b/Sprocket/Graphics/AssetManager.cpp
@@ -7,7 +7,7 @@ namespace spkt {
 AssetManager::AssetManager()
     : d_default_static_mesh(std::make_unique<static_mesh>())
     , d_default_animated_mesh(std::make_unique<animated_mesh>())
-    , d_defaultTexture(std::make_unique<Texture>())
+    , d_defaultTexture(std::make_unique<texture>())
     , d_defaultMaterial(std::make_unique<Material>())
 {
 }
@@ -64,7 +64,7 @@ animated_mesh* AssetManager::get_animated_mesh(std::string_view file)
     return d_default_animated_mesh.get();
 }
 
-Texture* AssetManager::GetTexture(std::string_view file)
+texture* AssetManager::GetTexture(std::string_view file)
 {
     if (file == "") { return d_defaultTexture.get(); }
     std::string filepath = std::filesystem::absolute(file).string();
@@ -75,10 +75,10 @@ Texture* AssetManager::GetTexture(std::string_view file)
 
     if (auto it = d_loadingTextures.find(filepath); it != d_loadingTextures.end()) {
         if (it->second.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-            auto texture = Texture::FromData(*(it->second.get()));
-            Texture* ret = texture.get();
+            auto tex = texture::from_data(*(it->second.get()));
+            spkt::texture* ret = tex.get();
             d_loadingTextures.erase(it);
-            d_textures.emplace(filepath, std::move(texture));
+            d_textures.emplace(filepath, std::move(tex));
             return ret;
         }
     } else {

--- a/Sprocket/Graphics/AssetManager.h
+++ b/Sprocket/Graphics/AssetManager.h
@@ -19,7 +19,7 @@ class AssetManager
     // Background Loaders
     std::unordered_map<std::string, std::future<std::unique_ptr<static_mesh_data>>> d_loading_static_meshes;
     std::unordered_map<std::string, std::future<std::unique_ptr<animated_mesh_data>>> d_loading_animated_meshes;
-    std::unordered_map<std::string, std::future<std::unique_ptr<TextureData>>> d_loadingTextures;
+    std::unordered_map<std::string, std::future<std::unique_ptr<texture_data>>> d_loadingTextures;
 
     // Primitives
     std::unordered_map<std::string, const spkt::static_mesh_ptr> d_static_meshes;

--- a/Sprocket/Graphics/AssetManager.h
+++ b/Sprocket/Graphics/AssetManager.h
@@ -11,7 +11,7 @@
 
 namespace spkt {
 
-using texture_ptr = std::unique_ptr<Texture>;
+using texture_ptr = std::unique_ptr<texture>;
 using material_ptr = std::unique_ptr<Material>;
 
 class AssetManager
@@ -53,7 +53,7 @@ public:
 
     static_mesh* get_static_mesh(std::string_view file);
     animated_mesh* get_animated_mesh(std::string_view file);
-    Texture* GetTexture(std::string_view file);
+    texture* GetTexture(std::string_view file);
     Material* GetMaterial(std::string_view file);
 
     auto static_meshes()   { return Iterator(&d_static_meshes); }

--- a/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
+++ b/Sprocket/Graphics/Rendering/Scene3DRenderer.cpp
@@ -79,10 +79,10 @@ void UploadMaterial(
     AssetManager* assetManager
 )
 {
-    assetManager->GetTexture(material->albedoMap)->Bind(ALBEDO_SLOT);
-    assetManager->GetTexture(material->normalMap)->Bind(NORMAL_SLOT);
-    assetManager->GetTexture(material->metallicMap)->Bind(METALLIC_SLOT);
-    assetManager->GetTexture(material->roughnessMap)->Bind(ROUGHNESS_SLOT);
+    assetManager->GetTexture(material->albedoMap)->bind(ALBEDO_SLOT);
+    assetManager->GetTexture(material->normalMap)->bind(NORMAL_SLOT);
+    assetManager->GetTexture(material->metallicMap)->bind(METALLIC_SLOT);
+    assetManager->GetTexture(material->roughnessMap)->bind(ROUGHNESS_SLOT);
 
     shader.load("u_use_albedo_map", material->useAlbedoMap ? 1.0f : 0.0f);
     shader.load("u_use_normal_map", material->useNormalMap ? 1.0f : 0.0f);
@@ -119,7 +119,7 @@ void Scene3DRenderer::EnableShadows(const ShadowMap& shadowMap)
 {
     d_staticShader.load("u_light_proj_view", shadowMap.GetLightProjViewMatrix());
     d_animatedShader.load("u_light_proj_view", shadowMap.GetLightProjViewMatrix());
-    shadowMap.GetShadowMap().Bind(SHADOW_MAP_SLOT);
+    shadowMap.GetShadowMap().bind(SHADOW_MAP_SLOT);
 }
 
 void Scene3DRenderer::Draw(

--- a/Sprocket/Graphics/ShadowMap.cpp
+++ b/Sprocket/Graphics/ShadowMap.cpp
@@ -56,7 +56,7 @@ glm::mat4 ShadowMap::GetLightProjViewMatrix() const
     return d_lightProjMatrix * d_lightViewMatrix;
 }
 
-const Texture& ShadowMap::GetShadowMap() const
+const texture& ShadowMap::GetShadowMap() const
 {
     return d_shadowMap.depth_texture();
 }

--- a/Sprocket/Graphics/ShadowMap.h
+++ b/Sprocket/Graphics/ShadowMap.h
@@ -13,7 +13,7 @@
 
 namespace spkt {
 
-class Texture;
+class texture;
 
 class ShadowMap
 {
@@ -34,7 +34,7 @@ public:
     void Draw(spkt::registry& registry, const glm::vec3& sunDirection, const glm::vec3& centre);
 
     glm::mat4 GetLightProjViewMatrix() const;
-    const Texture&  GetShadowMap() const;
+    const texture&  GetShadowMap() const;
 };
 
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -5,6 +5,7 @@
 #include <glad/glad.h>
 
 #include <memory>
+#include <span>
 
 namespace spkt {
 namespace {
@@ -21,12 +22,9 @@ void SetTextureParameters(std::uint32_t id)
 
 texture_data::texture_data(const std::string& file)
 {
-    data = stbi_load(file.c_str(), &width, &height, &bpp, 4);
-}
-
-texture_data::~texture_data()
-{
-    stbi_image_free(data);
+    unsigned char* d = stbi_load(file.c_str(), &width, &height, &bpp, 4);
+    std::span<unsigned char> span_data{d, (std::size_t)(width * height * 4)};
+    data = {span_data.begin(), span_data.end()};
 }
 
 texture::texture(int width, int height, const unsigned char* data)
@@ -61,7 +59,7 @@ texture::~texture()
 
 std::unique_ptr<texture> texture::from_data(const texture_data& data)
 {
-    return std::make_unique<texture>(data.width, data.height, data.data);
+    return std::make_unique<texture>(data.width, data.height, data.data.data());
 }
 
 std::unique_ptr<texture> texture::from_file(const std::string file)

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -39,7 +39,7 @@ texture::texture(int width, int height, const unsigned char* data)
     glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
 }
 
-texture::texture(int width, int height, Channels channels)
+texture::texture(int width, int height, texture_channels channels)
     : d_width(width)
     , d_height(height)
     , d_channels(channels)
@@ -80,15 +80,15 @@ void texture::resize(int width, int height)
 
     int ifmt, fmt;
     switch (d_channels) {
-        case Channels::RGBA: {
+        case texture_channels::RGBA: {
             ifmt = GL_RGBA;
             fmt = GL_RGBA;
         } break;
-        case Channels::RED: {
+        case texture_channels::RED: {
             ifmt = GL_RED;
             fmt = GL_RED;
         } break;
-        case Channels::DEPTH: {
+        case texture_channels::DEPTH: {
             ifmt = GL_DEPTH24_STENCIL8;
             fmt = GL_DEPTH_COMPONENT;
         } break;
@@ -122,11 +122,11 @@ void texture::set_subtexture(
     const unsigned char* data)
 {
     auto c = GL_RGBA;
-    if (d_channels == Channels::RED) {
+    if (d_channels == texture_channels::RED) {
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         c = GL_RED;
     }
-    else if (d_channels == Channels::DEPTH) {
+    else if (d_channels == texture_channels::DEPTH) {
         c = GL_DEPTH_COMPONENT;
     }
 

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -73,14 +73,9 @@ texture::~texture()
     if (d_id > 0) { glDeleteTextures(1, &d_id); }
 }
 
-std::unique_ptr<texture> texture::from_data(const texture_data& data)
-{
-    return std::make_unique<texture>(data.width, data.height, data.bytes.data());
-}
-
 std::unique_ptr<texture> texture::from_file(const std::string file)
 {
-    return texture::from_data(texture_data::load(file));
+    return std::make_unique<texture>(texture_data::load(file));
 }
 
 void texture::resize(int width, int height)

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -19,12 +19,12 @@ void SetTextureParameters(std::uint32_t id)
 
 }
 
-TextureData::TextureData(const std::string& file)
+texture_data::texture_data(const std::string& file)
 {
     data = stbi_load(file.c_str(), &width, &height, &bpp, 4);
 }
 
-TextureData::~TextureData()
+texture_data::~texture_data()
 {
     stbi_image_free(data);
 }
@@ -59,14 +59,14 @@ texture::~texture()
     if (d_id > 0) { glDeleteTextures(1, &d_id); }
 }
 
-std::unique_ptr<texture> texture::from_data(const TextureData& data)
+std::unique_ptr<texture> texture::from_data(const texture_data& data)
 {
     return std::make_unique<texture>(data.width, data.height, data.data);
 }
 
 std::unique_ptr<texture> texture::from_file(const std::string file)
 {
-    return texture::from_data(TextureData(file));
+    return texture::from_data(texture_data(file));
 }
 
 void texture::resize(int width, int height)

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -29,9 +29,23 @@ texture_data texture_data::load(const std::string& file)
     return td;
 }
 
+texture::texture(const texture_data& data)
+    : d_id(0)
+    , d_width(data.width)
+    , d_height(data.height)
+    , d_channels(spkt::texture_channels::RGBA)
+{
+    glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
+    SetTextureParameters(d_id);
+    glTextureStorage2D(d_id, 1, GL_RGBA8, d_width, d_height);
+    glTextureSubImage2D(d_id, 0, 0, 0, d_width, d_height, GL_RGBA, GL_UNSIGNED_BYTE, data.bytes.data());
+}
+
 texture::texture(int width, int height, const unsigned char* data)
-    : d_width(width)
+    : d_id(0)
+    , d_width(width)
     , d_height(height)
+    , d_channels(spkt::texture_channels::RGBA)
 {
     glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
     SetTextureParameters(d_id);

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -25,7 +25,7 @@ texture_data texture_data::load(const std::string& file)
     texture_data td;
     unsigned char* d = stbi_load(file.c_str(), &td.width, &td.height, &td.bpp, 4);
     std::span<unsigned char> span_data{d, (std::size_t)(td.width * td.height * 4)};
-    td.data = {span_data.begin(), span_data.end()};
+    td.bytes = {span_data.begin(), span_data.end()};
     return td;
 }
 
@@ -61,7 +61,7 @@ texture::~texture()
 
 std::unique_ptr<texture> texture::from_data(const texture_data& data)
 {
-    return std::make_unique<texture>(data.width, data.height, data.data.data());
+    return std::make_unique<texture>(data.width, data.height, data.bytes.data());
 }
 
 std::unique_ptr<texture> texture::from_file(const std::string file)

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -23,9 +23,10 @@ void SetTextureParameters(std::uint32_t id)
 texture_data texture_data::load(const std::string& file)
 {
     texture_data td;
-    unsigned char* d = stbi_load(file.c_str(), &td.width, &td.height, &td.bpp, 4);
+    unsigned char* d = stbi_load(file.c_str(), &td.width, &td.height, nullptr, 4);
     std::span<unsigned char> span_data{d, (std::size_t)(td.width * td.height * 4)};
     td.bytes = {span_data.begin(), span_data.end()};
+    stbi_image_free(d);
     return td;
 }
 
@@ -130,6 +131,7 @@ void texture::set_subtexture(
     glTextureSubImage2D(
         d_id, 0, region.x, region.y, region.z, region.w, c, GL_UNSIGNED_BYTE, data
     );
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4); // Reset back to initial value
 }
 
 }

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -41,18 +41,6 @@ texture::texture(const texture_data& data)
     glTextureSubImage2D(d_id, 0, 0, 0, d_width, d_height, GL_RGBA, GL_UNSIGNED_BYTE, data.bytes.data());
 }
 
-texture::texture(int width, int height, const unsigned char* data)
-    : d_id(0)
-    , d_width(width)
-    , d_height(height)
-    , d_channels(spkt::texture_channels::RGBA)
-{
-    glCreateTextures(GL_TEXTURE_2D, 1, &d_id);
-    SetTextureParameters(d_id);
-    glTextureStorage2D(d_id, 1, GL_RGBA8, width, height);
-    glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
-}
-
 texture::texture(int width, int height, texture_channels channels)
     : d_width(width)
     , d_height(height)

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -29,7 +29,7 @@ TextureData::~TextureData()
     stbi_image_free(data);
 }
 
-Texture::Texture(int width, int height, const unsigned char* data)
+texture::texture(int width, int height, const unsigned char* data)
     : d_width(width)
     , d_height(height)
 {
@@ -39,37 +39,37 @@ Texture::Texture(int width, int height, const unsigned char* data)
     glTextureSubImage2D(d_id, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
 }
 
-Texture::Texture(int width, int height, Channels channels)
+texture::texture(int width, int height, Channels channels)
     : d_width(width)
     , d_height(height)
     , d_channels(channels)
 {
-    Resize(width, height);
+    resize(width, height);
 }
 
-Texture::Texture()
+texture::texture()
     : d_id(0)
     , d_width(0)
     , d_height(0)
 {
 }
 
-Texture::~Texture()
+texture::~texture()
 {
     if (d_id > 0) { glDeleteTextures(1, &d_id); }
 }
 
-std::unique_ptr<Texture> Texture::FromData(const TextureData& data)
+std::unique_ptr<texture> texture::from_data(const TextureData& data)
 {
-    return std::make_unique<Texture>(data.width, data.height, data.data);
+    return std::make_unique<texture>(data.width, data.height, data.data);
 }
 
-std::unique_ptr<Texture> Texture::FromFile(const std::string file)
+std::unique_ptr<texture> texture::from_file(const std::string file)
 {
-    return Texture::FromData(TextureData(file));
+    return texture::from_data(TextureData(file));
 }
 
-void Texture::Resize(int width, int height)
+void texture::resize(int width, int height)
 {
     if (d_id) {
         glDeleteTextures(1, &d_id);
@@ -102,22 +102,22 @@ void Texture::Resize(int width, int height)
     d_height = height;
 }
 
-void Texture::Bind(int slot) const
+void texture::bind(int slot) const
 {
     glBindTextureUnit(slot, d_id);
 }
 
-std::uint32_t Texture::Id() const
+std::uint32_t texture::id() const
 {
     return d_id;
 }
 
-bool Texture::operator==(const Texture& other) const
+bool texture::operator==(const texture& other) const
 {
     return d_id == other.d_id;
 }
 
-void Texture::SetSubTexture(
+void texture::set_subtexture(
     const glm::ivec4& region,
     const unsigned char* data)
 {
@@ -131,9 +131,7 @@ void Texture::SetSubTexture(
     }
 
     glTextureSubImage2D(
-        d_id, 0,
-        region.x, region.y, region.z, region.w,
-        c, GL_UNSIGNED_BYTE, data
+        d_id, 0, region.x, region.y, region.z, region.w, c, GL_UNSIGNED_BYTE, data
     );
 }
 

--- a/Sprocket/Graphics/Texture.cpp
+++ b/Sprocket/Graphics/Texture.cpp
@@ -20,11 +20,13 @@ void SetTextureParameters(std::uint32_t id)
 
 }
 
-texture_data::texture_data(const std::string& file)
+texture_data texture_data::load(const std::string& file)
 {
-    unsigned char* d = stbi_load(file.c_str(), &width, &height, &bpp, 4);
-    std::span<unsigned char> span_data{d, (std::size_t)(width * height * 4)};
-    data = {span_data.begin(), span_data.end()};
+    texture_data td;
+    unsigned char* d = stbi_load(file.c_str(), &td.width, &td.height, &td.bpp, 4);
+    std::span<unsigned char> span_data{d, (std::size_t)(td.width * td.height * 4)};
+    td.data = {span_data.begin(), span_data.end()};
+    return td;
 }
 
 texture::texture(int width, int height, const unsigned char* data)
@@ -64,7 +66,7 @@ std::unique_ptr<texture> texture::from_data(const texture_data& data)
 
 std::unique_ptr<texture> texture::from_file(const std::string file)
 {
-    return texture::from_data(texture_data(file));
+    return texture::from_data(texture_data::load(file));
 }
 
 void texture::resize(int width, int height)

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -12,7 +12,7 @@ struct texture_data
     int width;
     int height;
     int bpp;
-    std::vector<unsigned char> data;
+    std::vector<unsigned char> bytes;
 
     static texture_data load(const std::string& file);
 };
@@ -37,6 +37,7 @@ class texture
     texture& operator=(const texture&) = delete;
 
 public:
+    //texture(const texture_data& data);
     texture(int width, int height, const unsigned char* data);
     texture(int width, int height, texture_channels channels = texture_channels::RGBA);
     texture();

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -2,6 +2,7 @@
 #include <glm/glm.hpp>
 
 #include <memory>
+#include <vector>
 #include <string>
 
 namespace spkt {
@@ -11,13 +12,9 @@ struct texture_data
     int width;
     int height;
     int bpp;
-    unsigned char* data;
-
-    texture_data(const texture_data&) = delete;
-    texture_data& operator=(const texture_data&) = delete;
+    std::vector<unsigned char> data;
 
     texture_data(const std::string& file);
-    ~texture_data();
 };
 
 enum class texture_channels
@@ -40,7 +37,6 @@ class texture
     texture& operator=(const texture&) = delete;
 
 public:
-    //texture(const texture_data& data, const texture_channels& channels);
     texture(int width, int height, const unsigned char* data);
     texture(int width, int height, texture_channels channels = texture_channels::RGBA);
     texture();

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -53,7 +53,6 @@ public:
     int Height() const { return d_height; }
     float AspectRatio() const { return (float)d_width / (float)d_height; }
 
-    int GetChannels() const { return d_channels == Channels::RGBA ? 4 : 1; }
     bool operator==(const Texture& other) const;
 
     // Mutable Texture Functions

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -6,18 +6,18 @@
 
 namespace spkt {
 
-struct TextureData
+struct texture_data
 {
     int width;
     int height;
     int bpp;
     unsigned char* data;
 
-    TextureData(const TextureData&) = delete;
-    TextureData& operator=(const TextureData&) = delete;
+    texture_data(const texture_data&) = delete;
+    texture_data& operator=(const texture_data&) = delete;
 
-    TextureData(const std::string& file);
-    ~TextureData();
+    texture_data(const std::string& file);
+    ~texture_data();
 };
 
 class texture
@@ -42,7 +42,7 @@ public:
     texture();
     ~texture();
 
-    static std::unique_ptr<texture> from_data(const TextureData& data);
+    static std::unique_ptr<texture> from_data(const texture_data& data);
     static std::unique_ptr<texture> from_file(const std::string file);
 
     void bind(int slot) const;

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -11,7 +11,6 @@ struct texture_data
 {
     int width;
     int height;
-    int bpp;
     std::vector<unsigned char> bytes;
 
     static texture_data load(const std::string& file);
@@ -38,7 +37,7 @@ class texture
 
 public:
     texture(const texture_data& data);
-    texture(int width, int height, texture_channels channels = texture_channels::RGBA);
+    texture(int width, int height, texture_channels channels);
     texture();
     ~texture();
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -14,7 +14,7 @@ struct texture_data
     int bpp;
     std::vector<unsigned char> data;
 
-    texture_data(const std::string& file);
+    static texture_data load(const std::string& file);
 };
 
 enum class texture_channels

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -43,7 +43,6 @@ public:
     texture();
     ~texture();
 
-    static std::unique_ptr<texture> from_data(const texture_data& data);
     static std::unique_ptr<texture> from_file(const std::string file);
 
     void bind(int slot) const;

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -37,7 +37,7 @@ class texture
     texture& operator=(const texture&) = delete;
 
 public:
-    //texture(const texture_data& data);
+    texture(const texture_data& data);
     texture(int width, int height, const unsigned char* data);
     texture(int width, int height, texture_channels channels = texture_channels::RGBA);
     texture();

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -38,7 +38,6 @@ class texture
 
 public:
     texture(const texture_data& data);
-    texture(int width, int height, const unsigned char* data);
     texture(int width, int height, texture_channels channels = texture_channels::RGBA);
     texture();
     ~texture();

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -20,25 +20,29 @@ struct texture_data
     ~texture_data();
 };
 
+enum class texture_channels
+{
+    RGBA,
+    RED,
+    DEPTH
+};
+
 class texture
 {
-public:
-    enum class Channels { RGBA, RED, DEPTH };
-
-private:
     std::uint32_t d_id;
 
     int d_width;
     int d_height;
 
-    Channels d_channels;
+    texture_channels d_channels;
 
     texture(const texture&) = delete;
     texture& operator=(const texture&) = delete;
 
 public:
+    //texture(const texture_data& data, const texture_channels& channels);
     texture(int width, int height, const unsigned char* data);
-    texture(int width, int height, Channels channels = Channels::RGBA);
+    texture(int width, int height, texture_channels channels = texture_channels::RGBA);
     texture();
     ~texture();
 

--- a/Sprocket/Graphics/Texture.h
+++ b/Sprocket/Graphics/Texture.h
@@ -20,7 +20,7 @@ struct TextureData
     ~TextureData();
 };
 
-class Texture
+class texture
 {
 public:
     enum class Channels { RGBA, RED, DEPTH };
@@ -33,31 +33,31 @@ private:
 
     Channels d_channels;
 
-    Texture(const Texture&) = delete;
-    Texture& operator=(const Texture&) = delete;
+    texture(const texture&) = delete;
+    texture& operator=(const texture&) = delete;
 
 public:
-    Texture(int width, int height, const unsigned char* data);
-    Texture(int width, int height, Channels channels = Channels::RGBA);
-    Texture();
-    ~Texture();
+    texture(int width, int height, const unsigned char* data);
+    texture(int width, int height, Channels channels = Channels::RGBA);
+    texture();
+    ~texture();
 
-    static std::unique_ptr<Texture> FromData(const TextureData& data);
-    static std::unique_ptr<Texture> FromFile(const std::string file);
+    static std::unique_ptr<texture> from_data(const TextureData& data);
+    static std::unique_ptr<texture> from_file(const std::string file);
 
-    void Bind(int slot) const;
+    void bind(int slot) const;
 
-    std::uint32_t Id() const;
+    std::uint32_t id() const;
 
-    int Width() const { return d_width; }
-    int Height() const { return d_height; }
-    float AspectRatio() const { return (float)d_width / (float)d_height; }
+    int width() const { return d_width; }
+    int height() const { return d_height; }
+    float aspect_ratio() const { return (float)d_width / (float)d_height; }
 
-    bool operator==(const Texture& other) const;
+    bool operator==(const texture& other) const;
 
     // Mutable Texture Functions
-    void SetSubTexture(const glm::ivec4& region, const unsigned char* data);
-    void Resize(int width, int height);
+    void set_subtexture(const glm::ivec4& region, const unsigned char* data);
+    void resize(int width, int height);
 
 };
 

--- a/Sprocket/Graphics/frame_buffer.cpp
+++ b/Sprocket/Graphics/frame_buffer.cpp
@@ -10,8 +10,8 @@
 namespace spkt {
 
 frame_buffer::frame_buffer(int width, int height)
-    : d_colour(std::make_unique<Texture>(width, height, Texture::Channels::RGBA))
-    , d_depth(std::make_unique<Texture>(width, height, Texture::Channels::DEPTH))
+    : d_colour(std::make_unique<texture>(width, height, texture::Channels::RGBA))
+    , d_depth(std::make_unique<texture>(width, height, texture::Channels::DEPTH))
     , d_width(width)
     , d_height(height)
     , d_fbo(0)
@@ -47,13 +47,13 @@ void frame_buffer::resize(int width, int height)
         }
 
         glDeleteFramebuffers(1, &d_fbo);
-        d_colour->Resize(width, height);
-        d_depth->Resize(width, height);
+        d_colour->resize(width, height);
+        d_depth->resize(width, height);
     }
 
     glCreateFramebuffers(1, &d_fbo);
-    glNamedFramebufferTexture(d_fbo, GL_COLOR_ATTACHMENT0, d_colour->Id(), 0);
-    glNamedFramebufferTexture(d_fbo, GL_DEPTH_ATTACHMENT, d_depth->Id(), 0);
+    glNamedFramebufferTexture(d_fbo, GL_COLOR_ATTACHMENT0, d_colour->id(), 0);
+    glNamedFramebufferTexture(d_fbo, GL_DEPTH_ATTACHMENT, d_depth->id(), 0);
 
     // Validate the framebuffer.
     if (glCheckNamedFramebufferStatus(d_fbo, GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {

--- a/Sprocket/Graphics/frame_buffer.cpp
+++ b/Sprocket/Graphics/frame_buffer.cpp
@@ -10,8 +10,8 @@
 namespace spkt {
 
 frame_buffer::frame_buffer(int width, int height)
-    : d_colour(std::make_unique<texture>(width, height, texture::Channels::RGBA))
-    , d_depth(std::make_unique<texture>(width, height, texture::Channels::DEPTH))
+    : d_colour(std::make_unique<texture>(width, height, texture_channels::RGBA))
+    , d_depth(std::make_unique<texture>(width, height, texture_channels::DEPTH))
     , d_width(width)
     , d_height(height)
     , d_fbo(0)

--- a/Sprocket/Graphics/frame_buffer.h
+++ b/Sprocket/Graphics/frame_buffer.h
@@ -7,14 +7,14 @@
 
 namespace spkt {
 
-class Texture;
+class texture;
 
 class frame_buffer
 {
     std::uint32_t d_fbo;
 
-    std::unique_ptr<Texture> d_colour;
-    std::unique_ptr<Texture> d_depth;
+    std::unique_ptr<texture> d_colour;
+    std::unique_ptr<texture> d_depth;
 
     int d_width;
     int d_height;
@@ -33,8 +33,8 @@ public:
     
     void resize(int width, int height);
 
-    const Texture& colour_texture() const { return *d_colour; }
-    const Texture& depth_texture() const { return *d_depth; }
+    const texture& colour_texture() const { return *d_colour; }
+    const texture& depth_texture() const { return *d_depth; }
     
     int width() const { return d_width; }
     int height() const { return d_height; }

--- a/Sprocket/Graphics/post_processor.cpp
+++ b/Sprocket/Graphics/post_processor.cpp
@@ -62,7 +62,7 @@ void post_processor::end_frame()
         effect->load("target_height", d_target->height());
 
         std::swap(d_target, d_source); // Previous render becomes the source
-        d_source->colour_texture().Bind(0);
+        d_source->colour_texture().bind(0);
         d_target->bind();
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
     }
@@ -72,7 +72,7 @@ void post_processor::end_frame()
     d_effects.back()->load("target_width", d_target->width());
     d_effects.back()->load("target_height", d_target->height());
     
-    d_target->colour_texture().Bind(0);
+    d_target->colour_texture().bind(0);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -134,13 +134,11 @@ std::unique_ptr<texture> SetFont(std::string_view font, float size)
     io.FontDefault = io.Fonts->AddFontFromFileTTF("Resources/Fonts/Calibri.ttf", 15.0f);
     unsigned char* data;
     int width, height;
-    const int bpp = 4;
     io.Fonts->GetTexDataAsRGBA32(&data, &width, &height);
     std::span<unsigned char> span_data{data, (std::size_t)(width * height * 4)};
     auto texture = std::make_unique<spkt::texture>(spkt::texture_data{
         .width = width,
         .height = height,
-        .bpp = bpp,
         .bytes = {span_data.begin(), span_data.end()}
     });
     io.Fonts->TexID = reinterpret_cast<void*>(texture->id());
@@ -165,8 +163,7 @@ void bind_imgui_vbo(std::uint32_t vbo)
 }
 
 DevUI::DevUI(Window* window)
-    : d_shader("Resources/Shaders/DevGUI.vert",
-               "Resources/Shaders/DevGUI.frag")
+    : d_shader("Resources/Shaders/DevGUI.vert", "Resources/Shaders/DevGUI.frag")
     , d_fontAtlas(nullptr)
     , d_vtx_buffer()
     , d_idx_buffer()

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -134,8 +134,15 @@ std::unique_ptr<texture> SetFont(std::string_view font, float size)
     io.FontDefault = io.Fonts->AddFontFromFileTTF("Resources/Fonts/Calibri.ttf", 15.0f);
     unsigned char* data;
     int width, height;
+    const int bpp = 4;
     io.Fonts->GetTexDataAsRGBA32(&data, &width, &height);
-    auto texture = std::make_unique<spkt::texture>(width, height, data);
+    std::span<unsigned char> span_data{data, (std::size_t)(width * height * 4)};
+    auto texture = std::make_unique<spkt::texture>(spkt::texture_data{
+        .width = width,
+        .height = height,
+        .bpp = bpp,
+        .bytes = {span_data.begin(), span_data.end()}
+    });
     io.Fonts->TexID = reinterpret_cast<void*>(texture->id());
     return texture;
 }

--- a/Sprocket/UI/DevUI.cpp
+++ b/Sprocket/UI/DevUI.cpp
@@ -128,15 +128,15 @@ void SetKeyMappings()
 
 // Loads the font atlas and assigns it to ImGui. Returns the pointer
 // for the caller to own.
-std::unique_ptr<Texture> SetFont(std::string_view font, float size)
+std::unique_ptr<texture> SetFont(std::string_view font, float size)
 {
     ImGuiIO& io = ImGui::GetIO();    
     io.FontDefault = io.Fonts->AddFontFromFileTTF("Resources/Fonts/Calibri.ttf", 15.0f);
     unsigned char* data;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&data, &width, &height);
-    auto texture = std::make_unique<Texture>(width, height, data);
-    io.Fonts->TexID = reinterpret_cast<void*>(texture->Id());
+    auto texture = std::make_unique<spkt::texture>(width, height, data);
+    io.Fonts->TexID = reinterpret_cast<void*>(texture->id());
     return texture;
 }
 
@@ -276,7 +276,7 @@ void DevUI::EndFrame()
     d_shader.load("Texture", 0);
     d_shader.load("ProjMtx", proj);
 
-    d_fontAtlas->Bind(0);
+    d_fontAtlas->bind(0);
 
     // Render command lists
     const int width = (int)drawData->DisplaySize.x;

--- a/Sprocket/UI/DevUI.h
+++ b/Sprocket/UI/DevUI.h
@@ -22,7 +22,7 @@ class DevUI
 // A class that wraps the setup and rendering of ImGui.
 {
     shader  d_shader;
-    std::unique_ptr<Texture> d_fontAtlas;
+    std::unique_ptr<texture> d_fontAtlas;
 
     spkt::imgui_vertex_buffer d_vtx_buffer;
     spkt::imgui_index_buffer  d_idx_buffer;

--- a/Sprocket/UI/Font/Font.h
+++ b/Sprocket/UI/Font/Font.h
@@ -41,7 +41,7 @@ public:
 
     float TextWidth(std::string_view text, float size);
 
-    Texture* GetAtlas() const { return d_atlas.GetAtlas(); }
+    texture* GetAtlas() const { return d_atlas.GetAtlas(); }
 };
 
 }

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -10,7 +10,7 @@
 namespace spkt {
 
 FontAtlas::FontAtlas(int width, int height)
-    : d_texture(std::make_unique<texture>(width, height, texture::Channels::RED))
+    : d_texture(std::make_unique<texture>(width, height, texture_channels::RED))
 {
     // We want a one pixel border around the whole atlas to avoid any
     // artefact when sampling texture

--- a/Sprocket/UI/Font/FontAtlas.cpp
+++ b/Sprocket/UI/Font/FontAtlas.cpp
@@ -10,7 +10,7 @@
 namespace spkt {
 
 FontAtlas::FontAtlas(int width, int height)
-    : d_texture(std::make_unique<Texture>(width, height, Texture::Channels::RED))
+    : d_texture(std::make_unique<texture>(width, height, texture::Channels::RED))
 {
     // We want a one pixel border around the whole atlas to avoid any
     // artefact when sampling texture
@@ -23,9 +23,9 @@ void FontAtlas::SetRegion(
 {
     assert(region.x > 0);
     assert(region.y > 0);
-    assert(region.x + region.z < d_texture->Width());
-    assert(region.y + region.w < d_texture->Height());
-    d_texture->SetSubTexture(region, data);
+    assert(region.x + region.z < d_texture->width());
+    assert(region.y + region.w < d_texture->height());
+    d_texture->set_subtexture(region, data);
 }
 
 int FontAtlas::Fit(int index, int width, int height)
@@ -35,7 +35,7 @@ int FontAtlas::Fit(int index, int width, int height)
     int y = node.y;
     int width_left = width;
 
-    if (x + width >= d_texture->Width()) {
+    if (x + width >= d_texture->width()) {
         return -1;
     }
 
@@ -44,7 +44,7 @@ int FontAtlas::Fit(int index, int width, int height)
         node = d_nodes[i];
         
         y = std::max(y, node.y);
-        if (y + height >= d_texture->Height()) {
+        if (y + height >= d_texture->height()) {
             return -1;
         }
 

--- a/Sprocket/UI/Font/FontAtlas.h
+++ b/Sprocket/UI/Font/FontAtlas.h
@@ -13,7 +13,7 @@ namespace spkt {
 class FontAtlas
 {
     std::vector<glm::ivec3> d_nodes;
-    std::unique_ptr<Texture> d_texture;
+    std::unique_ptr<texture> d_texture;
 
     int Fit(int index, int width, int height);
 
@@ -23,12 +23,12 @@ public:
     glm::ivec4 GetRegion(std::size_t width, std::size_t height);
     void SetRegion(const glm::ivec4& region, const unsigned char* data);
 
-    std::size_t Width() const { return d_texture->Width(); }
-    std::size_t Height() const { return d_texture->Height(); }
+    std::size_t Width() const { return d_texture->width(); }
+    std::size_t Height() const { return d_texture->height(); }
 
-    void Bind(int slot) const { d_texture->Bind(slot); }
+    void Bind(int slot) const { d_texture->bind(slot); }
 
-    Texture* GetAtlas() const { return d_texture.get(); }
+    texture* GetAtlas() const { return d_texture.get(); }
 };
 
 }

--- a/Sprocket/UI/ImGuiXtra.cpp
+++ b/Sprocket/UI/ImGuiXtra.cpp
@@ -57,7 +57,7 @@ void Text(const std::string& text)
     ImGui::Text(text.c_str());
 }
 
-void Image(const Texture& image,
+void Image(const texture& image,
            const glm::vec2& size,
            const glm::vec2& uv0,
            const glm::vec2& uv1,
@@ -65,7 +65,7 @@ void Image(const Texture& image,
            const glm::vec4& borderCol)
 {
     ImGui::Image(
-        (ImTextureID)(intptr_t)image.Id(),
+        (ImTextureID)(intptr_t)image.id(),
         {size.x, size.y},
         {uv0.x, uv0.y},
         {uv1.x, uv1.y},
@@ -74,14 +74,14 @@ void Image(const Texture& image,
     );
 }
 
-void Image(const Texture& image, float size)
+void Image(const texture& image, float size)
 {
-    Image(image, {image.AspectRatio() * size, size});
+    Image(image, {image.aspect_ratio() * size, size});
 }
 
-void Image(const Texture& image)
+void Image(const texture& image)
 {
-    Image(image, {(float)image.Width(), (float)image.Height()});
+    Image(image, {(float)image.width(), (float)image.height()});
 }
 
 void GuizmoSettings(

--- a/Sprocket/UI/ImGuiXtra.h
+++ b/Sprocket/UI/ImGuiXtra.h
@@ -10,7 +10,7 @@
 namespace spkt {
 
 class Window;
-class Texture;
+class texture;
 
 namespace ImGuiXtra {
 
@@ -28,7 +28,7 @@ void TextModifiable(std::string& text);
 void Text(const std::string& text);
 
 // A wrapper for ImGui::Image that uses Sprocket types.
-void Image(const Texture& image,
+void Image(const texture& image,
            const glm::vec2& size,
            const glm::vec2& uv0 = {0, 1},
            const glm::vec2& uv1 = {1, 0},
@@ -38,10 +38,10 @@ void Image(const Texture& image,
 
 // A simplified version of the above where the texture maintains
 // aspect ratio. The size is the height in pixels.
-void Image(const Texture& image, float size);
+void Image(const texture& image, float size);
 
 // An even more simple version where the size is the native size of the image.
-void Image(const Texture& image);
+void Image(const texture& image);
 
 void GuizmoSettings(
     ImGuizmo::OPERATION& mode,

--- a/Sprocket/UI/SimpleUI.cpp
+++ b/Sprocket/UI/SimpleUI.cpp
@@ -276,10 +276,10 @@ void SimpleUI::Dragger(std::string_view name,
 }
 
 void SimpleUI::Image(std::string_view name,
-                     const Texture* image,
+                     const texture* image,
                      const glm::vec2& position)
 {
-    glm::vec4 region{position.x, position.y, image->Width(), image->Height()};
+    glm::vec4 region{position.x, position.y, image->width(), image->height()};
     glm::vec4 copy = d_engine.ApplyOffset(region);
 
     DrawCommand cmd;

--- a/Sprocket/UI/SimpleUI.h
+++ b/Sprocket/UI/SimpleUI.h
@@ -81,7 +81,7 @@ public:
                  float* value, float speed);
 
     void Image(std::string_view name,
-               const Texture* image,
+               const texture* image,
                const glm::vec2& position);
 
 };

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -34,7 +34,6 @@ spkt::texture_data get_white_data()
     return {
         .width = 1,
         .height = 1,
-        .bpp = 4,
         .bytes = {0xff, 0xff, 0xff, 0xff}
     };
 }

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -418,9 +418,9 @@ void UIEngine::ExecuteCommand(const DrawCommand& cmd)
     }
 
     if (cmd.texture) {
-        cmd.texture->Bind(0);
+        cmd.texture->bind(0);
     } else {
-        d_white.Bind(0);
+        d_white.bind(0);
     }
 
     d_vertices.bind();

--- a/Sprocket/UI/UIEngine.cpp
+++ b/Sprocket/UI/UIEngine.cpp
@@ -29,9 +29,14 @@ bool InRegion(const glm::vec2& pos, const glm::vec4& quad)
     return x < pos.x && pos.x < x + width &&  y < pos.y && pos.y < y + height;
 }
 
-std::vector<unsigned char> GetWhiteData()
+spkt::texture_data get_white_data()
 {
-    return {0xff, 0xff, 0xff, 0xff};
+    return {
+        .width = 1,
+        .height = 1,
+        .bpp = 4,
+        .bytes = {0xff, 0xff, 0xff, 0xff}
+    };
 }
 
 }
@@ -130,7 +135,7 @@ UIEngine::UIEngine(Window* window)
     : d_window(window)
     , d_shader("Resources/Shaders/SimpleUI.vert",
                "Resources/Shaders/SimpleUI.frag")
-    , d_white(1, 1, GetWhiteData().data())
+    , d_white(get_white_data())
 {
 }
 

--- a/Sprocket/UI/UIEngine.h
+++ b/Sprocket/UI/UIEngine.h
@@ -35,7 +35,7 @@ struct TextProperties
 
 struct DrawCommand
 {
-    const Texture*             texture = nullptr;
+    const texture*             texture = nullptr;
     std::vector<ui_vertex>  vertices;
     std::vector<std::uint32_t> indices;
 
@@ -135,7 +135,7 @@ class UIEngine
 {
     spkt::Window* d_window;
 
-    spkt::Texture d_white;
+    spkt::texture d_white;
 
     // Rendering code    
     spkt::shader d_shader;


### PR DESCRIPTION
* Rename to `spkt::texture`.
* Make the `texture_data` struct consistent with the corresponding structs for meshes.
* Add a constructor that accepts a `texture_data` and remove `from_data`.