### PR TITLE
Shape Renderer

### DIFF
--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -144,6 +144,6 @@ void Runtime::on_render()
 
     static spkt::shape_renderer shapes;
     shapes.begin_frame((float)d_window->width(), (float)d_window->height());
-    shapes.draw_line({0.0, 0.0}, {1.0, 1.0}, {1.0, 0.0, 0.0, 1.0}, 1.0f);
+    shapes.draw_line({100.0, 100.0}, {200.0, 200.0}, {1.0, 0.0, 0.0, 1.0}, 1.0f);
     shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -144,6 +144,6 @@ void Runtime::on_render()
 
     static spkt::shape_renderer shapes;
     shapes.begin_frame((float)d_window->width(), (float)d_window->height());
-    shapes.draw_line({100.0, 100.0}, d_window->mouse_position(), {1.0, 0.0, 0.0, 1.0}, 1.0f);
+    shapes.draw_line({100.0, 100.0}, d_window->mouse_position(), {1.0, 0.0, 0.0, 1.0}, 5.0f);
     shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -151,5 +151,10 @@ void Runtime::on_render()
         {0.0, 0.0, 1.0, 1.0},
         5.0f
     );
+    shapes.draw_circle(
+        d_window->mouse_position(),
+        {0.0, 1.0, 0.0, 1.0},
+        25.0f
+    );
     shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -15,8 +15,6 @@
 #include <Sprocket/Graphics/camera.h>
 #include <Sprocket/Core/input_codes.h>
 
-#include <Sprocket/Graphics/Rendering/shape_renderer.h>
-
 const auto LIGHT_BLUE  = spkt::from_hex(0x25CCF7);
 const auto CLEAR_BLUE  = spkt::from_hex(0x1B9CFC);
 const auto GARDEN      = spkt::from_hex(0x55E6C1);
@@ -141,20 +139,4 @@ void Runtime::on_render()
         draw_console(d_console, d_command_line, d_ui, d_window->width(), d_window->height());
         d_ui.EndFrame();
     }
-
-    static spkt::shape_renderer shapes;
-    shapes.begin_frame((float)d_window->width(), (float)d_window->height());
-    shapes.draw_line(
-        {100.0, 100.0},
-        d_window->mouse_position(),
-        {1.0, 0.0, 0.0, 1.0},
-        {0.0, 0.0, 1.0, 1.0},
-        5.0f
-    );
-    shapes.draw_circle(
-        d_window->mouse_position(),
-        {0.0, 1.0, 0.0, 1.0},
-        25.0f
-    );
-    shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -15,6 +15,8 @@
 #include <Sprocket/Graphics/camera.h>
 #include <Sprocket/Core/input_codes.h>
 
+#include <Sprocket/Graphics/Rendering/shape_renderer.h>
+
 const auto LIGHT_BLUE  = spkt::from_hex(0x25CCF7);
 const auto CLEAR_BLUE  = spkt::from_hex(0x1B9CFC);
 const auto GARDEN      = spkt::from_hex(0x55E6C1);
@@ -139,4 +141,9 @@ void Runtime::on_render()
         draw_console(d_console, d_command_line, d_ui, d_window->width(), d_window->height());
         d_ui.EndFrame();
     }
+
+    static spkt::shape_renderer shapes;
+    shapes.begin_frame((float)d_window->width(), (float)d_window->height());
+    shapes.draw_line({0.0, 0.0}, {1.0, 1.0}, {1.0, 0.0, 0.0, 1.0}, 1.0f);
+    shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -144,6 +144,6 @@ void Runtime::on_render()
 
     static spkt::shape_renderer shapes;
     shapes.begin_frame((float)d_window->width(), (float)d_window->height());
-    shapes.draw_line({100.0, 100.0}, {200.0, 200.0}, {1.0, 0.0, 0.0, 1.0}, 1.0f);
+    shapes.draw_line({100.0, 100.0}, d_window->mouse_position(), {1.0, 0.0, 0.0, 1.0}, 1.0f);
     shapes.end_frame();
 }

--- a/Anvil/runtime.cpp
+++ b/Anvil/runtime.cpp
@@ -144,6 +144,12 @@ void Runtime::on_render()
 
     static spkt::shape_renderer shapes;
     shapes.begin_frame((float)d_window->width(), (float)d_window->height());
