### PR TITLE
Remove Singleton Component

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,18 @@
 
     
         {
-            "name": "Game",
+            "name": "Game (RelWithDebInfo)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Game/RelWithDebInfo/Game.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false
+        },
+        {
+            "name": "Game (Debug)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Game/Debug/Game.exe",

--- a/Anvil/anvil.cpp
+++ b/Anvil/anvil.cpp
@@ -124,16 +124,20 @@ void Anvil::on_update(double dt)
 
 glm::mat4 Anvil::get_proj_matrix() const
 {
-    auto& registry = d_activeScene->registry;
-    const auto& cc = registry.get<spkt::Camera3DComponent>(d_runtimeCamera);
-    return d_playingGame ? spkt::make_proj(cc.fov) : d_editor_camera.Proj();
+    if (!d_playingGame) { return d_editor_camera.Proj(); }
+
+    const auto& reg = d_activeScene->registry;
+    auto [tc, cc] = reg.get_all<spkt::Transform3DComponent, spkt::Camera3DComponent>(d_runtimeCamera);
+    return spkt::make_proj(cc.fov);
 }
 
 glm::mat4 Anvil::get_view_matrix() const
 {
-    auto& registry = d_activeScene->registry;
-    auto [tc, cc] = std::as_const(registry).get_all<spkt::Transform3DComponent, spkt::Camera3DComponent>(d_runtimeCamera);
-    return d_playingGame ? spkt::make_view(tc.position, tc.orientation, cc.pitch) : d_editor_camera.View();
+    if (!d_playingGame) { return d_editor_camera.View(); }
+
+    const auto& reg = d_activeScene->registry;
+    auto [tc, cc] = reg.get_all<spkt::Transform3DComponent, spkt::Camera3DComponent>(d_runtimeCamera);
+    return spkt::make_view(tc.position, tc.orientation, cc.pitch);
 }
 
 void Anvil::on_render()

--- a/Anvil/anvil.cpp
+++ b/Anvil/anvil.cpp
@@ -25,6 +25,12 @@
 
 namespace {
 
+template <typename T>
+T& get_singleton(spkt::registry& reg)
+{
+    return reg.get<T>(reg.find<T>());
+}
+
 std::string entiy_name(spkt::registry& registry, spkt::entity entity)
 {
     if (registry.has<spkt::NameComponent>(entity)) {
@@ -64,7 +70,6 @@ Anvil::Anvil(spkt::window* window)
     d_window->set_cursor_visibility(true);
 
     d_scene = std::make_shared<spkt::scene>();
-    spkt::add_singleton(d_scene->registry);
     spkt::load_registry_from_file(d_sceneFile, d_scene->registry);
     d_activeScene = d_scene;
 }
@@ -214,7 +219,6 @@ void Anvil::on_render()
             if (ImGui::MenuItem("Run")) {
                 d_activeScene = std::make_shared<spkt::scene>();
 
-                spkt::add_singleton(d_activeScene->registry);
                 spkt::input_system_init(d_activeScene->registry, d_window);
                 spkt::copy_registry(d_scene->registry, d_activeScene->registry);
 

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -52,7 +52,6 @@ Runtime::Runtime(spkt::window* window)
 {
     d_window->set_cursor_visibility(false);
 
-    spkt::add_singleton(d_scene.registry);
     spkt::input_system_init(d_scene.registry, d_window);
     spkt::load_registry_from_file("Resources/Anvil.yaml", d_scene.registry);
 

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -219,13 +219,11 @@ void Game::on_event(spkt::event& event)
     }
 
     if (auto data = event.get_if<mouse_pressed_event>()) {
-        auto& tr = registry.get<Transform3DComponent>(d_camera);
         if (data->mods & KeyModifier::CTRL) {
-
             const auto& reg = registry;
             auto [tc, cc] = reg.get_all<Transform3DComponent, Camera3DComponent>(d_camera);
 
-            glm::vec3 cameraPos = tr.position;
+            glm::vec3 cameraPos = tc.position;
             glm::vec3 direction = Maths::GetMouseRay(
                 d_window->mouse_position(),
                 (float)d_window->width(),

--- a/Game/Game.cpp
+++ b/Game/Game.cpp
@@ -24,6 +24,12 @@ using namespace spkt;
 
 namespace {
 
+template <typename T>
+T& get_singleton(spkt::registry& reg)
+{
+    return reg.get<T>(reg.find<T>());
+}
+
 void path_follower_system(spkt::registry& registry, double dt)
 {
     for (auto [path, transform] : registry.view_get<spkt::PathComponent, spkt::Transform3DComponent>()) {
@@ -145,7 +151,6 @@ void Game::load_scene(std::string_view file)
 {
     auto& registry = d_scene.registry;
     
-    spkt::add_singleton(registry);
     spkt::input_system_init(registry, d_window);
     game_grid_system_init(registry);
     spkt::load_registry_from_file(std::string(file), registry);

--- a/Game/game_grid.cpp
+++ b/Game/game_grid.cpp
@@ -16,11 +16,18 @@ namespace {
 
 constexpr const char* GRID_SQUARE = "Resources/Models/Square.obj";
 
+template <typename T>
+T& get_singleton(spkt::registry& reg)
+{
+    return reg.get<T>(reg.find<T>());
+}
+
 }
 
 void game_grid_system_init(spkt::registry& registry)
 {
-    auto singleton = registry.find<spkt::Singleton>();
+    auto singleton = registry.create();
+    registry.emplace<spkt::Runtime>(singleton);
     registry.emplace<spkt::CameraSingleton>(singleton);
     auto& grid = registry.emplace<spkt::GameGridSingleton>(singleton);
 

--- a/Game/game_grid.cpp
+++ b/Game/game_grid.cpp
@@ -63,7 +63,7 @@ void game_grid_system(spkt::registry& registry, double)
         return !registry.valid(entity);
     });
 
-    if (input.is_mouse_clicked(spkt::Mouse::RIGHT)) {
+    if (input.is_mouse_clicked(spkt::Mouse::LEFT)) {
         grid.clicked_square = grid.hovered_square;
     } else if (input.is_mouse_unclicked(spkt::Mouse::RIGHT)) {
         grid.clicked_square = std::nullopt;

--- a/Resources/Scene.yaml
+++ b/Resources/Scene.yaml
@@ -716,6 +716,9 @@ Entities:
       position: [8, 10, 0]
       orientation: [0.6373177, -0.3063107, 0.6373177, 0.3063107]
       scale: [1, 1, 1]
+    Camera3DComponent:
+      fov: 70
+      pitch: 0
     ScriptComponent:
       script: Resources/Scripts/ThirdPersonCamera.lua
       active: true

--- a/Sprocket/ComponentSpec.json
+++ b/Sprocket/ComponentSpec.json
@@ -14,15 +14,6 @@
             "attributes": []
         },
         {
-            "name": "Singleton",
-            "display_name": "Singleton",
-            "flags": {
-                "SCRIPTABLE": false,
-                "SAVABLE": false
-            },
-            "attributes": []
-        },
-        {
             "name": "Event",
             "display_name": "Event",
             "flags": {

--- a/Sprocket/Graphics/camera.cpp
+++ b/Sprocket/Graphics/camera.cpp
@@ -16,7 +16,7 @@ glm::mat4 make_view(const glm::vec3& pos, const glm::quat& ori, float pitch)
 
 glm::mat4 make_proj(float fov)
 {
-    return glm::perspective(fov, Viewport::CurrentAspectRatio(), 0.01f, 1000.0f);
+    return glm::perspective(glm::radians(fov), Viewport::CurrentAspectRatio(), 0.01f, 1000.0f);
 }
 
 }

--- a/Sprocket/Scene/Systems/basic_systems.cpp
+++ b/Sprocket/Scene/Systems/basic_systems.cpp
@@ -31,7 +31,8 @@ void script_system(spkt::registry& registry, double dt)
         if (!sc.active) { continue; }
 
         if (!sc.script_runtime) {
-            input_store& input = *get_singleton<InputSingleton>(registry).input_store;
+            auto input_singleton = registry.find<InputSingleton>();
+            input_store& input = *registry.get<InputSingleton>(input_singleton).input_store;
             
             sc.script_runtime = std::make_shared<lua::script>(sc.script);
             lua::script& script = *sc.script_runtime;

--- a/Sprocket/Scene/Systems/input_system.cpp
+++ b/Sprocket/Scene/Systems/input_system.cpp
@@ -13,19 +13,22 @@ namespace spkt {
 void input_system_init(spkt::registry& registry, spkt::window* window)
 {
     assert(window);
-    auto singleton = registry.find<Singleton>();
+    auto singleton = registry.create();
+    registry.emplace<Runtime>(singleton);
     auto& is = registry.emplace<InputSingleton>(singleton);
     is.input_store = std::make_shared<spkt::input_store>(window);
 }
 
 void input_system_on_event(spkt::registry& registry, spkt::event& event)
 {
-    get_singleton<InputSingleton>(registry).input_store->on_event(event);
+    auto singleton = registry.find<InputSingleton>();
+    registry.get<InputSingleton>(singleton).input_store->on_event(event);
 }
 
 void input_system_end(spkt::registry& registry, double dt)
 {
-    get_singleton<InputSingleton>(registry).input_store->end_frame();
+    auto singleton = registry.find<InputSingleton>();
+    registry.get<InputSingleton>(singleton).input_store->end_frame();
 }
     
 }

--- a/Sprocket/Scene/ecs.h
+++ b/Sprocket/Scene/ecs.h
@@ -40,10 +40,6 @@ struct Runtime
 {
 };
 
-struct Singleton
-{
-};
-
 struct Event
 {
 };
@@ -216,7 +212,6 @@ struct ParticleSingleton
 
 using registry = apx::registry<
     Runtime,
-    Singleton,
     Event,
     NameComponent,
     Transform2DComponent,

--- a/Sprocket/Scene/meta.h
+++ b/Sprocket/Scene/meta.h
@@ -42,26 +42,6 @@ struct reflcomp<Runtime>
 };
 
 template <>
-struct reflcomp<Singleton>
-{
-    static constexpr const char* name          = "Singleton";
-    static constexpr const char* display_name  = "Singleton";
-
-    static constexpr bool        is_savable()    { return false; }
-    static constexpr bool        is_scriptable() { return false; }
-
-    template <typename Func>
-    void for_each_attribute(Singleton& component, Func&& func)
-    {
-    }
-
-    template <typename Func>
-    void for_each_attribute(const Singleton& component, Func&& func) const
-    {
-    }
-};
-
-template <>
 struct reflcomp<Event>
 {
     static constexpr const char* name          = "Event";
@@ -694,7 +674,6 @@ template <typename Func>
 void for_each_component(Func&& func)
 {
     func(reflcomp<Runtime>{});
-    func(reflcomp<Singleton>{});
     func(reflcomp<Event>{});
     func(reflcomp<NameComponent>{});
     func(reflcomp<Transform2DComponent>{});

--- a/Sprocket/Scene/scene.cpp
+++ b/Sprocket/Scene/scene.cpp
@@ -9,15 +9,6 @@
 
 namespace spkt {
 
-spkt::entity add_singleton(spkt::registry& registry)
-{
-    auto singleton = registry.create();
-    registry.emplace<Runtime>(singleton);
-    registry.emplace<Singleton>(singleton);
-    registry.emplace<NameComponent>(singleton, "::RuntimeSingleton");
-    return singleton;
-}
-
 void scene::on_update(double dt)
 {
     std::ranges::for_each(systems, [&](const system& sys) {

--- a/Sprocket/Scene/scene.h
+++ b/Sprocket/Scene/scene.h
@@ -9,17 +9,6 @@ namespace spkt {
 
 class event;
 
-spkt::entity add_singleton(spkt::registry& registry);
-
-template <typename Comp>
-Comp& get_singleton(spkt::registry& registry)
-{
-    auto singleton = registry.find<Singleton>();
-    assert(registry.valid(singleton));
-    assert(registry.has<Comp>(singleton));
-    return registry.get<Comp>(singleton);
-}
-
 struct scene
 {
     using system        = std::function<void(spkt::registry&, double)>;


### PR DESCRIPTION
* Any system that needs a singleton can just create a fresh entity, no central singleton needed.
* Added a `Camera3DComponent` to the camera entity in Game, which it previously didn't need as the pitch isnt used and the fov was hardcoded.
* Remove the `Singleton` class usage in the scene files.
* Fix bugs from previous PRs.