### PR TITLE
Move Console to Sprocket

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,6 +103,7 @@
         "span": "cpp",
         "sstream": "cpp",
         "source_location": "cpp",
-        "numbers": "cpp"
+        "numbers": "cpp",
+        "resumable": "cpp"
     }
 }

--- a/Runtime/CMakeLists.txt
+++ b/Runtime/CMakeLists.txt
@@ -6,8 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 
 add_executable(Runtime
                Main.m.cpp
-               Runtime.cpp
-               Console.cpp)
+               Runtime.cpp)
 
 target_link_libraries(Runtime PRIVATE Sprocket)
 target_include_directories(Runtime PUBLIC

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -31,30 +31,35 @@ private:
 
     std::unordered_map<std::string, command_handler> d_command_handlers;
 
-    void HandleCommand(const std::string_view command);
+    void handle_command(const std::string_view command);
 
 public:
     Console(spkt::Window* window);
 
     void on_update(double dt);
     void on_event(spkt::event& event);
-    void Draw();
+    void draw();
+
+    void submit();
 
     void clear_history();
 
     void register_command(const std::string& command, const command_handler& handler);
     void deregister_command(const std::string& command);
 
-    void println(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
-
-    template <typename... Args> void log(std::string_view format, Args&&... args)
-    {
-        println(std::format(format, std::forward<Args>(args)...));
-    }
-
-    template <typename... Args> void error(std::string_view format, Args&&... args)
-    {
-        println(std::format(format, std::forward<Args>(args)...), {1.0, 0.0, 0.0, 1.0});
-    }
+    void print(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
+    void log(std::string_view format, auto&&... args);
+    void error(std::string_view format, auto&&... args);
 };
 
+template <typename... Args>
+void Console::log(std::string_view format, Args&&... args)
+{
+    print(std::format(format, std::forward<Args>(args)...));
+}
+
+template <typename... Args>
+void Console::error(std::string_view format, Args&&... args)
+{
+    print(std::format(format, std::forward<Args>(args)...), {1.0, 0.0, 0.0, 1.0});
+}

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 
 #include <deque>
+#include <functional>
 #include <string_view>
 
 namespace spkt {
@@ -18,13 +19,21 @@ struct ConsoleLine
 
 class Console
 {
+public:
+    using command_handler = std::function<
+        void(Console&, std::span<const std::string>)
+    >;
+
+private:
     spkt::Window*  d_window;
     spkt::SimpleUI d_ui;
 
     std::string             d_commandLine;
     std::deque<ConsoleLine> d_consoleLines;
 
-    void HandleCommand(std::string_view command);
+    std::unordered_map<std::string, command_handler> d_command_handlers;
+
+    void HandleCommand(const std::string_view command);
 
 public:
     Console(spkt::Window* window);
@@ -32,4 +41,11 @@ public:
     void on_update(double dt);
     void on_event(spkt::event& event);
     void Draw();
+
+    void clear_history();
+    void log_line(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
+
+    void register_command(const std::string& command, const command_handler& handler);
+    void deregister_command(const std::string& command);
 };
+

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -20,9 +20,7 @@ struct ConsoleLine
 class Console
 {
 public:
-    using command_handler = std::function<
-        void(Console&, std::span<const std::string>)
-    >;
+    using command_handler = std::function<void(Console&, std::span<const std::string>)>;
 
 private:
     spkt::Window*  d_window;
@@ -43,9 +41,20 @@ public:
     void Draw();
 
     void clear_history();
-    void log_line(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
 
     void register_command(const std::string& command, const command_handler& handler);
     void deregister_command(const std::string& command);
+
+    void println(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
+
+    template <typename... Args> void log(std::string_view format, Args&&... args)
+    {
+        println(std::format(format, std::forward<Args>(args)...));
+    }
+
+    template <typename... Args> void error(std::string_view format, Args&&... args)
+    {
+        println(std::format(format, std::forward<Args>(args)...), {1.0, 0.0, 0.0, 1.0});
+    }
 };
 

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -4,6 +4,7 @@
 
 #include <deque>
 #include <functional>
+#include <ranges>
 #include <string_view>
 
 namespace spkt {
@@ -23,9 +24,6 @@ public:
     using command_handler = std::function<void(Console&, std::span<const std::string>)>;
 
 private:
-    spkt::Window*  d_window;
-    spkt::SimpleUI d_ui;
-
     std::string             d_commandLine;
     std::deque<ConsoleLine> d_consoleLines;
 
@@ -34,11 +32,6 @@ private:
     void handle_command(const std::string_view command);
 
 public:
-    Console(spkt::Window* window);
-
-    void on_update(double dt);
-    void on_event(spkt::event& event);
-    void draw();
 
     void submit();
 
@@ -50,6 +43,11 @@ public:
     void print(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
     void log(std::string_view format, auto&&... args);
     void error(std::string_view format, auto&&... args);
+
+    const std::string& command_line() const { return d_commandLine; }
+    std::string& command_line() { return d_commandLine; }
+
+    const std::deque<ConsoleLine>& history() const { return d_consoleLines; }
 };
 
 template <typename... Args>
@@ -63,3 +61,5 @@ void Console::error(std::string_view format, Args&&... args)
 {
     print(std::format(format, std::forward<Args>(args)...), {1.0, 0.0, 0.0, 1.0});
 }
+
+void draw_console(Console& console, spkt::SimpleUI& ui, int width, int height);

--- a/Runtime/Console.h
+++ b/Runtime/Console.h
@@ -4,62 +4,55 @@
 
 #include <deque>
 #include <functional>
-#include <ranges>
+#include <span>
 #include <string_view>
+#include <string>
 
-namespace spkt {
-    class Window;
-    class event;
-}
-
-struct ConsoleLine
+struct console_line
 {
     std::string text;
     glm::vec4 colour;
 };
 
-class Console
+class console
 {
 public:
-    using command_handler = std::function<void(Console&, std::span<const std::string>)>;
+    using command_handler = std::function<void(console&, std::span<const std::string>)>;
 
 private:
-    std::string             d_commandLine;
-    std::deque<ConsoleLine> d_consoleLines;
-
-    std::unordered_map<std::string, command_handler> d_command_handlers;
-
-    void handle_command(const std::string_view command);
+    std::unordered_map<std::string, command_handler> d_handlers;
+    std::deque<console_line>                         d_history;
 
 public:
-
-    void submit();
-
-    void clear_history();
-
     void register_command(const std::string& command, const command_handler& handler);
     void deregister_command(const std::string& command);
+
+    void submit(const std::string& command);
+
+    [[nodiscard]] const std::deque<console_line>& history() const { return d_history; }
+    void clear_history();
 
     void print(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});
     void log(std::string_view format, auto&&... args);
     void error(std::string_view format, auto&&... args);
-
-    const std::string& command_line() const { return d_commandLine; }
-    std::string& command_line() { return d_commandLine; }
-
-    const std::deque<ConsoleLine>& history() const { return d_consoleLines; }
 };
 
 template <typename... Args>
-void Console::log(std::string_view format, Args&&... args)
+void console::log(std::string_view format, Args&&... args)
 {
     print(std::format(format, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
-void Console::error(std::string_view format, Args&&... args)
+void console::error(std::string_view format, Args&&... args)
 {
     print(std::format(format, std::forward<Args>(args)...), {1.0, 0.0, 0.0, 1.0});
 }
 
-void draw_console(Console& console, spkt::SimpleUI& ui, int width, int height);
+void draw_console(
+    const console& console,
+    std::string& command_line,
+    spkt::SimpleUI& ui,
+    int width,
+    int height
+);

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -7,6 +7,7 @@
 #include <Sprocket/Scene/Systems/particle_system.h>
 #include <Sprocket/Scene/Systems/physics_system.h>
 #include <Sprocket/Scripting/LuaScript.h>
+#include <Sprocket/UI/console.h>
 #include <Sprocket/Utility/Colour.h>
 #include <Sprocket/Utility/KeyboardCodes.h>
 
@@ -58,22 +59,22 @@ Runtime::Runtime(spkt::Window* window)
     theme.clickedColour = GARDEN;
     d_ui.SetTheme(theme);
 
-    d_console.register_command("clear", [](console& console, auto args) {
+    d_console.register_command("clear", [](spkt::console& console, auto args) {
         console.clear_history();
     });
     
-    d_console.register_command("exit", [&](console& console, auto args) {
+    d_console.register_command("exit", [&](spkt::console& console, auto args) {
         d_window->Close();
     });
 
-    d_console.register_command("echo", [](console& console, auto args) {
+    d_console.register_command("echo", [](spkt::console& console, auto args) {
         if (args.size() < 2) { return; }
         std::string echo = args[1];
         for (auto arg : args | std::views::drop(2)) echo += " " + arg;
         console.log(" > {}", echo);
     });
 
-    d_console.register_command("run", [](console& console, auto args) {
+    d_console.register_command("run", [](spkt::console& console, auto args) {
         if (args.size() != 2) {
             console.error("Invalid args for {}", args[0]);
             return;

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -112,6 +112,6 @@ void Runtime::on_render()
     d_entityRenderer.Draw(d_scene.registry, d_runtimeCamera);
 
     if (d_consoleActive) {
-        d_console.Draw();
+        d_console.draw();
     }
 }

--- a/Runtime/Runtime.cpp
+++ b/Runtime/Runtime.cpp
@@ -58,22 +58,22 @@ Runtime::Runtime(spkt::Window* window)
     theme.clickedColour = GARDEN;
     d_ui.SetTheme(theme);
 
-    d_console.register_command("clear", [](Console& console, auto args) {
+    d_console.register_command("clear", [](console& console, auto args) {
         console.clear_history();
     });
     
-    d_console.register_command("exit", [&](Console& console, auto args) {
+    d_console.register_command("exit", [&](console& console, auto args) {
         d_window->Close();
     });
 
-    d_console.register_command("echo", [](Console& console, auto args) {
+    d_console.register_command("echo", [](console& console, auto args) {
         if (args.size() < 2) { return; }
         std::string echo = args[1];
         for (auto arg : args | std::views::drop(2)) echo += " " + arg;
         console.log(" > {}", echo);
     });
 
-    d_console.register_command("run", [](Console& console, auto args) {
+    d_console.register_command("run", [](console& console, auto args) {
         if (args.size() != 2) {
             console.error("Invalid args for {}", args[0]);
             return;
@@ -99,7 +99,8 @@ void Runtime::on_event(spkt::event& event)
     if (d_consoleActive) {
         auto data = event.get_if<spkt::keyboard_pressed_event>();
         if (data && data->key == spkt::Keyboard::ENTER) {
-            d_console.submit();
+            d_console.submit(d_command_line);
+            d_command_line.clear();
             event.consume();
         } else {
             d_ui.on_event(event);
@@ -126,7 +127,7 @@ void Runtime::on_render()
 
     if (d_consoleActive) {
         d_ui.StartFrame();
-        draw_console(d_console, d_ui, d_window->Width(), d_window->Height());
+        draw_console(d_console, d_command_line, d_ui, d_window->Width(), d_window->Height());
         d_ui.EndFrame();
     }
 }

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -31,8 +31,9 @@ class Runtime
     spkt::entity d_runtimeCamera;
 
     // Console
-    Console d_console;
-    bool d_consoleActive = false;
+    spkt::SimpleUI d_ui;
+    Console        d_console;
+    bool           d_consoleActive = false;
 
 public:
     Runtime(spkt::Window* window);

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -1,12 +1,11 @@
 #pragma once
-#include "Console.h"
-
 #include <Sprocket/Graphics/asset_manager.h>
+#include <Sprocket/Graphics/CubeMap.h>
 #include <Sprocket/Graphics/Rendering/Scene3DRenderer.h>
 #include <Sprocket/Graphics/Rendering/SkyboxRenderer.h>
-#include <Sprocket/Scene/scene.h>
-#include <Sprocket/Graphics/CubeMap.h>
 #include <Sprocket/Scene/ecs.h>
+#include <Sprocket/Scene/scene.h>
+#include <Sprocket/UI/console.h>
 
 #include <memory>
 #include <random>
@@ -32,7 +31,7 @@ class Runtime
 
     // Console
     spkt::SimpleUI d_ui;
-    console        d_console;
+    spkt::console  d_console;
     std::string    d_command_line;
     bool           d_consoleActive = false;
 

--- a/Runtime/Runtime.h
+++ b/Runtime/Runtime.h
@@ -32,7 +32,8 @@ class Runtime
 
     // Console
     spkt::SimpleUI d_ui;
-    Console        d_console;
+    console        d_console;
+    std::string    d_command_line;
     bool           d_consoleActive = false;
 
 public:

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(Sprocket STATIC
             UI/Font/FontAtlas.cpp
             UI/Font/Font.cpp
             
+            UI/console.cpp
             UI/UIEngine.cpp
             UI/SimpleUI.cpp
             UI/SinglePanelUI.cpp

--- a/Sprocket/UI/console.cpp
+++ b/Sprocket/UI/console.cpp
@@ -43,14 +43,14 @@ void console::submit(const std::string& command)
 
 void console::clear_history()
 {
-    d_history.clear();
+    d_lines.clear();
 }
 
 void console::print(const std::string& line, const glm::vec4& colour)
 {
-    d_history.push_front({line, colour});
-    while (d_history.size() > 100) {
-        d_history.pop_back();
+    d_lines.push_front({line, colour});
+    while (d_lines.size() > 100) {
+        d_lines.pop_back();
     }
 }
 

--- a/Sprocket/UI/console.cpp
+++ b/Sprocket/UI/console.cpp
@@ -1,4 +1,4 @@
-#include "Console.h"
+#include "console.h"
 
 #include <Sprocket/UI/SimpleUI.h>
 
@@ -20,6 +20,8 @@ std::vector<std::string> tokenize(const std::string& command)
 }
 
 }
+
+namespace spkt {
 
 void console::submit(const std::string& command)
 {
@@ -87,4 +89,6 @@ void draw_console(
     }
 
     ui.EndPanel();
+}
+
 }

--- a/Sprocket/UI/console.h
+++ b/Sprocket/UI/console.h
@@ -24,7 +24,7 @@ public:
 
 private:
     std::unordered_map<std::string, command_handler> d_handlers;
-    std::deque<console_line>                         d_history;
+    std::deque<console_line>                         d_lines;
 
 public:
     void register_command(const std::string& command, const command_handler& handler);
@@ -32,7 +32,7 @@ public:
 
     void submit(const std::string& command);
 
-    [[nodiscard]] const std::deque<console_line>& history() const { return d_history; }
+    [[nodiscard]] const std::deque<console_line>& history() const { return d_lines; }
     void clear_history();
 
     void print(const std::string& line, const glm::vec4& colour = {1.0, 1.0, 1.0, 1.0});

--- a/Sprocket/UI/console.h
+++ b/Sprocket/UI/console.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <Sprocket/UI/SimpleUI.h>
 
 #include <glm/glm.hpp>
@@ -7,6 +8,8 @@
 #include <span>
 #include <string_view>
 #include <string>
+
+namespace spkt {
 
 struct console_line
 {
@@ -56,3 +59,5 @@ void draw_console(
     int width,
     int height
 );
+
+}


### PR DESCRIPTION
* Completely refactor the `Console` class. Interface has completely changed.
* Renamed `Console` to `spkt::console`, moving it into the UI package.
* Is no longer responsible for rendering, purely used for storing the terminal lines and handling inputs.
* Commands are functions that get registered with the console, rather than being hardcoded.
* No longer needs `on_update`, `on_event`, a `window*` or `SimpleUI`.