-    shapes.draw_line({100.0, 100.0}, d_window->mouse_position(), {1.0, 0.0, 0.0, 1.0}, 5.0f);
+    shapes.draw_line(
+        {100.0, 100.0},
+        d_window->mouse_position(),
+        {1.0, 0.0, 0.0, 1.0},
+        {0.0, 0.0, 1.0, 1.0},
+        5.0f
+    );
     shapes.end_frame();
 }

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -1,0 +1,15 @@
+#version 410 core
+layout (location = 0) out vec4 out_colour;
+
+in vec2  o_line_begin;
+in vec2  o_line_end;
+in vec4  o_line_colour;
+in float o_line_thickness;
+
+uniform float u_width;
+uniform float u_height;
+
+void main()
+{    
+    out_colour = vec4(1.0, 0.0, 0.0, 0.5);
+}

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -9,15 +9,20 @@ in float o_line_thickness;
 uniform float u_width;
 uniform float u_height;
 
+float cross2d(vec2 a, vec2 b)
+{
+    return a.x * b.y - b.x * a.y;
+}
+
 void main()
 {   
     vec2 pixel = vec2(gl_FragCoord.x, u_height - gl_FragCoord.y);
 
     vec2 line = o_line_end - o_line_begin;
     vec2 to_pixel = pixel - o_line_begin;
-    float angle = dot(line, to_pixel) / (length(line) * length(to_pixel));
+    float sin_angle = abs(cross2d(line, to_pixel)) / (length(line) * length(to_pixel));
 
-    float distance_from_line = length(to_pixel) * sin(acos(angle));
+    float distance_from_line = length(to_pixel) * sin_angle;
 
     if (distance(pixel, o_line_begin) < 10) {
         out_colour = vec4(0.0, 0.0, 1.0, 1.0);

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -10,6 +10,14 @@ uniform float u_width;
 uniform float u_height;
 
 void main()
-{    
-    out_colour = vec4(1.0, 0.0, 0.0, 0.5);
+{   
+    vec2 pixel = vec2(gl_FragCoord.x, u_height - gl_FragCoord.y);
+
+    if (distance(pixel, o_line_begin) < 10) {
+        out_colour = vec4(0.0, 0.0, 1.0, 1.0);
+    } else if (distance(pixel, o_line_end) < 10) {
+        out_colour = vec4(1.0, 0.0, 0.0, 1.0);
+    } else {
+        out_colour = vec4(0.0);;
+    }
 }

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -20,10 +20,11 @@ void main()
 
     vec2 A = o_line_end - o_line_begin;
     vec2 B = pixel - o_line_begin;
+    float lengthA = length(A);
 
-    float distance_from_line = abs(cross2d(A, B)) / length(A);
+    float distance_from_line = abs(cross2d(A, B)) / lengthA;
 
-    float ratio_along = dot(A, B) / (length(A) * length(A));
+    float ratio_along = dot(A, B) / (lengthA * lengthA);
 
     if (distance_from_line < o_line_thickness) {
         if (ratio_along > 0 && ratio_along < 1) {

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -3,7 +3,8 @@ layout (location = 0) out vec4 out_colour;
 
 in vec2  o_line_begin;
 in vec2  o_line_end;
-in vec4  o_line_colour;
+in vec4  o_line_begin_colour;
+in vec4  o_line_end_colour;
 in float o_line_thickness;
 
 uniform float u_width;
@@ -28,11 +29,11 @@ void main()
 
     if (distance_from_line < o_line_thickness) {
         if (ratio_along > 0 && ratio_along < 1) {
-            out_colour = o_line_colour;
+            out_colour = mix(o_line_begin_colour, o_line_end_colour, ratio_along);
         } else if (ratio_along <= 0 && distance(o_line_begin, pixel) < o_line_thickness) {
-            out_colour = o_line_colour;
+            out_colour = o_line_begin_colour;
         } else if (ratio_along >= 1 && distance(o_line_end, pixel) < o_line_thickness) {
-            out_colour = o_line_colour;
+            out_colour = o_line_end_colour;
         } else {
             out_colour = vec4(0.0);
         }

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -19,6 +19,11 @@ void main()
 {   
     vec2 pixel = vec2(gl_FragCoord.x, u_height - gl_FragCoord.y);
 
+    if (o_line_begin == o_line_end && distance(pixel, o_line_begin) < o_line_thickness) {
+        out_colour = o_line_begin_colour;
+        return;
+    }
+
     vec2 A = o_line_end - o_line_begin;
     vec2 B = pixel - o_line_begin;
     float lengthA = length(A);
@@ -27,7 +32,7 @@ void main()
 
     float ratio_along = dot(A, B) / (lengthA * lengthA);
 
-    if (distance_from_line < o_line_thickness) {
+    if (distance_from_line <= o_line_thickness) {
         if (ratio_along > 0 && ratio_along < 1) {
             out_colour = mix(o_line_begin_colour, o_line_end_colour, ratio_along);
         } else if (ratio_along <= 0 && distance(o_line_begin, pixel) < o_line_thickness) {

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -13,11 +13,17 @@ void main()
 {   
     vec2 pixel = vec2(gl_FragCoord.x, u_height - gl_FragCoord.y);
 
+    vec2 line = o_line_end - o_line_begin;
+    vec2 to_pixel = pixel - o_line_begin;
+    float angle = dot(line, to_pixel) / (length(line) * length(to_pixel));
+
+    float distance_from_line = length(to_pixel) * sin(acos(angle));
+
     if (distance(pixel, o_line_begin) < 10) {
         out_colour = vec4(0.0, 0.0, 1.0, 1.0);
     } else if (distance(pixel, o_line_end) < 10) {
         out_colour = vec4(1.0, 0.0, 0.0, 1.0);
-    } else {
-        out_colour = vec4(0.0);;
+    } else if (distance_from_line < 5) {
+        out_colour = vec4(0.0, 1.0, 0.0, 1.0);
     }
 }

--- a/Resources/Shaders/shape.frag
+++ b/Resources/Shaders/shape.frag
@@ -18,17 +18,22 @@ void main()
 {   
     vec2 pixel = vec2(gl_FragCoord.x, u_height - gl_FragCoord.y);
 
-    vec2 line = o_line_end - o_line_begin;
-    vec2 to_pixel = pixel - o_line_begin;
-    float sin_angle = abs(cross2d(line, to_pixel)) / (length(line) * length(to_pixel));
+    vec2 A = o_line_end - o_line_begin;
+    vec2 B = pixel - o_line_begin;
 
-    float distance_from_line = length(to_pixel) * sin_angle;
+    float distance_from_line = abs(cross2d(A, B)) / length(A);
 
-    if (distance(pixel, o_line_begin) < 10) {
-        out_colour = vec4(0.0, 0.0, 1.0, 1.0);
-    } else if (distance(pixel, o_line_end) < 10) {
-        out_colour = vec4(1.0, 0.0, 0.0, 1.0);
-    } else if (distance_from_line < 5) {
-        out_colour = vec4(0.0, 1.0, 0.0, 1.0);
+    float ratio_along = dot(A, B) / (length(A) * length(A));
+
+    if (distance_from_line < o_line_thickness) {
+        if (ratio_along > 0 && ratio_along < 1) {
+            out_colour = o_line_colour;
+        } else if (ratio_along <= 0 && distance(o_line_begin, pixel) < o_line_thickness) {
+            out_colour = o_line_colour;
+        } else if (ratio_along >= 1 && distance(o_line_end, pixel) < o_line_thickness) {
+            out_colour = o_line_colour;
+        } else {
+            out_colour = vec4(0.0);
+        }
     }
 }

--- a/Resources/Shaders/shape.vert
+++ b/Resources/Shaders/shape.vert
@@ -1,0 +1,22 @@
+#version 410 core
+layout (location = 0) in vec2 position;
+
+layout (location = 1) in vec2  line_begin;
+layout (location = 2) in vec2  line_end;
+layout (location = 3) in vec4  line_colour;
+layout (location = 4) in float line_thickness;
+
+out vec2  o_line_begin;
+out vec2  o_line_end;
+out vec4  o_line_colour;
+out float o_line_thickness;
+
+void main()
+{
+    gl_Position = position;
+
+    o_line_begin = line_begin;
+    o_line_end = line_end;
+    o_line_colour = line_colour;
+    o_line_thickness = line_thickness;
+} 

--- a/Resources/Shaders/shape.vert
+++ b/Resources/Shaders/shape.vert
@@ -13,7 +13,7 @@ out float o_line_thickness;
 
 void main()
 {
-    gl_Position = position;
+    gl_Position = vec4(position, 0.0, 1.0);
 
     o_line_begin = line_begin;
     o_line_end = line_end;

--- a/Resources/Shaders/shape.vert
+++ b/Resources/Shaders/shape.vert
@@ -3,12 +3,14 @@ layout (location = 0) in vec2 position;
 
 layout (location = 1) in vec2  line_begin;
 layout (location = 2) in vec2  line_end;
-layout (location = 3) in vec4  line_colour;
-layout (location = 4) in float line_thickness;
+layout (location = 3) in vec4  line_begin_colour;
+layout (location = 4) in vec4  line_end_colour;
+layout (location = 5) in float line_thickness;
 
 out vec2  o_line_begin;
 out vec2  o_line_end;
-out vec4  o_line_colour;
+out vec4  o_line_begin_colour;
+out vec4  o_line_end_colour;
 out float o_line_thickness;
 
 void main()
@@ -17,6 +19,7 @@ void main()
 
     o_line_begin = line_begin;
     o_line_end = line_end;
-    o_line_colour = line_colour;
+    o_line_begin_colour = line_begin_colour;
+    o_line_end_colour = line_end_colour;
     o_line_thickness = line_thickness;
 } 

--- a/Sprocket/CMakeLists.txt
+++ b/Sprocket/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(Sprocket STATIC
             Graphics/Viewport.cpp
 
             Graphics/Rendering/geometry_renderer.cpp
+            Graphics/Rendering/shape_renderer.cpp
             Graphics/Rendering/pbr_renderer.cpp
             Graphics/Rendering/SkyboxRenderer.cpp
             

--- a/Sprocket/Graphics/Rendering/shape_renderer.cpp
+++ b/Sprocket/Graphics/Rendering/shape_renderer.cpp
@@ -37,14 +37,15 @@ void quad_vertex::set_buffer_attributes(std::uint32_t vbo)
 void line_instance::set_buffer_attributes(std::uint32_t vbo)
 {
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    for (int i = 1; i != 5; ++i) {
+    for (int i = 1; i != 6; ++i) {
         glEnableVertexAttribArray(i);
         glVertexAttribDivisor(i, 1);
     }
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, begin));
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, end));
-    glVertexAttribPointer(3, 4, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, colour));
-    glVertexAttribPointer(4, 1, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, thickness));
+    glVertexAttribPointer(3, 4, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, begin_colour));
+    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, end_colour));
+    glVertexAttribPointer(5, 1, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, thickness));
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -90,10 +91,11 @@ void shape_renderer::end_frame()
 void shape_renderer::draw_line(
     const glm::vec2& begin,
     const glm::vec2& end,
-    const glm::vec4& colour,
+    const glm::vec4& begin_colour,
+    const glm::vec4& end_colour,
     const float thickness)
 {
-    d_lines.emplace_back(begin, end, colour, thickness);
+    d_lines.emplace_back(begin, end, begin_colour, end_colour, thickness);
 }
     
 }

--- a/Sprocket/Graphics/Rendering/shape_renderer.cpp
+++ b/Sprocket/Graphics/Rendering/shape_renderer.cpp
@@ -1,6 +1,7 @@
 #include "shape_renderer.h"
 
 #include <Sprocket/Graphics/render_context.h>
+#include <Sprocket/Core/log.h>
 
 #include <glad/glad.h>
 

--- a/Sprocket/Graphics/Rendering/shape_renderer.cpp
+++ b/Sprocket/Graphics/Rendering/shape_renderer.cpp
@@ -1,0 +1,98 @@
+#include "shape_renderer.h"
+
+#include <Sprocket/Graphics/render_context.h>
+
+#include <glad/glad.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <cstddef>
+
+namespace spkt {
+namespace {
+
+constexpr std::vector<quad_vertex> get_quad_vertices()
+{
+    return { {{-1, -1}}, {{-1, 1}}, {{1, 1}}, {{1, -1}} };
+}
+
+constexpr std::vector<std::uint32_t> get_quad_indices()
+{
+    return {0, 1, 2, 0, 2, 3};
+}
+
+}
+
+void quad_vertex::set_buffer_attributes(std::uint32_t vbo)
+{
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glEnableVertexAttribArray(0);
+    glVertexAttribDivisor(0, 0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(quad_vertex), (void*)offsetof(quad_vertex, position));
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void line_instance::set_buffer_attributes(std::uint32_t vbo)
+{
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    for (int i = 1; i != 5; ++i) {
+        glEnableVertexAttribArray(i);
+        glVertexAttribDivisor(i, 1);
+    }
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, begin));
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, end));
+    glVertexAttribPointer(3, 4, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, colour));
+    glVertexAttribPointer(4, 1, GL_FLOAT, GL_FALSE, sizeof(line_instance), (void*)offsetof(line_instance, thickness));
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+shape_renderer::shape_renderer()
+    : d_shader("Resources/Shaders/shape.vert", "Resources/Shaders/shape.frag")
+    , d_quad_vertices(get_quad_vertices())
+    , d_quad_indices(get_quad_indices())
+{
+}
+
+void shape_renderer::begin_frame(const float width, const float height)
+{
+    d_shader.bind();
+    d_shader.load("u_width", width);
+    d_shader.load("u_height", height);
+    d_lines.clear();
+}
+
+void shape_renderer::end_frame()
+{
+    spkt::render_context rc;
+    rc.alpha_blending(true);
+    rc.depth_testing(false);
+
+    d_line_instances.set_data(d_lines);
+
+    d_shader.bind();
+    d_quad_vertices.bind();
+    d_quad_indices.bind();
+    d_line_instances.bind();
+
+    glDrawElementsInstanced(
+        GL_TRIANGLES,
+        (int)d_quad_indices.size(),
+        GL_UNSIGNED_INT,
+        nullptr,
+        (int)d_line_instances.size()
+    );
+
+    d_shader.unbind();
+}
+
+void shape_renderer::draw_line(
+    const glm::vec2& begin,
+    const glm::vec2& end,
+    const glm::vec4& colour,
+    const float thickness)
+{
+    d_lines.emplace_back(begin, end, colour, thickness);
+}
+    
+}

--- a/Sprocket/Graphics/Rendering/shape_renderer.cpp
+++ b/Sprocket/Graphics/Rendering/shape_renderer.cpp
@@ -97,5 +97,13 @@ void shape_renderer::draw_line(
 {
     d_lines.emplace_back(begin, end, begin_colour, end_colour, thickness);
 }
+
+void shape_renderer::draw_circle(
+    const glm::vec2& centre,
+    const glm::vec4& colour,
+    const float radius)
+{
+    draw_line(centre, centre, colour, colour, radius);
+}
     
 }

--- a/Sprocket/Graphics/Rendering/shape_renderer.h
+++ b/Sprocket/Graphics/Rendering/shape_renderer.h
@@ -19,7 +19,8 @@ struct line_instance
 {
     glm::vec2 begin;
     glm::vec2 end;
-    glm::vec4 colour;
+    glm::vec4 begin_colour;
+    glm::vec4 end_colour;
     float     thickness;
 
     static void set_buffer_attributes(std::uint32_t vbo);
@@ -47,7 +48,8 @@ public:
     void draw_line(
         const glm::vec2& begin,
         const glm::vec2& end,
-        const glm::vec4& colour,
+        const glm::vec4& begin_colour,
+        const glm::vec4& end_colour,
         const float thickness
     );
 };

--- a/Sprocket/Graphics/Rendering/shape_renderer.h
+++ b/Sprocket/Graphics/Rendering/shape_renderer.h
@@ -15,6 +15,7 @@ struct quad_vertex
     static void set_buffer_attributes(std::uint32_t vbo);
 };
 
+
 struct line_instance
 {
     glm::vec2 begin;
@@ -51,6 +52,12 @@ public:
         const glm::vec4& begin_colour,
         const glm::vec4& end_colour,
         const float thickness
+    );
+
+    void draw_circle(
+        const glm::vec2& centre,
+        const glm::vec4& colour,
+        const float radius
     );
 };
 

--- a/Sprocket/Graphics/Rendering/shape_renderer.h
+++ b/Sprocket/Graphics/Rendering/shape_renderer.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <Sprocket/Graphics/shader.h>
+#include <Sprocket/Graphics/buffer.h>
+
+#include <glm/glm.hpp>
+
+#include <memory>
+
+namespace spkt {
+
+struct quad_vertex
+{
+    glm::vec2 position;
+
+    static void set_buffer_attributes(std::uint32_t vbo);
+};
+
+struct line_instance
+{
+    glm::vec2 begin;
+    glm::vec2 end;
+    glm::vec4 colour;
+    float     thickness;
+
+    static void set_buffer_attributes(std::uint32_t vbo);
+};
+
+class shape_renderer
+{
+    spkt::shader d_shader;
+
+    // Combine these two into a static mesh? This is just a quad to be drawn onto the whole
+    // screen. The actual line drawing will be done in the fragment shader.
+    const spkt::vertex_buffer<quad_vertex>  d_quad_vertices;
+    const spkt::index_buffer<std::uint32_t> d_quad_indices;
+
+    // Maybe give the vertex_buffer an owning vector for streaming?
+    std::vector<line_instance>         d_lines;
+    spkt::vertex_buffer<line_instance> d_line_instances;
+
+public:
+    shape_renderer();
+
+    void begin_frame(const float width, const float height);
+    void end_frame();
+
+    void draw_line(
+        const glm::vec2& begin,
+        const glm::vec2& end,
+        const glm::vec4& colour,
+        const float thickness
+    );
+};
+
+}


### PR DESCRIPTION
* Adds the very simple `spkt::shape_renderer` for rendering lines and circles.
* Will be extended to draw quads.
* Will eventually rewrite the UI system to use this when it is more fully featured.